### PR TITLE
chore: Add input validation to `*_lecuyer_cmrg_*` seed functions

### DIFF
--- a/R/lecuyer-cmrg-seed.R
+++ b/R/lecuyer-cmrg-seed.R
@@ -66,6 +66,8 @@ set_state <- function(state) {
 #' local_lecuyer_cmrg_seed(42)
 #' runif(3)
 local_lecuyer_cmrg_seed <- function(seed, .local_envir = parent.frame()) {
+  chk::chk_whole_number(seed)
+  chk::chk_environment(.local_envir)
   withr::local_seed(
     seed,
     .local_envir = .local_envir,
@@ -115,6 +117,10 @@ with_lecuyer_cmrg_seed <- function(seed, code) {
 #' local_lecuyer_cmrg_state(state)
 #' runif(3)
 local_lecuyer_cmrg_state <- function(state, .local_envir = parent.frame()) {
+  chk::chk_integer(state)
+  chk::chk_not_any_na(state)
+  chk::chk_length(state, length = 7L)
+  chk::chk_environment(.local_envir)
   old <- get_state()
   withr::defer(set_state(old), envir = .local_envir)
   set_state(list(

--- a/tests/testthat/_snaps/lecuyer-cmrg-seed.md
+++ b/tests/testthat/_snaps/lecuyer-cmrg-seed.md
@@ -129,3 +129,83 @@
     Output
       [1] 0.0006085795 0.0701991342 0.7472101830
 
+# local_lecuyer_cmrg_seed rejects non-scalar seed
+
+    Code
+      local_lecuyer_cmrg_seed(state)
+    Condition
+      Error in `local_lecuyer_cmrg_seed()`:
+      ! `seed` must be a whole number (non-missing integer scalar or double equivalent).
+
+---
+
+    Code
+      local_lecuyer_cmrg_seed(integer())
+    Condition
+      Error in `local_lecuyer_cmrg_seed()`:
+      ! `seed` must be a whole number (non-missing integer scalar or double equivalent).
+
+---
+
+    Code
+      local_lecuyer_cmrg_seed(NA_integer_)
+    Condition
+      Error in `local_lecuyer_cmrg_seed()`:
+      ! `seed` must be a whole number (non-missing integer scalar or double equivalent).
+
+---
+
+    Code
+      local_lecuyer_cmrg_seed("10")
+    Condition
+      Error in `local_lecuyer_cmrg_seed()`:
+      ! `seed` must be a whole number (non-missing integer scalar or double equivalent).
+
+# local_lecuyer_cmrg_seed rejects non-environment .local_envir
+
+    Code
+      local_lecuyer_cmrg_seed(10, .local_envir = "env")
+    Condition
+      Error in `local_lecuyer_cmrg_seed()`:
+      ! `.local_envir` must be an environment.
+
+# local_lecuyer_cmrg_state rejects non-integer state
+
+    Code
+      local_lecuyer_cmrg_state(10)
+    Condition
+      Error in `local_lecuyer_cmrg_state()`:
+      ! `state` must be integer.
+
+---
+
+    Code
+      local_lecuyer_cmrg_state(1:6)
+    Condition
+      Error in `local_lecuyer_cmrg_state()`:
+      ! `state` must be length 7 not 6.
+
+---
+
+    Code
+      local_lecuyer_cmrg_state(c(1L, 2L, 3L, 4L, 5L, 6L, NA_integer_))
+    Condition
+      Error in `local_lecuyer_cmrg_state()`:
+      ! `state` must not have any missing values.
+
+---
+
+    Code
+      local_lecuyer_cmrg_state("a")
+    Condition
+      Error in `local_lecuyer_cmrg_state()`:
+      ! `state` must be integer.
+
+# local_lecuyer_cmrg_state rejects non-environment .local_envir
+
+    Code
+      local_lecuyer_cmrg_state(state, .local_envir = "env")
+    Condition
+      Error in `local_lecuyer_cmrg_state()`:
+      ! `.local_envir` must be an environment.
+

--- a/tests/testthat/test-lecuyer-cmrg-seed.R
+++ b/tests/testthat/test-lecuyer-cmrg-seed.R
@@ -396,3 +396,42 @@ test_that("local_lecuyer_cmrg_state different states produce different outcomes"
   }
   expect_false(identical(gen(states[[1]]), gen(states[[2]])))
 })
+
+test_that("local_lecuyer_cmrg_seed rejects non-scalar seed", {
+  state <- withr::with_seed(
+    10,
+    get_lecuyer_cmrg_stream_state(seed = NULL, stream = 1L, start_sim = 1L)
+  )
+  expect_snapshot(local_lecuyer_cmrg_seed(state), error = TRUE)
+  expect_snapshot(local_lecuyer_cmrg_seed(integer()), error = TRUE)
+  expect_snapshot(local_lecuyer_cmrg_seed(NA_integer_), error = TRUE)
+  expect_snapshot(local_lecuyer_cmrg_seed("10"), error = TRUE)
+})
+
+test_that("local_lecuyer_cmrg_seed rejects non-environment .local_envir", {
+  expect_snapshot(
+    local_lecuyer_cmrg_seed(10, .local_envir = "env"),
+    error = TRUE
+  )
+})
+
+test_that("local_lecuyer_cmrg_state rejects non-integer state", {
+  expect_snapshot(local_lecuyer_cmrg_state(10), error = TRUE)
+  expect_snapshot(local_lecuyer_cmrg_state(1:6), error = TRUE)
+  expect_snapshot(
+    local_lecuyer_cmrg_state(c(1L, 2L, 3L, 4L, 5L, 6L, NA_integer_)),
+    error = TRUE
+  )
+  expect_snapshot(local_lecuyer_cmrg_state("a"), error = TRUE)
+})
+
+test_that("local_lecuyer_cmrg_state rejects non-environment .local_envir", {
+  state <- withr::with_seed(
+    10,
+    get_lecuyer_cmrg_stream_state(seed = NULL, stream = 1L, start_sim = 1L)
+  )
+  expect_snapshot(
+    local_lecuyer_cmrg_state(state, .local_envir = "env"),
+    error = TRUE
+  )
+})


### PR DESCRIPTION
Add input validation to `local_lecuyer_cmrg_seed()` and `local_lecuyer_cmrg_state()` functions using the `chk` package to ensure:

- `local_lecuyer_cmrg_seed()` validates that `seed` is a whole number (non-missing integer scalar or double equivalent) and `.local_envir` is an environment
- `local_lecuyer_cmrg_state()` validates that `state` is an integer vector of length 7 with no missing values, and `.local_envir` is an environment

This prevents invalid inputs from being silently passed to downstream functions and provides clear error messages to users.

Includes comprehensive unit tests covering all validation scenarios with snapshot testing for error messages.

https://claude.ai/code/session_0123N1TRv43eg8CGJNS2PH2e