### PR TITLE
refactor: Extract `fit_dists_state()` and `hc_state()` from `*_seed()` helpers

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -11,6 +11,37 @@ do_call_seed <- function(what, args, seed) {
   })
 }
 
+fit_dists_state <- function(
+  data,
+  state,
+  dists,
+  rescale,
+  computable,
+  at_boundary_ok,
+  min_pmix,
+  range_shape1,
+  range_shape2,
+  silent,
+  ...
+) {
+  with_lecuyer_cmrg_state(state, {
+    fit <- ssdtools::ssd_fit_dists(
+      data,
+      dists = dists,
+      rescale = rescale,
+      computable = computable,
+      at_boundary_ok = at_boundary_ok,
+      min_pmix = min_pmix(nrow(data)),
+      range_shape1 = range_shape1,
+      range_shape2 = range_shape2,
+      silent = silent,
+      nrow = 5L,
+      ...
+    )
+  })
+  fit
+}
+
 fit_dists_seed <- function(
   data,
   sim,
@@ -31,24 +62,47 @@ fit_dists_seed <- function(
     start_sim = sim,
     stream = stream
   )
+  fit_dists_state(
+    data = data,
+    state = state,
+    dists = dists,
+    rescale = rescale,
+    computable = computable,
+    at_boundary_ok = at_boundary_ok,
+    min_pmix = min_pmix,
+    range_shape1 = range_shape1,
+    range_shape2 = range_shape2,
+    silent = silent,
+    ...
+  )
+}
 
-  ## TODO: handle failure of all model to fit!!
+hc_state <- function(
+  data,
+  state,
+  nboot,
+  est_method,
+  ci_method,
+  proportion,
+  ci,
+  parametric,
+  save_to,
+  ...
+) {
   with_lecuyer_cmrg_state(state, {
-    fit <- ssdtools::ssd_fit_dists(
+    hc <- ssdtools::ssd_hc(
       data,
-      dists = dists,
-      rescale = rescale,
-      computable = computable,
-      at_boundary_ok = at_boundary_ok,
-      min_pmix = min_pmix(nrow(data)),
-      range_shape1 = range_shape1,
-      range_shape2 = range_shape2,
-      silent = silent,
-      nrow = 5L,
+      proportion = proportion,
+      ci = ci,
+      nboot = nboot,
+      est_method = est_method,
+      ci_method = ci_method,
+      parametric = parametric,
+      min_pboot = 0,
       ...
     )
   })
-  fit
+  dplyr::select(hc, !c("nboot", "est_method", "ci_method"))
 }
 
 hc_seed <- function(
@@ -70,21 +124,18 @@ hc_seed <- function(
     start_sim = sim,
     stream = stream
   )
-  ## TODO: handle failures
-  with_lecuyer_cmrg_state(state, {
-    hc <- ssdtools::ssd_hc(
-      data,
-      proportion = proportion,
-      ci = ci,
-      nboot = nboot,
-      est_method = est_method,
-      ci_method = ci_method,
-      parametric = parametric,
-      min_pboot = 0,
-      ...
-    )
-  })
-  dplyr::select(hc, !c("nboot", "est_method", "ci_method"))
+  hc_state(
+    data = data,
+    state = state,
+    nboot = nboot,
+    est_method = est_method,
+    ci_method = ci_method,
+    proportion = proportion,
+    ci = ci,
+    parametric = parametric,
+    save_to = save_to,
+    ...
+  )
 }
 
 run_scenario <- function(


### PR DESCRIPTION
## Summary

Isolated the `fit_dists_state` / `hc_state` extraction from #67, without the tracing scaffolding.

- New `fit_dists_state(data, state, ...)` — runs `ssdtools::ssd_fit_dists()` under a pre-computed L'Ecuyer-CMRG state.
- New `hc_state(data, state, ...)` — runs `ssdtools::ssd_hc()` under a pre-computed state.
- `fit_dists_seed()` / `hc_seed()` keep their public-facing `(sim, stream, seed)` signatures; they now compute the state via `get_lecuyer_cmrg_stream_state()` and delegate to the new `*_state()` workers.

This makes the worker functions callable with any pre-computed state vector (e.g. a sub-stream walked elsewhere) without going through `seed`/`stream`/`sim`.

## Proof of work

- `R/internal.R` is the only file changed.
- Diff vs. #67's `R/internal.R` is purely `trace_msg(...)` additions — no code movement, no semantic differences — verified via `diff -u`.
- `devtools::test()` → `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 89 ]`.

## Test plan

- [x] `devtools::test()` — all 89 tests pass
- [ ] CI green on push

https://claude.ai/code/session_01RZAArpRyAjjPnPnVE2x4Lq

---
_Generated by [Claude Code](https://claude.ai/code/session_01HejMcVvUMuoe8xk83S77yJ)_