### PR TITLE
Redesign cloud upload and code-pinning mechanisms

### DIFF
--- a/TARGETS-DESIGN.md
+++ b/TARGETS-DESIGN.md
@@ -15,8 +15,9 @@ Three primary goals, each a hard constraint:
   reuses shards with Parquets already computed and
   computes the rest. Path-axis growth adds
   new shards; inner-axis growth rewrites affected shards atomically
-  (§8). One named exception — dag-of-dags for *pinning outputs
-  despite a code change* — is documented in §8.3.
+  (§8). Pinning outputs *despite a code change* stays inside the one
+  project via `tar_cue(depend = FALSE)` — no second project needed
+  (§8.3).
 
 Parallelism is assumed throughout. The document covers, in order:
 the **scenario object** and central registries (§1), the
@@ -82,10 +83,18 @@ The most consequential design choices, with section refs:
   `results/<step>/dataset=.../sim=.../`; `targets` passes upstream
   shard paths into downstream branches via `format = "file"`, and
   duckplyr predicate-pushes filters into the partition columns.
-- **Cloud upload as a scenario property (§6.1).** `scenario$upload`
-  pushes each shard to Azure Blob (or another object store)
-  right after the local write; `ssd_test_upload()` probes the
-  backend at pipeline init.
+- **Cloud upload as a separate target (§6.1).** When
+  `scenario$upload` is set, an `upload_<step>` target sits
+  downstream of each shard file and pushes it to Azure Blob (or
+  another object store). Because it is its own `format = "file"`
+  target, content-hashing skips re-uploading shards that did not
+  change; `ssd_test_upload()` probes the backend at pipeline init,
+  and the graph still builds and dry-runs with no credentials.
+- **One bad shard does not abort the run (§6.2).** Step targets
+  carry `error = "null"`: a branch that errors goes `NULL`,
+  `targets` records the error, and the pipeline keeps building so
+  `summary` unions the survivors. Errors are read from `tar_meta()`
+  *after* `tar_make()` returns (a target cannot call it mid-run).
 - **Debug = task row + one upstream shard (§7).** Any failed branch
   replays locally with `local_dqrng_state(seed, primer)` + the
   immediate-upstream shard, no `targets` needed; the lightweight
@@ -95,9 +104,10 @@ The most consequential design choices, with section refs:
   cache: a larger scenario reuses shards whose partition path
   already has a Parquet, and adds shards (path-axis growth, §8.1)
   or atomically rewrites them (inner-axis growth, §8.2) as needed.
-  One explicit case: dag-of-dags for *pinning outputs despite a
-  code change* (§8.3 — the opposite of invalidation, achieved by
-  declaring parent's shards as input files in a child project).
+  Pinning shards *despite a code change* (the opposite of
+  invalidation) is `tar_cue(depend = FALSE)` on the step targets,
+  all in the one project — no child project, no `parent` reference
+  (§8.3).
 - **Roadmap with parallel work streams (§12).** Eighteen
   kebab-slugged steps with a Mermaid DAG showing where branches
   open. Two ground-up entries — `ssd-define-scenario` and the
@@ -131,12 +141,15 @@ ssdsims_scenario
 │                  one shard per (step, partition-cell). Default:
 │                  data=(dataset,sim,replace), fit=(dataset,sim,rescale),
 │                  hc=(dataset,sim). See §5.
-├── upload       ← NULL (no upload) or list(backend, url, …) (§6.1)
-└── parent       ← NULL, or a previous results dir referenced for
-                   dag-of-dags / mixed-code use (§8). Plain extension
-                   (more datasets, more nsim) does NOT need a parent
-                   reference — the shards are the cache (file existence ⇒ cache hit).
+└── upload       ← NULL (no upload) or list(backend, url, …) (§6.1)
 ```
+
+There is no `parent` field. Extension never needs one: plain growth
+(more datasets, more `nsim`) reuses shards by file existence
+(`file existence ⇒ cache hit`, §8.1), inner-axis growth rewrites the
+affected shards (§8.2), and pinning shards against a code change is
+done in-project with `tar_cue(depend = FALSE)` (§8.3) rather than by
+pointing a second project at this one's outputs.
 
 Three design points distinguish this from the current code:
 
@@ -152,13 +165,14 @@ Three design points distinguish this from the current code:
    knobs) and lets the per-task hash (§2) ignore function-body
    contents — so a non-behavior-changing code edit to a registered
    function does *not* invalidate cached results. See §1.1.
-3. **No `parent` for plain extension.** Adding tasks on a *path*
-   axis (new dataset, more `nsim`) creates new shards; existing
-   shards are unaffected. Adding tasks on an *inner* axis (new
-   `min_pmix`, new `nboot`) rewrites the affected shards atomically
-   (§8.2). The `parent` reference is only for one case
-   path-addressing alone can't handle: pinning the parent's shards
-   despite a code change in the child (`dag-of-dags`, §8.3).
+3. **No `parent` reference at all.** Adding tasks on a *path* axis
+   (new dataset, more `nsim`) creates new shards; existing shards
+   are unaffected. Adding tasks on an *inner* axis (new `min_pmix`,
+   new `nboot`) rewrites the affected shards atomically (§8.2). The
+   one case that once seemed to need a second project pointing back
+   at this one — pinning shards despite a code change — is handled
+   in-project with `tar_cue(depend = FALSE)` (§8.3), so the scenario
+   carries no `parent`.
 
 ### 1.1 Implicit registries: datasets and min_pmix
 
@@ -488,7 +502,7 @@ parallel; none is downstream of the others. Roles:
 
 - **C — working scenario object** contributes the *content*:
   `seed`, dataset names, fit/hc argument vectors, optional
-  `upload` (§6.1), optional `parent` (§8). Already exercised
+  `upload` (§6.1). Already exercised
   locally with `ssd_run_scenario()` (§3) so the only remaining
   unknown when assembling the three is the cluster wiring itself.
 
@@ -732,10 +746,14 @@ list(
   tar_group_by(fit_tasks,  ssd_scenario_fit_tasks(scenario),  dataset, sim, rescale),
   tar_group_by(hc_tasks,   ssd_scenario_hc_tasks(scenario),   dataset, sim),
 
+  # error = "null" so one bad shard does not abort the run: the
+  # branch goes NULL, the error is recorded, the rest keeps building
+  # and summary unions the survivors (§6.2). format = "file" passes
+  # the shard path, not its value, between targets (see below).
   tar_target(
     data_step,
     ssd_run_data_step(data_tasks, scenario, out_dir = "results/data"),
-    pattern = map(data_tasks), format = "file"
+    pattern = map(data_tasks), format = "file", error = "null"
   ),
 
   tar_target(
@@ -743,7 +761,7 @@ list(
     ssd_run_fit_step(fit_tasks, scenario,
                      data_dir = "results/data",
                      out_dir  = "results/fit"),
-    pattern = map(fit_tasks), format = "file"
+    pattern = map(fit_tasks), format = "file", error = "null"
   ),
 
   tar_target(
@@ -751,7 +769,7 @@ list(
     ssd_run_hc_step(hc_tasks, scenario,
                     fit_dir = "results/fit",
                     out_dir = "results/hc"),
-    pattern = map(hc_tasks), format = "file"
+    pattern = map(hc_tasks), format = "file", error = "null"
   ),
 
   tar_target(
@@ -875,13 +893,28 @@ lookup-by-hash in the body. The partition layout above is for
 *downstream queries* and for the debug replay (§7), not for the
 inter-target wiring.
 
+#### Why `format = "file"`, not the native Parquet store
+
+`targets` ships a native Parquet store (`tar_option_set(format =
+"parquet")`) that serialises each target's value to Parquet with no
+explicit write — the obvious first reach. An independent experiment
+ruled it out: depending on such a target **eagerly deserialises its
+value back into R**, even when the downstream body only wants the
+store path, so it does *not* avoid the R roundtrip; and the store
+layout (`_targets/objects/<name>`, no extension) is not a stable
+contract to read against from outside `targets`. `format = "file"`
+is the seam that actually passes storage between targets without the
+roundtrip: the target's value *is* the Parquet path, so a downstream
+branch receives a string and hands it straight to duckplyr / `arrow`
+/ the uploader. That is why every step target here — and the
+`summary` and `upload_<step>` targets — is `format = "file"`.
+
 ### 6.1 Cloud upload hook
 
 The data/fit/hc shards are the user-facing artefacts and they need
 to be readable **from outside the cluster** — analysis notebooks on a
 laptop, dashboards, downstream R/Python scripts. The scenario carries
-an optional `upload` field describing a destination object store; each
-branch pushes its shard there right after the local write.
+an optional `upload` field describing a destination object store.
 
 ```
    scenario$upload (NULL by default; non-NULL example):
@@ -892,16 +925,45 @@ branch pushes its shard there right after the local write.
      )
 ```
 
+**Upload is its own target, not an inline side effect.** When
+`upload` is non-NULL the pipeline adds an `upload_<step>` target
+downstream of each step, mapping over the same shards:
+
+```r
+tar_target(
+  upload_fit,
+  ssd_upload_shard(fit_step, scenario$upload),   # fit_step = the shard path
+  pattern = map(fit_step), format = "file", error = "null"
+)
+```
+
+An independent experiment showed why this beats pushing the blob
+from inside `ssd_run_<step>_step()` right after the local write:
+
+- **Content-hashing skips unchanged shards.** Because `upload_<step>`
+  takes the shard's path (`format = "file"`) as input, `targets`
+  re-runs it only when that shard's content hash changes. A re-driven
+  `tar_make()` that rebuilt nothing uploads nothing; a partial
+  extension uploads only the new/rewritten shards.
+- **The graph builds and dry-runs with no credentials.**
+  `ssd_upload_shard()` checks for credentials and, when absent,
+  returns the local path as a no-op (a dry run) instead of erroring —
+  so the same pipeline is runnable offline and against real cloud
+  storage, and the upload nodes still appear in the DAG.
+- **Concerns stay separated by dependency.** The compute manifest
+  depends only on the shard targets (what was produced); the upload
+  manifest depends on the `upload_<step>` targets (what was shipped).
+  A reader that needs only uploaded data depends on the latter.
+
 Per-shard flow when `upload` is non-NULL:
 
 ```
-   ssd_run_<step>_step(...)
-        │
-        ▼ writes results/<step>/<partition-path>/part.parquet
-                                   (local; targets tracks this via format = "file")
-        │
-        ▼ pushes the same file to  <url>/<container>/<step>/<partition-path>/part.parquet
-                                   (cluster-side helper, e.g. AzureStor)
+   <step>_step branch  ──▶ results/<step>/<partition-path>/part.parquet
+        │                  (local shard; targets tracks it, format = "file")
+        ▼
+   upload_<step> branch ──▶ <url>/<container>/<step>/<partition-path>/part.parquet
+                            (own target; runs only if the shard hash changed,
+                             dry-run no-op when credentials are absent)
         │
         ▼ records the upload's sha256 in the result manifest
 ```
@@ -912,7 +974,8 @@ tracking is unaffected; the cloud copy is an additional artefact.
 **Auth is external.** Credentials come from environment variables
 (`AZURE_STORAGE_ACCOUNT`, `AZURE_STORAGE_KEY`, or a service-principal
 combo). The scenario object does **not** carry secrets — it carries
-only the destination URL and container name.
+only the destination URL and container name. Their absence is what
+flips `ssd_upload_shard()` into its dry-run no-op.
 
 **Connectivity probe up front.** `ssd_test_upload(scenario)` performs
 a minimal round-trip (list the container, write and delete a small
@@ -927,10 +990,43 @@ ssd_test_upload(scenario)   # silent on success, throws on failure
 tar_make()
 ```
 
-**Failure mode.** A per-shard upload error becomes the target's error;
-the local shard remains, so `tar_make()` can be re-driven and the
-upload retried. The scenario's manifest records, per `id`, the local
-sha256 and the cloud sha256; a mismatch flags a corrupted transfer.
+**Failure mode.** A per-shard upload error becomes that
+`upload_<step>` branch's error (and, under `error = "null"`, leaves
+the rest uploading); the local shard remains, so `tar_make()` can be
+re-driven and only the failed uploads retried. The scenario's
+manifest records, per shard, the local sha256 and the cloud sha256; a
+mismatch flags a corrupted transfer.
+
+### 6.2 Surviving a failed shard
+
+A single bad shard must not abort an N-shard cluster run. Every step
+target (and `upload_<step>`) carries `error = "null"`: a branch that
+errors has its value set to `NULL`, `targets` records the error in
+its metadata, and the rest of the pipeline keeps building, so
+`summary` unions the shards that did land instead of `tar_make()`
+halting on the first failure. An errored branch is always out of
+date, so a re-driven `tar_make()` after a fix retries only the failed
+shards (§8.4).
+
+Two constraints, both confirmed by independent experiments:
+
+- **Errors are read *after* the run, not inside it.** A target cannot
+  call `tar_meta()` (or other store functions) while the pipeline is
+  running. So `summary` detects a gap from the missing shard / `NULL`
+  value *inside* the DAG, and the error *messages* are pulled from
+  metadata once `tar_make()` returns:
+
+  ```r
+  tar_make()
+  tar_meta(fields = "error") |> dplyr::filter(!is.na(error))
+  ```
+
+- **The end-of-pipeline warning needs handling, not silencing.** Even
+  with `error = "null"`, `tar_make()` emits a "some targets errored"
+  warning at the end; under `options(warn = 2)` that becomes an abort.
+  The runner wraps `tar_make()` in a `withCallingHandlers()` that
+  muffles only that one expected warning rather than relaxing the
+  global option.
 
 ---
 
@@ -1060,7 +1156,7 @@ phantom.
 
 The mechanism is per-shard content-hashing (sha256). Every shard
 the cluster writes is fingerprinted with `sha256` and the value is
-stored in the parent's manifest, keyed by the shard's partition
+stored in the cluster run's manifest, keyed by the shard's partition
 path, before any upload happens:
 
 ```r
@@ -1073,9 +1169,9 @@ Local recipe:
 ```
    1. tar_make() locally up to fit_step, then look at the
       regenerated upstream shard at its partition path.
-   2. local_hash  <- digest::digest(file = <upstream_path>, algo = "sha256")
-      parent_hash <- parent_manifest$completed_shards[[<partition_key>]]
-      stopifnot(identical(local_hash, parent_hash))
+   2. local_hash   <- digest::digest(file = <upstream_path>, algo = "sha256")
+      cluster_hash <- cluster_manifest$completed_shards[[<partition_key>]]
+      stopifnot(identical(local_hash, cluster_hash))
         ✓  the cluster's input is reproduced byte-for-byte;
            continue to step 4 of the rsync recipe.
         ✗  upstream is host-dependent (BLAS, system libs, env);
@@ -1107,8 +1203,9 @@ Hash verification is the bridge.
 
 Once the bug is fixed, the natural follow-up is to lock in the
 surviving N−3 shards and re-run only the 3 failures despite the
-code change — see §8.4 (`unlink()` the bad Parquets + `tar_make()`)
-or §8.3 (dag-of-dags) depending on the scope of the change.
+code change — see §8.4 (`unlink()` the bad Parquets + `tar_make()`),
+or §8.3 (`tar_cue(depend = FALSE)` to pin the survivors against the
+edit) depending on the scope of the change.
 
 ---
 
@@ -1154,6 +1251,18 @@ as a whole. Trade-off accepted (Q2 in the design dialogue):
 simpler cache semantics in exchange for redoing the work of every
 task already in the shard.
 
+**Whether `summary` rebuilds depends on the bytes, not the rewrite.**
+An independent experiment confirmed `targets` propagates on *value*,
+not on the act of rebuilding: a recomputed target whose value is
+byte-identical leaves its dependents skipped. Here the shard *did*
+gain a row, so its Parquet bytes change and `summary` (which reads
+the shard) re-runs. But the corollary matters for §8.4 and for any
+no-op rewrite: if a rewrite reproduced the exact same bytes,
+`format = "file"` content-hashing would see no change and `summary`
+would not rebuild. Byte-stable Parquet writes (pinned `arrow`,
+deterministic column order) are what make that hash comparison
+meaningful.
+
 | What you added             | Inner axis for…   | Cost                                  |
 | -------------------------- | ----------------- | ------------------------------------- |
 | new `min_pmix` name        | fit               | rewrite all fit shards (was K tasks each → now K+1) |
@@ -1168,26 +1277,43 @@ an axis into the path means future growth on that axis adds new
 shards instead of rewriting old ones, at the cost of producing
 more (smaller) Parquets up front.
 
-### 8.3 Pinning shards despite a code change — dag-of-dags
+### 8.3 Pinning shards despite a code change — `tar_cue(depend = FALSE)`
 
 The user edited an `_state` function (or `ssdtools` ticked over a
-version); `targets`' own hash-graph would now flag every
-dependent branch as out-of-date, forcing a re-run the user does
-*not* want. The question is the **opposite** of invalidation —
-how to keep targets from re-running things whose shards are still
-trusted.
+version); `targets`' own hash-graph would now flag every dependent
+branch as out-of-date, forcing a re-run the user does *not* want.
+The question is the **opposite** of invalidation — how to keep
+`targets` from re-running things whose shards are still trusted.
 
-There is no clean single-project knob for this. (`tar_target(...,
-cue = tar_cue(file = "always"))` and friends are coarse and don't
-distinguish "the file is fine" from "I haven't checked yet".) The
-canonical workaround is **dag-of-dags**: open a child project that
-declares the parent's `results/` directory as an *input* via
-`tar_target(..., format = "file", command = "../parent/results/<path>")`.
-File-as-input targets are pinned to the file's content hash, not to
-the function that produced it; the child's own functions are free to
-evolve without invalidating the parent's shards. The child does
-its new compute, writes into its own `results/`, and the `summary`
-target unions both directories.
+This stays inside the one project. An independent experiment settled
+it: `tar_cue(depend = FALSE)` is exactly the knob. It tells a target
+to ignore changes to its upstream dependencies — including the
+function bodies it calls — so editing an `_state` function (or
+bumping an `ssdtools` version) rebuilds *nothing*:
+
+```r
+tar_target(
+  fit_step,
+  ssd_run_fit_step(fit_tasks, scenario, data_dir = "results/data",
+                   out_dir = "results/fit"),
+  pattern = map(fit_tasks), format = "file", error = "null",
+  cue = tar_cue(depend = FALSE)   # pin against upstream code edits
+)
+```
+
+`tar_invalidate(names = ...)` still forces a rebuild of the specific
+shards the user *does* want refreshed — it deletes the metadata the
+cue compares against, overriding the pin per-target (§8.4). So the
+mixed-code case — keep the trusted shards, recompute a few under the
+new code — is two single-project moves: pin everything with the cue,
+then `tar_invalidate()` the handful to refresh. No second project,
+no `parent` reference, no cross-project file-input wiring.
+
+(`tar_cue(depend = FALSE)` pins against *dependency/code* changes
+only; the target still rebuilds if its own `format = "file"` output
+goes missing or if its task-table grouping changes — which is what
+makes path-axis and inner-axis growth in §8.1–§8.2 still work while
+the pin is in place.)
 
 ### 8.4 Forced re-run after a code fix
 
@@ -1202,7 +1328,11 @@ tar_make()                   # targets sees the missing files, re-runs only thos
 ```
 
 `targets::tar_invalidate(names = failed_branch_names)` is the
-bookkeeping-preserving alternative — same end state.
+bookkeeping-preserving alternative — same end state, and the same
+call that overrides a §8.3 pin on the shards you do want refreshed.
+Either way the patched code produces different bytes, so the
+rewritten shards' content hashes change and `summary` rebuilds from
+them (value-propagation, §8.2); the shards left alone stay cached.
 
 ### 8.5 Manifest contents
 
@@ -1278,7 +1408,7 @@ in any function that touches the methods).
 
 | Gap                                                  | Resolution                                                                                  |
 | ---------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| No DAG-of-DAGs primitive                             | §8.3 — child reads parent's `results/` directly; partition paths identify shards.            |
+| No DAG-of-DAGs primitive                             | Not needed — §8.3 pins shards against code changes in-project with `tar_cue(depend = FALSE)`; §8.1–§8.2 handle extension via the shards-as-cache. |
 | No "load previous run from Parquet" path             | §8 — shards are the cache; no explicit load needed.                          |
 | Persists fragile RNG state                           | §1, §2 — scenario stores a single integer `seed`; per-task `(seed, state)` is reproducible via `dqset.seed()`. |
 | Positional task IDs                                  | §2 — task IDs are keyed by `task_primer(p)` = 64-bit hash of canonical params. |
@@ -1291,8 +1421,8 @@ in any function that touches the methods).
 | Function-arg edits invalidate caches                 | §1.1 — `min_pmix` referenced by name; function body edits do not move tasks across streams. |
 | Bootstrap-only knobs spuriously fan out under `ci=FALSE` | §1.2 — `ci=FALSE` collapses `nboot`/`ci_method`/`parametric` to NA; one task instead of N. |
 | Branch failure unreproducible off the cluster        | §7 — task row + upstream shard replays the failing task via `_state` primitives.          |
-| Code fix re-runs every branch by hash invalidation   | §8.4 — `unlink()` failed shards (or `tar_invalidate`); path-keyed addressing leaves the rest untouched. |
-| Off-cluster access to Parquet outputs                | §6.1 — `scenario$upload` pushes each shard to a configurable object store (e.g. Azure Blob). |
+| Code fix re-runs every branch by hash invalidation   | §8.3 — `tar_cue(depend = FALSE)` pins shards against the edit; §8.4 — `tar_invalidate()` / `unlink()` refreshes only the chosen shards. |
+| Off-cluster access to Parquet outputs                | §6.1 — `scenario$upload` adds a per-shard `upload_<step>` target (content-hashed, dry-run offline) to a configurable object store (e.g. Azure Blob). |
 | Phantom local repros (regenerated upstream ≠ cluster's actual) | §7 — manifest's per-shard sha256 lets the lightweight recipe verify the local upstream before running the failing task. |
 
 The RNGkind side-effect bug and the independent data/fit/hc substream
@@ -1414,6 +1544,12 @@ shows where branches open and close.
   `_fit_tasks` / `_hc_tasks` returning the per-step task tables
   with `(seed, primer)` on each row. The §6 sketch compiles and
   `tar_make()`s a tiny scenario.
+- **`shard-failure-survival`** — §6.2 — step targets carry
+  `error = "null"` and `summary` unions the survivors; the runner
+  muffles only the expected end-of-pipeline "errored" warning under
+  `options(warn = 2)`. Test: a deterministically-failing shard
+  leaves the others built and the error readable via `tar_meta()`
+  after the run.
 - **`hive-partitioning`** — Write each per-task shard under a
   Hive-partitioned path (§6 layout). Smoke: duckplyr predicate
   pushdown returns the right subset without opening unrelated
@@ -1421,9 +1557,13 @@ shows where branches open and close.
 - **`cluster-pipeline`** — `inst/targets-templates/cluster/` with
   `crew.cluster::crew_controller_slurm()`. End-to-end `tar_make()`
   on a real (or sandboxed) Slurm queue.
-- **`cloud-upload`** — §6.1 hook + `ssd_test_upload()`. Hello-Azure
-  round trip from interactive R; `tar_make()`'s first target is the
-  connectivity probe.
+- **`cloud-upload`** — §6.1 — per-shard `upload_<step>` target +
+  `ssd_test_upload()` probe + `ssd_upload_shard()` with a credential
+  check that dry-runs (no-op) when secrets are absent. Hello-Azure
+  round trip from interactive R; the connectivity probe is
+  `tar_make()`'s first target. Test: a second `tar_make()` with no
+  shard changes uploads nothing (content-hash skip); the graph
+  builds offline.
 - **`replay-helper`** — `ssd_replay_task()` (§7) and
   `ssd_input_hash()` for the lightweight recipe. Tests simulate a
   branch failure and reproduce locally.
@@ -1438,9 +1578,10 @@ shows where branches open and close.
   causes targets to re-run the affected fit branches and overwrite
   the shards' Parquets; rows that were there before come out
   byte-identical to the previous Parquet.
-- **`mixed-code-lockin`** — §8.3 — `unlink()` + `tar_invalidate()`
-  for forced re-runs (§8.4); dag-of-dags child project for pinning
-  parent outputs against code change. Both recipes have tests.
+- **`mixed-code-lockin`** — §8.3 — `tar_cue(depend = FALSE)` on the
+  step targets to pin shards against a code change (in-project, no
+  child project); `tar_invalidate()` / `unlink()` for forced re-runs
+  of the chosen shards (§8.4). Both recipes have tests.
 - **`cleanup-lecuyer`** — Remove the L'Ecuyer-CMRG helpers and the
   `_seed` shims; `scripts/experiment-substream-restart.R` becomes
   a historical reference.
@@ -1474,6 +1615,7 @@ flowchart TD
 
     hive[hive-partitioning]
     cluster[cluster-pipeline]
+    survive[shard-failure-survival]
     cloud[cloud-upload]
     replay[replay-helper]
     rewrite[shard-atomic-rewrite]
@@ -1500,10 +1642,12 @@ flowchart TD
 
     tt --> hive
     tt --> cluster
+    tt --> survive
     tt --> cloud
     tt --> replay
     tt --> rewrite
 
+    cluster --> survive
     rewrite --> lockin
     lockin --> cleanup
 ```

--- a/TARGETS-DESIGN.md
+++ b/TARGETS-DESIGN.md
@@ -34,10 +34,11 @@ Terminology (per GLOSSARY.md): a **task** is one row of a
 carrying a primer; a **shard** is the Parquet file produced by
 running one or several tasks (depending on **partitioning**). **Step** = one of the three stages data / fit /
 hc; **target** = `tar_target()` declaration; **job** = Slurm work
-unit. 1 task is part of a branch of the `*_step` target; 1 branch
-writes 1 shard. Independent branches/shards run in parallel; how
-branches map to Slurm jobs under `crew_controller_slurm()` is an
-open question (§11).
+unit. Each shard is its own named `*_step` target (minted by
+`tar_map` at construction time — **static branching**, §6); a shard's
+tasks run inside that one target, which writes 1 shard. Independent
+shard targets run in parallel; how they map to Slurm jobs under
+`crew_controller_slurm()` is an open question (§11).
 
 Background and the list of gaps this design closes are in `RNG-FLOW.md`
 §5. This is a forward-looking design; it does not document the existing
@@ -78,10 +79,17 @@ The most consequential design choices, with section refs:
 - **`ci = FALSE` collapses bootstrap knobs (§1.2).** When `ci =
   FALSE` the `nboot` / `ci_method` / `parametric` axes are stored
   as `NA` in the hc-task table — no phantom branches.
-- **Per-shard Parquet shards, Hive-style (§6).** Each task writes
-  one shard (one Parquet file) under
-  `results/<step>/dataset=.../sim=.../`; `targets` passes upstream
-  shard paths into downstream branches via `format = "file"`, and
+- **Static branching — one named target per shard (§6).** The shard
+  set is a pure function of the scenario, known when `_targets.R` is
+  sourced, so `tarchetypes::tar_map()` mints one named target per
+  shard (no `pattern = map` over a runtime task-table target). The
+  scenario is a plain construction-time object, not a `tar_target()`.
+  Dynamic branching stays available as a documented fallback for
+  extreme-scale fan-outs (§6).
+- **Per-shard Parquet shards, Hive-style (§6).** Each shard target
+  writes one Parquet file under
+  `results/<step>/dataset=.../sim=.../`; downstream shards open the
+  upstream shard by partition path (`format = "file"`), and
   duckplyr predicate-pushes filters into the partition columns.
 - **Cloud upload as a separate target (§6.1).** When
   `scenario$upload` is set, an `upload_<step>` target sits
@@ -119,8 +127,12 @@ The most consequential design choices, with section refs:
 ## 1. Scenario object
 
 The scenario is **purely declarative**. It does not carry the
-materialized task grid; expansion happens at run time via
-`ssd_scenario_tasks(scenario)` (§2). An S3 object holding:
+materialized task grid; expansion happens via
+`ssd_scenario_tasks(scenario)` (§2). It is a **plain construction-time
+object** built at the top of `_targets.R`, not a `tar_target()` — so
+the shard set it expands to is known when the pipeline is sourced,
+which is what lets the steps use static branching (§6). An S3 object
+holding:
 
 ```
 ssdsims_scenario
@@ -430,8 +442,9 @@ ssd_run_scenario(scenario, plan = "mirai")  # in-process parallel
 `ssd_scenario()` stores the scenario inputs (seed, dataset names,
 fit/hc arg grids). It is purely declarative — it does **not** expand
 the task tables. Expansion is `ssd_scenario_tasks(scenario)`, called
-either by `ssd_run_scenario()` (local) or by the `data_tasks` /
-`fit_tasks` / `hc_tasks` targets in the cluster pipeline (§4).
+either by `ssd_run_scenario()` (local) or, in the cluster pipeline
+(§4), while `_targets.R` is sourced to build the per-shard task tables
+that `tar_map` fans out over (§6).
 
 ```
    ssd_scenario(...) ──▶ ssdsims_scenario   (declarative; carries seed)
@@ -472,15 +485,15 @@ others — they're equal inputs that get assembled into the final
               ┌───────────────────────────────────────┐
               │ ssdsims _targets.R for our cluster    │
               │                                       │
-              │   scenario ─▶ {data,fit,hc}_tasks     │
+              │   scenario ─▶ {data,fit,hc}_shards    │
               │                            │          │
               │                            ▼          │
-              │                pattern = map(...) on  │
+              │              tar_map(...) targets on  │
               │             crew_controller_slurm()   │
               │                            │          │
               │                            ▼          │
               │           shards run in parallel;     │
-              │           each branch writes one shard│
+              │           each target writes one shard│
               └───────────────────────────────────────┘
 ```
 
@@ -489,7 +502,7 @@ parallel; none is downstream of the others. Roles:
 
 - **A — example pipeline for another cluster** contributes the
   *shape* of `_targets.R`: how a `crew` controller is constructed,
-  how dynamic branching is wired, where results land, where the
+  how the per-shard branching is wired, where results land, where the
   merge target sits. Lifted as a skeleton, not as content.
   Source: another lab's published targets+crew repo.
 
@@ -562,10 +575,11 @@ sharing is the deliberate `nrow` sub-truncation below.
 
 Tasks are the unit of computation (one row, one primer, one
 `_state` call). Shards are the unit of *storage, dispatch and
-parallelism*: one shard ≡ one Parquet file ≡ one branch of the
-step target, and **independent shards run in parallel**. (How
-branches are packed into Slurm jobs under `crew_controller_slurm()`
-is an open question — see §11.) **One shard typically contains
+parallelism*: one shard ≡ one Parquet file ≡ one named step target
+(minted by `tar_map`, §6), and **independent shards run in
+parallel**. (How shard targets are packed into Slurm jobs under
+`crew_controller_slurm()` is an open question — see §11.) **One
+shard typically contains
 many tasks**: the scenario's `partition_by[[step]]` picks which
 task-table columns become Hive directory levels, and every task
 row sharing those column values goes into the same shard.
@@ -662,13 +676,13 @@ fan-out by 5×.
 ### Implications for the targets pipeline
 
 Each step needs its **own** task table (`data_tasks`, `fit_tasks`,
-`hc_tasks`) and its own dynamic-branched target — a single shared
-task table mapped lockstep through all three steps does **not**
-work when the grids differ. Layers link via the upstream **shard's
-partition path**: each task row carries the partition column
-values of the upstream shard it needs (the `data_id` / `fit_id`
-columns are sugar for the path), and the per-branch body opens
-that one upstream Parquet. §6 wires this up concretely.
+`hc_tasks`) and its own per-shard targets (one named target per
+shard, §6) — a single shared task table mapped lockstep through all
+three steps does **not** work when the grids differ. Layers link via
+the upstream **shard's partition path**: each task row carries the
+partition column values of the upstream shard it needs (the `data_id`
+/ `fit_id` columns are sugar for the path), and the per-shard body
+opens that one upstream Parquet. §6 wires this up concretely.
 
 ---
 
@@ -696,80 +710,157 @@ Parquet per shard so the data, fit, and hc layers are
 independently queryable for analysis without re-running upstream
 steps.
 
+### Static branching: one named target per shard
+
+The shard set is a **pure function of the scenario**, and the
+scenario is known when `_targets.R` is *sourced* — it is a plain
+constructor call at the top of the file, not a `tar_target()`. So
+the fan-out width is fixed at construction time, never data-dependent
+at run time. By the standard rule of thumb — *static branching when
+the branch count is known at sourcing time, dynamic branching only
+when it depends on data computed during the run* — this design uses
+**static branching**: `tarchetypes::tar_map()` mints one named target
+per shard while the pipeline is built. An independent experiment
+exercised both styles head to head and confirmed the rule applies
+here; the most complete experiment (pinning + `error = "null"` +
+per-shard upload, all composed) is itself built on static branching.
+
+Why static fits this design specifically:
+
+- **The scenario need not live in a target.** It is a construction-time
+  object; `ssd_scenario_*_shards(scenario)` evaluate at sourcing time
+  and feed `tar_map()`'s `values`. `targets` still tracks the scenario
+  as a referenced global, so editing a knob still invalidates the
+  dependent shards — tracking is not lost by taking it out of a target.
+- **Named, addressable shards.** Each shard is its own DAG node
+  (`fit_step_boron_sim1_rescaleFALSE`), so `tar_read()` /
+  `tar_invalidate()` (§8.3–§8.4) and the replay story (§7) can point at
+  one shard by name, and `tar_mermaid()` shows the real per-shard graph
+  with per-shard status colours.
+- **Extension is literally "more named targets."** Adding a dataset or
+  growing `nsim` (path-axis growth, §8.1) mints new shard targets at
+  the next sourcing; `targets` diffs the target set and builds only the
+  new ones — exactly the §8 cache story, with no directory-hash
+  indirection needed to keep existing shards from rebuilding.
+- **Precise upstream edges.** A fit shard target can name its one
+  upstream data shard target directly, so a changed data shard
+  invalidates only its dependent fit/hc shards — strictly better than
+  depending on a whole pattern target. (The Hive partition-path layout
+  below is still kept, but for the off-cluster query layer and replay,
+  not as the inter-target wiring crutch dynamic branching would force.)
+
+**The bounded exception — scale.** `tar_map()` builds one target object
+per shard every time `_targets.R` is sourced, so a scenario with very
+many shards (thousands: many datasets × large `nsim` under a
+fine-grained `partition_by`) makes sourcing and the graph tooling
+heavy, where dynamic branching's single pattern node stays light.
+Branching is an implementation detail *behind the shard abstraction* —
+one Parquet per shard, identical per-task RNG, partition-path linking,
+and replay contract either way — so a step whose fan-out is large
+enough to hurt may opt into dynamic branching
+(`tar_target(pattern = map(<step>_tasks))` over a grouped task-table
+target) without changing anything else. Static is the default; dynamic
+is the documented escape hatch for extreme fan-outs.
+
 ```
-   scenario   (declarative; carries seed, partition_by)
+   scenario   (plain construction-time object; carries seed, partition_by)
        │
-       ├──▶ data_tasks  ( 2 rows ; partition cols dataset,sim,replace)
+       ├──▶ data_shards  ( 2 rows ; partition cols dataset,sim,replace)
        │         │
-       │         ▼  tar_group_by(..., dataset, sim, replace)
-       │     data_step  ──▶ results/data/dataset=boron/sim=1/replace=FALSE/part.parquet  (2 shards)
+       │         ▼  tar_map(values = data_shards, names = c(dataset, sim, replace))
+       │     data_step_*  ──▶ results/data/dataset=boron/sim=1/replace=FALSE/part.parquet  (2 named shard targets)
        │
-       ├──▶ fit_tasks   ( 4 rows ; partition cols dataset,sim,rescale; data upstream)
+       ├──▶ fit_shards   ( 4 rows ; partition cols dataset,sim,rescale; data upstream)
        │         │
-       │         ▼  tar_group_by(..., dataset, sim, rescale)
-       │     fit_step   ──▶ results/fit/dataset=boron/sim=1/rescale=FALSE/part.parquet   (4 shards)
-       │                 each shard reads the matching data shard by partition path
+       │         ▼  tar_map(values = fit_shards, names = c(dataset, sim, rescale))
+       │     fit_step_*   ──▶ results/fit/dataset=boron/sim=1/rescale=FALSE/part.parquet   (4 named shard targets)
+       │                  each shard reads the matching data shard by partition path
        │
-       └──▶ hc_tasks    ( 8 rows ; partition cols dataset,sim; fit upstream)
+       └──▶ hc_shards    ( 2 rows ; partition cols dataset,sim; fit upstream)
                  │
-                 ▼  tar_group_by(..., dataset, sim)
-             hc_step    ──▶ results/hc/dataset=boron/sim=1/part.parquet                  (2 shards, 4 tasks each)
+                 ▼  tar_map(values = hc_shards, names = c(dataset, sim))
+             hc_step_*  ──▶ results/hc/dataset=boron/sim=1/part.parquet                  (2 named shard targets, 4 tasks each)
                          each shard reads the matching fit shard(s) by partition path
 
    summary  ──▶ results/summary.parquet
                 (reads all three layers via duckplyr)
 ```
 
-The link between steps is by **upstream partition path (passed by `targets`)**, not by a
-single shared dynamic-branch index — `targets` passes the upstream branch's shard path into each downstream branch automatically. Each task row carries the upstream's partition column values; the body opens that one upstream Parquet. This is what lets tweaking `rescale` re-run fit + hc without re-running data (the fit task row's `data` partition columns are unchanged).
+The link between steps is by **upstream partition path**: each shard
+row carries the partition column values of the upstream shard it needs,
+and the body opens that one upstream Parquet. Under static branching a
+shard target can additionally name its specific upstream shard target
+for a precise dependency edge; the partition path remains the portable
+contract used for the off-cluster query layer (the Hive-style layout
+below) and replay (§7).
+This is what lets tweaking `rescale` re-run fit + hc without re-running
+data (the fit shard's `data` partition columns are unchanged).
 
 `_targets.R` sketch:
 
 ```r
+library(targets)
+library(tarchetypes)
+
+# The scenario is a plain object built HERE, at sourcing time — not a
+# tar_target. Everything downstream is a pure function of it, so the
+# shard set is fixed before any target runs (static branching).
+scenario <- ssd_scenario(
+  ssddata::ccme_boron,
+  nsim = 2L,
+  nrow = c(5L, 10L),
+  rescale = c(FALSE, TRUE),
+  est_method = c("arithmetic", "multi"),
+  nboot = 10,
+  seed = 42L
+)
+
+# One row per shard, computed now (sourcing time). Each row carries the
+# step's partition_by values (which become the tar_map target-name
+# suffix and the Hive path) plus a list-column `tasks` of the task rows
+# that shard must run.
+data_shards <- ssd_scenario_data_shards(scenario)  # 2 rows
+fit_shards  <- ssd_scenario_fit_shards(scenario)   # 4 rows
+hc_shards   <- ssd_scenario_hc_shards(scenario)    # 2 rows (4 tasks each)
+
 list(
-  tar_target(scenario,
-    ssd_scenario(
-      ssddata::ccme_boron,
-      nsim = 2L,
-      nrow = c(5L, 10L),
-      rescale = c(FALSE, TRUE),
-      est_method = c("arithmetic", "multi"),
-      nboot = 10,
-      seed = 42L)),
-
-  # Three separate task tables, one per step grid (§5). tar_group_by
-  # buckets task rows by the step's partition_by columns; each group
-  # becomes one branch (= one shard out, possibly many tasks).
-  # Independent branches run in parallel; how they pack into Slurm
-  # jobs under crew_controller_slurm() is an open question (§11).
-  tar_group_by(data_tasks, ssd_scenario_data_tasks(scenario), dataset, sim, replace),
-  tar_group_by(fit_tasks,  ssd_scenario_fit_tasks(scenario),  dataset, sim, rescale),
-  tar_group_by(hc_tasks,   ssd_scenario_hc_tasks(scenario),   dataset, sim),
-
-  # error = "null" so one bad shard does not abort the run: the
-  # branch goes NULL, the error is recorded, the rest keeps building
-  # and summary unions the survivors (§6.2). format = "file" passes
-  # the shard path, not its value, between targets (see below).
-  tar_target(
-    data_step,
-    ssd_run_data_step(data_tasks, scenario, out_dir = "results/data"),
-    pattern = map(data_tasks), format = "file", error = "null"
+  # tar_map mints one named target per shard at sourcing time. Independent
+  # shard targets run in parallel; how they pack into Slurm jobs under
+  # crew_controller_slurm() is an open question (§11).
+  #
+  # error = "null" so one bad shard does not abort the run: the target
+  # goes NULL, the error is recorded, the rest keeps building and summary
+  # unions the survivors (§6.2). format = "file" passes the shard path,
+  # not its value, between targets (see below).
+  tar_map(
+    values = data_shards, names = c(dataset, sim, replace),
+    tar_target(
+      data_step,
+      ssd_run_data_step(tasks, scenario, out_dir = "results/data"),
+      format = "file", error = "null"
+    )
   ),
 
-  tar_target(
-    fit_step,
-    ssd_run_fit_step(fit_tasks, scenario,
-                     data_dir = "results/data",
-                     out_dir  = "results/fit"),
-    pattern = map(fit_tasks), format = "file", error = "null"
+  tar_map(
+    values = fit_shards, names = c(dataset, sim, rescale),
+    tar_target(
+      fit_step,
+      ssd_run_fit_step(tasks, scenario,
+                       data_dir = "results/data",
+                       out_dir  = "results/fit"),
+      format = "file", error = "null"
+    )
   ),
 
-  tar_target(
-    hc_step,
-    ssd_run_hc_step(hc_tasks, scenario,
-                    fit_dir = "results/fit",
-                    out_dir = "results/hc"),
-    pattern = map(hc_tasks), format = "file", error = "null"
+  tar_map(
+    values = hc_shards, names = c(dataset, sim),
+    tar_target(
+      hc_step,
+      ssd_run_hc_step(tasks, scenario,
+                      fit_dir = "results/fit",
+                      out_dir = "results/hc"),
+      format = "file", error = "null"
+    )
   ),
 
   tar_target(
@@ -783,12 +874,20 @@ list(
 )
 ```
 
+`summary` reads the three result directories directly with duckplyr
+rather than depending on each shard target — so it sees whatever
+shards landed (survivors included, §6.2) and does not pull every
+shard's value back into R. `tarchetypes::tar_combine()` is the
+alternative fan-in when an in-memory bind is wanted instead.
+
 A step body (sketch):
 
 ```r
-ssd_run_fit_step <- function(fit_tasks_group, scenario, data_dir, out_dir) {
-  rows <- purrr::pmap_dfr(fit_tasks_group, function(task_id, primer, data_id,
-                                                   rescale, min_pmix, ...) {
+# `tasks` is the shard row's list-column of task rows (one per task in
+# this shard), supplied by tar_map from fit_shards.
+ssd_run_fit_step <- function(tasks, scenario, data_dir, out_dir) {
+  rows <- purrr::pmap_dfr(tasks, function(task_id, primer, data_id,
+                                          rescale, min_pmix, ...) {
     upstream <- arrow::read_parquet(file.path(data_dir,
                                               # partition path from upstream cols
                                               .upstream_path(...),
@@ -800,7 +899,7 @@ ssd_run_fit_step <- function(fit_tasks_group, scenario, data_dir, out_dir) {
                    fit = list(fit_dists_state(upstream, rescale, min_pmix, ...)))
   })
   out <- file.path(out_dir,
-                   .partition_path(fit_tasks_group, scenario$partition_by$fit),
+                   .partition_path(tasks, scenario$partition_by$fit),
                    "part.parquet")
   dir.create(dirname(out), recursive = TRUE, showWarnings = FALSE)
   arrow::write_parquet(rows, out)
@@ -808,15 +907,16 @@ ssd_run_fit_step <- function(fit_tasks_group, scenario, data_dir, out_dir) {
 }
 ```
 
-The body loops once per task in the group, primes the RNG with
+The body loops once per task in the shard, primes the RNG with
 that task's primer, calls the (state-less) `_state` primitive, and
 stacks K result rows into one Parquet at the shard's partition
-path. To keep `fit_step` from depending on the whole `data_step`
-target (which would re-run every fit branch on any data branch
-change), we use file-path indirection: the fit body opens the one
-upstream data shard via its partition path. `targets` tracks the
-*directory* by hash of all file names it contains, so adding new
-data shards does not invalidate existing fit shards.
+path. Each fit shard opens the one upstream data shard via its
+partition path, so a fit shard never depends on the whole data step.
+Under static branching that scoping is natural: a fit shard target can
+name its single upstream data shard target (`data_step_boron_sim1_…`)
+for a precise edge, so adding new data shards mints new targets and
+leaves existing fit shards untouched — no directory-hash indirection
+required to avoid spurious rebuilds.
 
 **Dependencies and what re-runs on a knob change** (applied to the
 2/4/2 shard counts above; "1 shard re-runs" = its Parquet is
@@ -926,14 +1026,16 @@ an optional `upload` field describing a destination object store.
 ```
 
 **Upload is its own target, not an inline side effect.** When
-`upload` is non-NULL the pipeline adds an `upload_<step>` target
-downstream of each step, mapping over the same shards:
+`upload` is non-NULL the pipeline adds one `upload_<step>` target per
+shard, paired with its step target by the same `tar_map`:
 
 ```r
-tar_target(
-  upload_fit,
-  ssd_upload_shard(fit_step, scenario$upload),   # fit_step = the shard path
-  pattern = map(fit_step), format = "file", error = "null"
+tar_map(
+  values = fit_shards, names = c(dataset, sim, rescale),
+  tar_target(fit_step, ssd_run_fit_step(tasks, scenario, ...),
+             format = "file", error = "null"),
+  tar_target(upload_fit, ssd_upload_shard(fit_step, scenario$upload),
+             format = "file", error = "null")   # fit_step = the shard path
 )
 ```
 
@@ -1030,14 +1132,15 @@ Two constraints, both confirmed by independent experiments:
 
 **The `NULL` must flow cleanly downstream.** A failed shard's value is
 `NULL`, and the targets immediately downstream — the `upload_<step>`
-branch (§6.1) and the two manifests — have to tolerate it rather than
+target (§6.1) and the two manifests — have to tolerate it rather than
 choke. `ssd_upload_shard(NULL, ...)` records the shard as a skip
 instead of erroring, and the compute / upload manifests simply omit
 it; the survivors still upload and `summary` still unions them. An
-independent experiment that composed a dynamically-sized fan-out, this
-`error = "null"` handling, and the per-shard upload target found this
-`NULL`-tolerance in the upload and manifest helpers was the *only*
-glue the composition needed — and that once the failing branch is
+independent experiment that composed a construction-time-sized fan-out
+(static branching), this `error = "null"` handling, and the per-shard
+upload target found this `NULL`-tolerance in the upload and manifest
+helpers was the *only* glue the composition needed — and that once the
+failing branch is
 fixed under the §8.3 pin, only that one shard rebuilds, re-uploads,
 and is re-queried (a minimal re-run, not a full redo).
 
@@ -1305,12 +1408,15 @@ function bodies it calls — so editing an `_state` function (or
 bumping an `ssdtools` version) rebuilds *nothing*:
 
 ```r
-tar_target(
-  fit_step,
-  ssd_run_fit_step(fit_tasks, scenario, data_dir = "results/data",
-                   out_dir = "results/fit"),
-  pattern = map(fit_tasks), format = "file", error = "null",
-  cue = tar_cue(depend = FALSE)   # pin against upstream code edits
+tar_map(
+  values = fit_shards, names = c(dataset, sim, rescale),
+  tar_target(
+    fit_step,
+    ssd_run_fit_step(tasks, scenario, data_dir = "results/data",
+                     out_dir = "results/fit"),
+    format = "file", error = "null",
+    cue = tar_cue(depend = FALSE)   # pin against upstream code edits
+  )
 )
 ```
 
@@ -1475,15 +1581,15 @@ per process and is restored on exit).
 5. **Toy pipeline shape.** Ship a single
    `inst/targets-templates/cluster/` that the LLM-authoring prompt
    edits, or only documentation pointing at `crew.cluster` examples?
-6. **Branch ↔ Slurm-job mapping under `crew_controller_slurm()`.**
-   `targets` + `crew` dispatch branches across Slurm jobs but the
-   precise mapping — one branch per job vs several branches packed
+6. **Shard-target ↔ Slurm-job mapping under `crew_controller_slurm()`.**
+   `targets` + `crew` dispatch the per-shard targets across Slurm jobs
+   but the precise mapping — one shard target per job vs several packed
    into one job — is configurable and depends on `crew` settings.
    The design commits only to **shards being the unit of
-   parallelism**: independent shards run concurrently, regardless
+   parallelism**: independent shard targets run concurrently, regardless
    of job packing. Resolve by prototyping with the
    `cluster-pipeline` step (§12) and document the chosen packing
-   convention; until then `branch ↔ job` should be read as "many
+   convention; until then `shard target ↔ job` should be read as "many
    to one or one to one, depending on configuration".
 
 ---
@@ -1555,8 +1661,13 @@ shows where branches open and close.
   alongside the Parquet on success.
 - **`task-tables`** — `ssd_scenario_data_tasks` /
   `_fit_tasks` / `_hc_tasks` returning the per-step task tables
-  with `(seed, primer)` on each row. The §6 sketch compiles and
-  `tar_make()`s a tiny scenario.
+  with `(seed, primer)` on each row, plus the `ssd_scenario_*_shards`
+  wrappers that group those rows by `partition_by` into one row per
+  shard (a `tasks` list-column) for `tar_map`'s `values`. The §6
+  sketch compiles and `tar_make()`s a tiny scenario. **Static
+  branching**: the scenario is a plain construction-time object and
+  `tar_map` mints one named target per shard (§6) — no
+  `pattern = map` over a runtime target.
 - **`shard-failure-survival`** — §6.2 — step targets carry
   `error = "null"` and `summary` unions the survivors; the runner
   muffles only the expected end-of-pipeline "errored" warning under

--- a/TARGETS-DESIGN.md
+++ b/TARGETS-DESIGN.md
@@ -1028,6 +1028,19 @@ Two constraints, both confirmed by independent experiments:
   muffles only that one expected warning rather than relaxing the
   global option.
 
+**The `NULL` must flow cleanly downstream.** A failed shard's value is
+`NULL`, and the targets immediately downstream — the `upload_<step>`
+branch (§6.1) and the two manifests — have to tolerate it rather than
+choke. `ssd_upload_shard(NULL, ...)` records the shard as a skip
+instead of erroring, and the compute / upload manifests simply omit
+it; the survivors still upload and `summary` still unions them. An
+independent experiment that composed a dynamically-sized fan-out, this
+`error = "null"` handling, and the per-shard upload target found this
+`NULL`-tolerance in the upload and manifest helpers was the *only*
+glue the composition needed — and that once the failing branch is
+fixed under the §8.3 pin, only that one shard rebuilds, re-uploads,
+and is re-queried (a minimal re-run, not a full redo).
+
 ---
 
 ## 7. Debugging a cluster failure
@@ -1286,7 +1299,7 @@ The question is the **opposite** of invalidation — how to keep
 `targets` from re-running things whose shards are still trusted.
 
 This stays inside the one project. An independent experiment settled
-it: `tar_cue(depend = FALSE)` is exactly the knob. It tells a target
+it: `tar_cue(depend = FALSE)` does exactly this. It tells a target
 to ignore changes to its upstream dependencies — including the
 function bodies it calls — so editing an `_state` function (or
 bumping an `ssdtools` version) rebuilds *nothing*:


### PR DESCRIPTION
## Summary

This PR updates TARGETS-DESIGN.md to document significant architectural changes to two core mechanisms:

1. **Cloud upload refactored as separate targets** (§6.1): Instead of pushing shards inline after local writes, upload is now its own `upload_<step>` target downstream of each shard. This enables content-hashing to skip re-uploading unchanged shards, allows the graph to build and dry-run offline without credentials, and separates concerns by dependency.

2. **Code-pinning via `tar_cue(depend = FALSE)` instead of dag-of-dags** (§8.3): Removed the `parent` field from `ssdsims_scenario` entirely. Pinning shards against code changes now uses `tar_cue(depend = FALSE)` on step targets within a single project, eliminating the need for a child project pointing back at parent outputs.

3. **Shard failure survival with `error = "null"`** (§6.2): Step targets now carry `error = "null"` so a single failed shard does not abort the run; `summary` unions the survivors and errors are read from `tar_meta()` after `tar_make()` returns.

## Key Changes

- Removed `parent` field from scenario object; extension now relies entirely on shards-as-cache (file existence ⇒ cache hit)
- Added `error = "null"` to all step targets and upload targets
- Documented why `format = "file"` is used instead of native Parquet store
- Clarified upload flow: separate target with content-hashing and dry-run support
- Updated roadmap to include `shard-failure-survival` entry point
- Corrected references from "parent's manifest" to "cluster run's manifest"
- Simplified design dialogue point 3 to reflect removal of `parent` reference

## Test Plan

No code changes; documentation only. Existing tests for the mechanisms described (cloud upload, error handling, caching) remain unchanged and should continue to pass.

https://claude.ai/code/session_01Cere3fz4dWtGkk29B1wi5J