### PR TITLE
chore: Replace `seq_up()` with `rlang::seq2()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ Imports:
     methods,
     parallel,
     purrr,
+    rlang,
     ssdtools (>= 2.6.0),
     tidyr,
     withr

--- a/R/internal.R
+++ b/R/internal.R
@@ -11,13 +11,6 @@ do_call_seed <- function(what, args, seed) {
   })
 }
 
-seq_up <- function(from, to) {
-  if (to < from) {
-    return(integer())
-  }
-  seq(from, to)
-}
-
 fit_dists_seed <- function(
   data,
   sim,

--- a/R/simulate-data.R
+++ b/R/simulate-data.R
@@ -134,9 +134,9 @@ ssd_sim_data.fitdists <- function(
     wch <- which(dist_sim == "all")
     n <- length(dist_sim)
     dist_sim <- c(
-      dist_sim[seq_up(1, wch - 1)],
+      dist_sim[rlang::seq2(1, wch - 1)],
       names(x),
-      dist_sim[seq_up(wch + 1, n)]
+      dist_sim[rlang::seq2(wch + 1, n)]
     )
     dist_sim <- unique(dist_sim)
   }


### PR DESCRIPTION
Replace the internal `seq_up()` function with `rlang::seq2()` from the rlang package, which provides equivalent functionality. This removes unnecessary custom code and leverages an established utility function.

**Changes:**
- Removed `seq_up()` function from `R/internal.R`
- Updated calls in `R/simulate-data.R` to use `rlang::seq2()` instead
- Added `rlang` to package imports in `DESCRIPTION`

**Test Plan:**
Existing tests should pass as `rlang::seq2()` provides identical behavior to the removed `seq_up()` function.

https://claude.ai/code/session_01SL13sfQ6LYcYbRH3DEHheR