### PR TITLE
Add comprehensive roxygen2 documentation to internal functions

### DIFF
--- a/R/fit-dists-sims.R
+++ b/R/fit-dists-sims.R
@@ -18,9 +18,9 @@
 #' @param min_pmix A list of one or more functions with a single argument
 #' that inputs the number of rows of data and returns a proportion between 0 and 0.5.
 #' @param range_shape1 A list of numeric vectors of length two of the lower
-#' and upper bounds for the shape1 parameter.
+#' and upper bounds of the shape1 parameter for the burrIII3 distribution.
 #' @param range_shape2 A list of numeric vectors of length two of the lower
-#' and upper bounds for the shape2 parameter.
+#' and upper bounds of the shape2 parameter for the burrIII3 distribution.
 #' @inheritParams params
 #' @param x A data frame with sim and stream integer columns and a list column of the data frames to fit distributions to.
 #' @param ... Additional arguments passed to `ssdtools::ssd_fit_dists()`.

--- a/R/fit-dists-sims.R
+++ b/R/fit-dists-sims.R
@@ -1,5 +1,19 @@
 #' Fit SSD Distributions to Simulated Data
 #'
+#' Fits one or more species sensitivity distributions to each of the simulated
+#' data sets stored in a nested tibble.
+#'
+#' For each row of `x`, the function calls [ssdtools::ssd_fit_dists()] on the
+#' data in the `data` list column, using an independent L'Ecuyer-CMRG random
+#' number stream derived from `seed`, `sim` and `stream` so that fits are
+#' reproducible across parallel workers.
+#'
+#' The `rescale`, `computable`, `at_boundary_ok`, `min_pmix`, `range_shape1`
+#' and `range_shape2` arguments may each be supplied as vectors or lists; their
+#' values are crossed with the rows of `x` so that every combination of inputs
+#' is fitted, allowing different fitting configurations to be compared in a
+#' single call.
+#'
 #' @inheritParams ssdtools::ssd_fit_dists
 #' @param min_pmix A list of one or more functions with a single argument
 #' that inputs the number of rows of data and returns a proportion between 0 and 0.5.

--- a/R/hc-sims.R
+++ b/R/hc-sims.R
@@ -1,4 +1,4 @@
-#' Estimate hazard concentrations for multiple simulations using bootstrapping
+#' Estimate Hazard Concentrations for Multiple Simulations
 #'
 #' Estimates one or more hazard concentrations from a nested tibble of fitted
 #' species sensitivity distributions, optionally with bootstrapped confidence

--- a/R/hc-sims.R
+++ b/R/hc-sims.R
@@ -1,5 +1,22 @@
 #' Estimate hazard concentrations for multiple simulations using bootstrapping
 #'
+#' Estimates one or more hazard concentrations from a nested tibble of fitted
+#' species sensitivity distributions, optionally with bootstrapped confidence
+#' limits.
+#'
+#' For each row of `x`, the function calls [ssdtools::ssd_hc()] on the
+#' `fitdists` object in the `fits` list column. Random number generation is
+#' performed using an independent L'Ecuyer-CMRG stream derived from `seed`,
+#' `sim` and `stream`, so bootstrap samples are reproducible and statistically
+#' independent across simulations.
+#'
+#' The `nboot`, `est_method`, `ci_method` and `parametric` arguments may be
+#' supplied as vectors; their values are crossed with the rows of `x` so that
+#' every combination of estimation settings is computed.
+#'
+#' The `min_pboot` argument of [ssdtools::ssd_hc()] is fixed at 0 and cannot be
+#' overridden.
+#'
 #' @inheritParams ssdtools::ssd_hc
 #' @inheritParams params
 #' @param x A data frame with sim and stream integer columns and a list column of fitdists objects.

--- a/R/internal.R
+++ b/R/internal.R
@@ -61,8 +61,10 @@ do_call_seed <- function(what, args, seed) {
 #' @param computable A flag controlling discarding non-computable fits.
 #' @param at_boundary_ok A flag controlling acceptance of boundary fits.
 #' @param min_pmix A function returning the minimum mixture proportion.
-#' @param range_shape1 A numeric vector of length two for the shape1 bounds.
-#' @param range_shape2 A numeric vector of length two for the shape2 bounds.
+#' @param range_shape1 A numeric vector of length two of the lower
+#' and upper bounds of the shape1 parameter for the burrIII3 distribution.
+#' @param range_shape2 A numeric vector of length two of the lower
+#' and upper bounds of the shape2 parameter for the burrIII3 distribution.
 #' @param silent A flag controlling whether fitting warnings are suppressed.
 #' @param ... Additional arguments passed to [ssdtools::ssd_fit_dists()].
 #' @return A `fitdists` object.

--- a/R/internal.R
+++ b/R/internal.R
@@ -1,3 +1,19 @@
+#' Sample Rows from a Data Frame with a Fixed Seed
+#'
+#' Samples `n` rows from `data` using [dplyr::slice_sample()] under a
+#' L'Ecuyer-CMRG seed.
+#'
+#' The body of the sample call is wrapped in [with_lecuyer_cmrg_seed()] so
+#' the RNG state outside the call is unaffected and the result depends only
+#' on `seed`. This makes each simulation row of `ssd_sim_data()` independently
+#' reproducible.
+#'
+#' @param data A data frame to sample from.
+#' @param n A count of the number of rows to draw.
+#' @param replace A flag specifying whether to sample with replacement.
+#' @param seed An integer vector that is a valid L'Ecuyer-CMRG seed.
+#' @return A data frame with `n` rows.
+#' @noRd
 slice_sample_seed <- function(data, n, replace, seed) {
   with_lecuyer_cmrg_seed(seed, {
     data |>
@@ -5,12 +21,39 @@ slice_sample_seed <- function(data, n, replace, seed) {
   })
 }
 
+#' Call a Function with a Fixed Seed
+#'
+#' Invokes [do.call()] on `what` and `args` inside a temporary
+#' L'Ecuyer-CMRG seed scope so that the call is reproducible without
+#' touching the surrounding RNG state.
+#'
+#' Used to drive random-number-generating distribution functions (e.g.
+#' [ssdtools::ssd_rlnorm()]) for each simulation row of [ssd_sim_data()].
+#'
+#' @param what A function or function name.
+#' @param args A list of arguments to pass to `what`.
+#' @param seed An integer vector that is a valid L'Ecuyer-CMRG seed.
+#' @return The return value of `do.call(what, args)`.
+#' @noRd
 do_call_seed <- function(what, args, seed) {
   with_lecuyer_cmrg_seed(seed, {
     do.call(what, args = args)
   })
 }
 
+#' Safe Upward Integer Sequence
+#'
+#' Returns the integer sequence from `from` to `to`, or an empty integer
+#' vector when `to < from`.
+#'
+#' Used in place of [seq()] when constructing slicing indices that may be
+#' empty - the base implementation of `seq(1, 0)` returns `c(1, 0)` rather
+#' than `integer(0)`, which would be incorrect for slicing.
+#'
+#' @param from An integer scalar.
+#' @param to An integer scalar.
+#' @return An integer vector, possibly of length zero.
+#' @noRd
 seq_up <- function(from, to) {
   if (to < from) {
     return(integer())
@@ -18,6 +61,32 @@ seq_up <- function(from, to) {
   seq(from, to)
 }
 
+#' Fit Distributions for a Single Simulation
+#'
+#' Fits the supplied `dists` to one simulated data set using a deterministic
+#' L'Ecuyer-CMRG seed derived from `seed`, `sim` and `stream`.
+#'
+#' The L'Ecuyer-CMRG seed is computed via `get_lecuyer_cmrg_seed_stream()` so
+#' that fits across `(stream, sim)` pairs are statistically independent yet
+#' fully reproducible. The fit itself is performed by [ssdtools::ssd_fit_dists()].
+#' The `min_pmix` argument is a function of `nrow(data)` rather than a value,
+#' enabling the minimum mixture proportion to scale with the sample size.
+#'
+#' @param data A data frame to fit distributions to.
+#' @param sim A count of the simulation index.
+#' @param stream A count of the stream index.
+#' @param seed An integer of the starting seed or `NULL`.
+#' @param dists A character vector of distribution names.
+#' @param rescale A flag for rescaling the data before fitting.
+#' @param computable A flag controlling discarding non-computable fits.
+#' @param at_boundary_ok A flag controlling acceptance of boundary fits.
+#' @param min_pmix A function returning the minimum mixture proportion.
+#' @param range_shape1 A numeric vector of length two for the shape1 bounds.
+#' @param range_shape2 A numeric vector of length two for the shape2 bounds.
+#' @param silent A flag controlling whether fitting warnings are suppressed.
+#' @param ... Additional arguments passed to [ssdtools::ssd_fit_dists()].
+#' @return A `fitdists` object.
+#' @noRd
 fit_dists_seed <- function(
   data,
   sim,
@@ -58,6 +127,32 @@ fit_dists_seed <- function(
   fit
 }
 
+#' Compute Hazard Concentration for a Single Simulation
+#'
+#' Calls [ssdtools::ssd_hc()] on a single `fitdists` object using a
+#' deterministic L'Ecuyer-CMRG seed derived from `seed`, `sim` and `stream`.
+#'
+#' Bootstrap sampling is performed inside [with_lecuyer_cmrg_seed()] so the
+#' confidence limits are reproducible across parallel workers. The `nboot`,
+#' `est_method` and `ci_method` columns are dropped from the returned data
+#' frame because they are stored at the row level of the caller's tibble.
+#' The minimum bootstrap acceptance proportion is hard-wired to zero so that
+#' all simulations always return a value.
+#'
+#' @param data A `fitdists` object.
+#' @param sim A count of the simulation index.
+#' @param stream A count of the stream index.
+#' @param nboot A count of the number of bootstrap samples.
+#' @param est_method A string naming the estimation method.
+#' @param ci_method A string naming the confidence interval method.
+#' @param seed An integer of the starting seed or `NULL`.
+#' @param proportion The hazard concentration proportion(s).
+#' @param ci A flag specifying whether to estimate confidence intervals.
+#' @param parametric A flag specifying parametric bootstrap.
+#' @param save_to A directory path or `NULL`.
+#' @param ... Additional arguments passed to [ssdtools::ssd_hc()].
+#' @return A data frame of hazard concentration estimates.
+#' @noRd
 hc_seed <- function(
   data,
   sim,
@@ -94,6 +189,27 @@ hc_seed <- function(
   dplyr::select(hc, !c("nboot", "est_method", "ci_method"))
 }
 
+#' Fit Distributions and Estimate Hazard Concentrations for a Scenario
+#'
+#' Internal driver that chains [ssd_fit_dists_sims()] and [ssd_hc_sims()] for
+#' the `ssd_run_scenario()` methods.
+#'
+#' Splits the contents of `...` between arguments that belong to
+#' [ssdtools::ssd_fit_dists()] and those that belong to
+#' [ssdtools::ssd_hc.fitdists()] using [methods::formalArgs()], aborting with
+#' a friendly message if any unrecognised arguments are supplied. The
+#' arguments listed explicitly (`dists`, `rescale`, ..., `parametric`) are
+#' the simulation-level defaults supplied by each `ssd_run_scenario()` method.
+#'
+#' @param x A nested tibble of simulated data, as produced by [ssd_sim_data()].
+#' @param ... Additional arguments forwarded to the underlying calls.
+#' @param dists,rescale,computable,at_boundary_ok,min_pmix,range_shape1,range_shape2
+#'   Arguments forwarded to [ssd_fit_dists_sims()].
+#' @param proportion,ci,nboot,est_method,ci_method,parametric Arguments
+#'   forwarded to [ssd_hc_sims()].
+#' @param .progress Whether to show a progress bar.
+#' @return A tibble of hazard concentration estimates.
+#' @noRd
 run_scenario <- function(
   x,
   ...,

--- a/R/lecuyer-cmrg-seed.R
+++ b/R/lecuyer-cmrg-seed.R
@@ -1,3 +1,16 @@
+#' Generate Random Integers
+#'
+#' Generates `n` random integers drawn uniformly from the full signed 32-bit
+#' integer range.
+#'
+#' The values are produced with [stats::runif()] using `-.Machine$integer.max`
+#' and `.Machine$integer.max` (2147483647) as bounds and then coerced to
+#' integer. This is used internally to seed L'Ecuyer-CMRG streams when the
+#' caller has not supplied an explicit seed.
+#'
+#' @param n A count of the number of integers to generate.
+#' @return An integer vector of length `n`.
+#' @noRd
 rinteger <- function(n = 1L) {
   if (n == 0) {
     integer(0)
@@ -11,6 +24,19 @@ has_seed <- function() {
   exists(".Random.seed", globalenv(), mode = "integer", inherits = FALSE)
 }
 
+#' Capture the Current RNG State
+#'
+#' Returns the current random number generator state in a form that can later
+#' be restored with `set_seed()`.
+#'
+#' Re-implementation of the (unexported) `withr:::get_seed()` helper. The
+#' returned list contains the integer `.Random.seed` vector together with the
+#' result of [RNGkind()] so the RNG kind, normal kind and sample kind can be
+#' restored. Returns `NULL` if no random numbers have yet been generated in
+#' the session.
+#'
+#' @return A list with components `random_seed` and `rng_kind`, or `NULL`.
+#' @noRd
 # internal function from withr
 get_seed <- function() {
   if (!has_seed()) {
@@ -27,6 +53,18 @@ get_seed <- function() {
   )
 }
 
+#' Restore the RNG Kind
+#'
+#' Restores the RNG kind, normal kind and sample kind from a value previously
+#' produced by [RNGkind()].
+#'
+#' Re-implementation of the (unexported) `withr:::restore_rng_kind()` helper.
+#' The `"Rounding"` sample kind is restored under [suppressWarnings()] because
+#' R emits a non-actionable warning when it is selected.
+#'
+#' @param kind A character vector of length 3 as returned by [RNGkind()].
+#' @return `NULL`, invisibly.
+#' @noRd
 # internal function from withr
 restore_rng_kind <- function(kind) {
   RNGkind <- get("RNGkind")
@@ -40,6 +78,19 @@ restore_rng_kind <- function(kind) {
   NULL
 }
 
+#' Restore a Captured RNG State
+#'
+#' Restores the random number generator state captured by `get_seed()`.
+#'
+#' First restores the RNG kind via `restore_rng_kind()`, then either assigns
+#' `.Random.seed` directly in the global environment or, if a scalar `seed`
+#' was supplied, calls [set.seed()] with it. Returns the new RNG state
+#' invisibly so callers can chain capture-and-restore operations.
+#'
+#' @param seed A list as produced by `get_seed()`, optionally with an extra
+#'   `seed` component to be passed to [set.seed()].
+#' @return The new RNG state, invisibly.
+#' @noRd
 set_seed <- function(seed) {
   restore_rng_kind(seed$rng_kind)
   if (is.null(seed$seed)) {
@@ -51,6 +102,16 @@ set_seed <- function(seed) {
 }
 
 #' Local L'Euyer-CMRG Seed
+#'
+#' Sets the random number generator state in the calling environment to use
+#' the L'Ecuyer-CMRG algorithm with the supplied seed.
+#'
+#' This is a thin wrapper around [withr::local_seed()] that pins the RNG kind
+#' to `"L'Ecuyer-CMRG"`, the normal kind to `"Inversion"` and the sample kind
+#' to `"Rejection"`. The previous RNG state is restored when the calling
+#' frame exits, making this convenient for tests and reproducible workflows
+#' that need a parallel-safe RNG without polluting the global state.
+#'
 #' @inheritParams withr::local_seed
 #' @seealso [`withr::local_seed()`]
 #' @export
@@ -69,6 +130,16 @@ local_lecuyer_cmrg_seed <- function(seed, .local_envir = parent.frame()) {
 }
 
 #' With L'Euyer-CMRG Seed
+#'
+#' Evaluates an R expression with the random number generator temporarily set
+#' to the L'Ecuyer-CMRG algorithm and the supplied seed.
+#'
+#' This is a thin wrapper around [withr::with_seed()] that pins the RNG kind
+#' to `"L'Ecuyer-CMRG"`, the normal kind to `"Inversion"` and the sample kind
+#' to `"Rejection"` while `code` is being evaluated. The previous RNG state
+#' is restored on exit, which makes it suitable for generating reproducible
+#' parallel-safe random numbers inside a larger pipeline.
+#'
 #' @inheritParams withr::with_seed
 #' @seealso [`withr::with_seed()`]
 #' @export
@@ -88,12 +159,43 @@ with_lecuyer_cmrg_seed <- function(seed, code) {
   )
 }
 
+#' Get a Fresh L'Ecuyer-CMRG Seed
+#'
+#' Switches the RNG to L'Ecuyer-CMRG, seeds it with a random integer and
+#' returns the resulting `.Random.seed` vector.
+#'
+#' This is used internally as the starting point for generating independent
+#' parallel streams via [parallel::nextRNGStream()] and
+#' [parallel::nextRNGSubStream()]. Note that this function mutates the global
+#' RNG state; callers that need to preserve the existing state should
+#' surround the call with `get_seed()` / `set_seed()`.
+#'
+#' @return An integer vector representing a L'Ecuyer-CMRG `.Random.seed`.
+#' @noRd
 get_lecuyer_cmrg_seed <- function() {
   RNGkind("L'Ecuyer-CMRG", "Inversion", "Rejection")
   set.seed(rinteger(1))
   globalenv()$.Random.seed
 }
 
+#' Generate a Sequence of L'Ecuyer-CMRG Seeds for a Stream
+#'
+#' Builds a list of `nsim` L'Ecuyer-CMRG seeds that are statistically
+#' independent across both `stream` and simulation index.
+#'
+#' Starting from a base L'Ecuyer-CMRG seed, the helper advances the stream by
+#' `stream - 1` full RNG streams using [parallel::nextRNGStream()] and then
+#' the simulation index by `start_sim - 1` sub-streams using
+#' [parallel::nextRNGSubStream()]. The subsequent `nsim - 1` seeds are then
+#' obtained by repeated sub-stream advancement. The existing global RNG state
+#' is captured before the call and restored on exit so the function has no
+#' visible side effects.
+#'
+#' Inspired by `furrr:::generate_seed_streams`.
+#'
+#' @inheritParams params
+#' @return A list of `nsim` integer vectors, each a valid L'Ecuyer-CMRG seed.
+#' @noRd
 # inspired by furrr:::generate_seed_streams
 get_lecuyer_cmrg_seeds_stream <- function(seed, nsim, stream, start_sim) {
   if (nsim == 0) {
@@ -121,6 +223,14 @@ get_lecuyer_cmrg_seeds_stream <- function(seed, nsim, stream, start_sim) {
   seeds
 }
 
+#' Get a Single L'Ecuyer-CMRG Seed for a Stream
+#'
+#' Convenience wrapper around `get_lecuyer_cmrg_seeds_stream()` that returns
+#' the seed for a single `(stream, start_sim)` coordinate.
+#'
+#' @inheritParams params
+#' @return An integer vector that is a valid L'Ecuyer-CMRG seed.
+#' @noRd
 get_lecuyer_cmrg_seed_stream <- function(seed = NULL, stream, start_sim) {
   get_lecuyer_cmrg_seeds_stream(
     seed = seed,

--- a/R/lecuyer-cmrg-seed.R
+++ b/R/lecuyer-cmrg-seed.R
@@ -50,7 +50,6 @@ has_seed <- function() {
 #'
 #' @return A list with components `random_seed` and `rng_kind`, or `NULL`.
 #' @noRd
-# internal function from withr
 get_seed <- function() {
   if (!has_seed()) {
     return(NULL)
@@ -78,7 +77,6 @@ get_seed <- function() {
 #' @param kind A character vector of length 3 as returned by [RNGkind()].
 #' @return `NULL`, invisibly.
 #' @noRd
-# internal function from withr
 restore_rng_kind <- function(kind) {
   RNGkind <- get("RNGkind")
   RNGkind(kind[[1]], normal.kind = kind[[2]])

--- a/R/lecuyer-cmrg-seed.R
+++ b/R/lecuyer-cmrg-seed.R
@@ -1,12 +1,25 @@
 #' Generate Random Integers
 #'
-#' Generates `n` random integers drawn uniformly from the full signed 32-bit
-#' integer range.
+#' Generates `n` random integers drawn uniformly from
+#' `[-.Machine$integer.max, .Machine$integer.max]`.
 #'
 #' The values are produced with [stats::runif()] using `-.Machine$integer.max`
-#' and `.Machine$integer.max` (2147483647) as bounds and then coerced to
-#' integer. This is used internally to seed L'Ecuyer-CMRG streams when the
-#' caller has not supplied an explicit seed.
+#' (i.e. `-(2^31 - 1) = -2147483647`) and `.Machine$integer.max` (`2^31 - 1 =
+#' 2147483647`) as bounds and then coerced to integer. This is used internally
+#' to seed L'Ecuyer-CMRG streams when the caller has not supplied an explicit
+#' seed.
+#'
+#' The symmetric range deliberately excludes `-2^31 = -2147483648`: R reserves
+#' that bit pattern for `NA_integer_`, so any attempt to coerce it from a
+#' double via [as.integer()] returns `NA` with a warning rather than a valid
+#' integer. Using `-.Machine$integer.max` as the lower bound therefore keeps
+#' every draw inside R's representable integer range. This costs at most one
+#' value of entropy out of `~2^32`, which is irrelevant given the function's
+#' sole use - producing a single scalar to pass to [set.seed()] when
+#' bootstrapping a fresh L'Ecuyer-CMRG state. [set.seed()] would in turn
+#' expand any such scalar into the six-integer L'Ecuyer-CMRG seed vector, so
+#' the missing value has no observable effect on the diversity of generated
+#' streams.
 #'
 #' @param n A count of the number of integers to generate.
 #' @return An integer vector of length `n`.

--- a/R/run-scenario.R
+++ b/R/run-scenario.R
@@ -1,5 +1,19 @@
 #' Run Scenario
 #'
+#' Runs an end-to-end species sensitivity distribution simulation scenario by
+#' generating data, fitting distributions and computing hazard concentrations.
+#'
+#' The generic dispatches on the class of `x` and selects an appropriate
+#' [ssd_sim_data()] method to produce the nested tibble of simulated data
+#' sets. The simulated tibble is then passed through [ssd_fit_dists_sims()]
+#' and finally [ssd_hc_sims()]; any extra arguments in `...` are routed to
+#' whichever of the two underlying calls accepts them, with unrecognised
+#' arguments triggering an informative error.
+#'
+#' This makes `ssd_run_scenario()` a convenient single-call entry point for
+#' the simulation pipeline, while still allowing fine-grained control over
+#' the fitting and hazard-estimation steps.
+#'
 #' @inheritParams ssdtools::ssd_fit_dists
 #' @inheritParams ssdtools::ssd_hc
 #' @inheritParams params

--- a/R/simulate-data.R
+++ b/R/simulate-data.R
@@ -2,6 +2,18 @@
 #'
 #' A family of functions to generate a tibble of nested data sets.
 #'
+#' The generic dispatches on the class of `x`. Methods are provided for
+#' `data.frame` (resampling rows from an empirical data set), `fitdists`
+#' (drawing from a fitted species sensitivity distribution or the multi-model
+#' density), `tmbfit` (drawing from a single fitted distribution), `character`
+#' (treating `x` as the name of a random-number-generating function such as
+#' `"rlnorm"`) and `function` (calling the function directly).
+#'
+#' Random number generation is parallel-safe: each `(stream, sim)` pair uses
+#' an independent L'Ecuyer-CMRG sub-stream derived from `seed`, so individual
+#' simulations are reproducible and can be regenerated without recomputing
+#' the entire grid.
+#'
 #' @inheritParams params
 #' @param x The object to use for generating the data.
 #' @return A tibble of nested data sets.

--- a/R/simulate-data.R
+++ b/R/simulate-data.R
@@ -4,8 +4,8 @@
 #'
 #' The generic dispatches on the class of `x`. Methods are provided for
 #' `data.frame` (resampling rows from an empirical data set), `fitdists`
-#' (drawing from a fitted species sensitivity distribution or the multi-model
-#' density), `tmbfit` (drawing from a single fitted distribution), `character`
+#' (drawing from a set of species sensitivity distributions), 
+#' `tmbfit` (drawing from a single species sensitivity distribution), `character`
 #' (treating `x` as the name of a random-number-generating function such as
 #' `"rlnorm"`) and `function` (calling the function directly).
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,14 +1,14 @@
 #' Simulation Index Sequence
 #'
 #' Returns the integer sequence of simulation indices starting from
-#' `start_sim` and of length `nsim`.
+#' `start_sim` of length `nsim`.
 #'
-#' Validates that both inputs are positive counts before constructing the
+#' Validates that `start_sim` is a positive count and `nsim` is a count before constructing the
 #' sequence. Used to assemble the `sim` column of the nested tibbles produced
 #' by the [ssd_sim_data()] family.
 #'
 #' @inheritParams params
-#' @return An integer vector of length `nsim`.
+#' @return An integer vector of consecutive positive numbers of length `nsim`.
 #' @noRd
 sim_seq <- function(start_sim, nsim) {
   chk::chk_count(nsim)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,15 @@
+#' Simulation Index Sequence
+#'
+#' Returns the integer sequence of simulation indices starting from
+#' `start_sim` and of length `nsim`.
+#'
+#' Validates that both inputs are positive counts before constructing the
+#' sequence. Used to assemble the `sim` column of the nested tibbles produced
+#' by the [ssd_sim_data()] family.
+#'
+#' @inheritParams params
+#' @return An integer vector of length `nsim`.
+#' @noRd
 sim_seq <- function(start_sim, nsim) {
   chk::chk_count(nsim)
   chk::chk_count(start_sim)

--- a/man/local_lecuyer_cmrg_seed.Rd
+++ b/man/local_lecuyer_cmrg_seed.Rd
@@ -12,7 +12,15 @@ local_lecuyer_cmrg_seed(seed, .local_envir = parent.frame())
 \item{.local_envir}{\verb{[environment]}\cr The environment to use for scoping.}
 }
 \description{
-Local L'Euyer-CMRG Seed
+Sets the random number generator state in the calling environment to use
+the L'Ecuyer-CMRG algorithm with the supplied seed.
+}
+\details{
+This is a thin wrapper around \code{\link[withr:local_seed]{withr::local_seed()}} that pins the RNG kind
+to \code{"L'Ecuyer-CMRG"}, the normal kind to \code{"Inversion"} and the sample kind
+to \code{"Rejection"}. The previous RNG state is restored when the calling
+frame exits, making this convenient for tests and reproducible workflows
+that need a parallel-safe RNG without polluting the global state.
 }
 \examples{
 

--- a/man/ssd_fit_dists_sims.Rd
+++ b/man/ssd_fit_dists_sims.Rd
@@ -52,5 +52,18 @@ and upper bounds for the shape2 parameter.}
 The x tibble with a list column fits of fistdist objects.
 }
 \description{
-Fit SSD Distributions to Simulated Data
+Fits one or more species sensitivity distributions to each of the simulated
+data sets stored in a nested tibble.
+}
+\details{
+For each row of \code{x}, the function calls \code{\link[ssdtools:ssd_fit_dists]{ssdtools::ssd_fit_dists()}} on the
+data in the \code{data} list column, using an independent L'Ecuyer-CMRG random
+number stream derived from \code{seed}, \code{sim} and \code{stream} so that fits are
+reproducible across parallel workers.
+
+The \code{rescale}, \code{computable}, \code{at_boundary_ok}, \code{min_pmix}, \code{range_shape1}
+and \code{range_shape2} arguments may each be supplied as vectors or lists; their
+values are crossed with the rows of \code{x} so that every combination of inputs
+is fitted, allowing different fitting configurations to be compared in a
+single call.
 }

--- a/man/ssd_hc_sims.Rd
+++ b/man/ssd_hc_sims.Rd
@@ -67,5 +67,21 @@ calculate the confidence limits (and SE) from the single set of samples.}
 The x tibble with a list column hc of data frames produced by applying ssd_hc() to fits.
 }
 \description{
-Estimate hazard concentrations for multiple simulations using bootstrapping
+Estimates one or more hazard concentrations from a nested tibble of fitted
+species sensitivity distributions, optionally with bootstrapped confidence
+limits.
+}
+\details{
+For each row of \code{x}, the function calls \code{\link[ssdtools:ssd_hc]{ssdtools::ssd_hc()}} on the
+\code{fitdists} object in the \code{fits} list column. Random number generation is
+performed using an independent L'Ecuyer-CMRG stream derived from \code{seed},
+\code{sim} and \code{stream}, so bootstrap samples are reproducible and statistically
+independent across simulations.
+
+The \code{nboot}, \code{est_method}, \code{ci_method} and \code{parametric} arguments may be
+supplied as vectors; their values are crossed with the rows of \code{x} so that
+every combination of estimation settings is computed.
+
+The \code{min_pboot} argument of \code{\link[ssdtools:ssd_hc]{ssdtools::ssd_hc()}} is fixed at 0 and cannot be
+overridden.
 }

--- a/man/ssd_run_scenario.Rd
+++ b/man/ssd_run_scenario.Rd
@@ -211,7 +211,20 @@ calculate the confidence limits (and SE) from the single set of samples.}
 A tibble of nested data sets.
 }
 \description{
-Run Scenario
+Runs an end-to-end species sensitivity distribution simulation scenario by
+generating data, fitting distributions and computing hazard concentrations.
+}
+\details{
+The generic dispatches on the class of \code{x} and selects an appropriate
+\code{\link[=ssd_sim_data]{ssd_sim_data()}} method to produce the nested tibble of simulated data
+sets. The simulated tibble is then passed through \code{\link[=ssd_fit_dists_sims]{ssd_fit_dists_sims()}}
+and finally \code{\link[=ssd_hc_sims]{ssd_hc_sims()}}; any extra arguments in \code{...} are routed to
+whichever of the two underlying calls accepts them, with unrecognised
+arguments triggering an informative error.
+
+This makes \code{ssd_run_scenario()} a convenient single-call entry point for
+the simulation pipeline, while still allowing fine-grained control over
+the fitting and hazard-estimation steps.
 }
 \section{Methods (by class)}{
 \itemize{

--- a/man/ssd_sim_data.Rd
+++ b/man/ssd_sim_data.Rd
@@ -99,6 +99,19 @@ A tibble of nested data sets.
 \description{
 A family of functions to generate a tibble of nested data sets.
 }
+\details{
+The generic dispatches on the class of \code{x}. Methods are provided for
+\code{data.frame} (resampling rows from an empirical data set), \code{fitdists}
+(drawing from a fitted species sensitivity distribution or the multi-model
+density), \code{tmbfit} (drawing from a single fitted distribution), \code{character}
+(treating \code{x} as the name of a random-number-generating function such as
+\code{"rlnorm"}) and \code{function} (calling the function directly).
+
+Random number generation is parallel-safe: each \verb{(stream, sim)} pair uses
+an independent L'Ecuyer-CMRG sub-stream derived from \code{seed}, so individual
+simulations are reproducible and can be regenerated without recomputing
+the entire grid.
+}
 \section{Methods (by class)}{
 \itemize{
 \item \code{ssd_sim_data(data.frame)}: Generate data by sampling from data.frame

--- a/man/with_lecuyer_cmrg_seed.Rd
+++ b/man/with_lecuyer_cmrg_seed.Rd
@@ -12,7 +12,15 @@ with_lecuyer_cmrg_seed(seed, code)
 \item{code}{\code{[any]}\cr Code to execute in the temporary environment}
 }
 \description{
-With L'Euyer-CMRG Seed
+Evaluates an R expression with the random number generator temporarily set
+to the L'Ecuyer-CMRG algorithm and the supplied seed.
+}
+\details{
+This is a thin wrapper around \code{\link[withr:with_seed]{withr::with_seed()}} that pins the RNG kind
+to \code{"L'Ecuyer-CMRG"}, the normal kind to \code{"Inversion"} and the sample kind
+to \code{"Rejection"} while \code{code} is being evaluated. The previous RNG state
+is restored on exit, which makes it suitable for generating reproducible
+parallel-safe random numbers inside a larger pipeline.
 }
 \examples{
 


### PR DESCRIPTION
## Description

This PR adds detailed roxygen2 documentation to all internal functions and improves documentation for public functions across the codebase.

### Changes

**Internal Functions Documentation (`R/internal.R`)**
- Added roxygen2 docstrings for `slice_sample_seed()`, `do_call_seed()`, `seq_up()`, `fit_dists_seed()`, `hc_seed()`, and `run_scenario()`
- Each docstring includes parameter descriptions, return value documentation, and usage context

**L'Ecuyer-CMRG Seed Functions (`R/lecuyer-cmrg-seed.R`)**
- Added roxygen2 docstrings for `rinteger()`, `get_seed()`, `restore_rng_kind()`, `set_seed()`, `get_lecuyer_cmrg_seed()`, `get_lecuyer_cmrg_seeds_stream()`, and `get_lecuyer_cmrg_seed_stream()`
- Enhanced documentation for exported functions `local_lecuyer_cmrg_seed()` and `with_lecuyer_cmrg_seed()` with detailed descriptions and implementation notes

**Public Functions Documentation**
- Enhanced `ssd_sim_data()` documentation with details section explaining the generic dispatch mechanism and parallel-safe RNG behavior
- Enhanced `ssd_fit_dists_sims()` documentation with details about L'Ecuyer-CMRG stream usage and argument crossing
- Enhanced `ssd_hc_sims()` documentation with details about bootstrap sampling and argument handling
- Enhanced `ssd_run_scenario()` documentation with details about the end-to-end pipeline

**Utility Functions (`R/utils.R`)**
- Added roxygen2 docstring for `sim_seq()` with parameter and return value documentation

### Benefits

- Improved code maintainability through comprehensive inline documentation
- Better IDE support and help system integration via roxygen2
- Clearer understanding of internal implementation details for future contributors
- Consistent documentation style across the codebase

### Test Plan

Existing tests pass. Documentation changes are non-functional and verified through roxygen2 processing.

https://claude.ai/code/session_01PGKRDur8BHXf9bUHxXanX8