### PR TITLE
Install ssdtools from r-universe (pinned to dev build)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,8 +26,8 @@ Suggests:
     readr,
     ssddata,
     testthat (>= 3.0.0)
-Remotes:
-    poissonconsulting/ssdtools@dev
+Additional_repositories:
+    https://poissonconsulting.r-universe.dev
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,13 +19,15 @@ Imports:
     parallel,
     purrr,
     rlang,
-    ssdtools (>= 2.6.0),
+    ssdtools (>= 2.6.0.9002),
     tidyr,
     withr
 Suggests: 
     readr,
     ssddata,
     testthat (>= 3.0.0)
+Remotes:
+    ssdtools=url::https://poissonconsulting.r-universe.dev/src/contrib/ssdtools_2.6.0.9002.tar.gz
 Additional_repositories:
     https://poissonconsulting.r-universe.dev
 Config/testthat/edition: 3


### PR DESCRIPTION
## What

Switch the `ssdtools` development dependency from a GitHub git-checkout to the
[poissonconsulting r-universe](https://poissonconsulting.r-universe.dev),
**enforcing** the r-universe install and pinning to the current dev build.

`DESCRIPTION` changes:

```diff
-    ssdtools (>= 2.6.0),
+    ssdtools (>= 2.6.0.9002),
 ...
-Remotes:
-    poissonconsulting/ssdtools@dev
+Remotes:
+    ssdtools=url::https://poissonconsulting.r-universe.dev/src/contrib/ssdtools_2.6.0.9002.tar.gz
+Additional_repositories:
+    https://poissonconsulting.r-universe.dev
```

- **`Remotes: ssdtools=url::…`** — uses the `pkg=url::` reference notation that
  **both `remotes` and `pak` understand** for installing a package from a
  non-default repository. This is what actually *forces* `ssdtools` to come
  from r-universe (verified: `remotes:::parse_one_extra()` strips the `pkg=`
  prefix and resolves it to a `url_remote`; pak requires the explicit package
  name for `url::` refs). `Additional_repositories` on its own does **not**
  enforce installation — its only purpose is letting CRAN verify the package is
  available there — so it is kept for discoverability/CRAN checks but is no
  longer relied on to do the install.
- **`Imports: ssdtools (>= 2.6.0.9002)`** — requires at least the currently
  active dev build.

## Same code as GitHub — confirmed

The pinned r-universe tarball (`ssdtools` 2.6.0.9002) is built from the **same
commit** the old `Remotes` field targeted:

| Source | Ref | Commit |
|--------|-----|--------|
| GitHub `dev` branch (old `Remotes` target) | `dev` | `d4865f6` |
| GitHub `main` branch | `main` | `d4865f6` |
| r-universe build of `ssdtools` 2.6.0.9002 | `RemoteSha` | `d4865f6` |

All three resolve to `d4865f65c73bd453e25f96821e991f7da23520d5`, so the
installed code is identical — only the delivery mechanism changes.

## Note on the pinned URL

r-universe keeps only the latest source tarball in `src/contrib` (older
versions 404), so the `url::` reference names the exact version `2.6.0.9002`.
When ssdtools advances on r-universe, bump both the `Imports` constraint and
the tarball version in the `Remotes` URL together.

https://claude.ai/code/session_01M2G2ruH2xfFESknjqunS9y