### PR TITLE
docs: expand development workflow and coding guidelines

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "defaultMode": "acceptEdits",
+    "allow": [
+      "Bash(air:*)",
+      "Bash(cat:*)",
+      "Bash(find:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr view:*)",
+      "Bash(git checkout:*)",
+      "Bash(git grep:*)",
+      "Bash(grep:*)",
+      "Bash(ls:*)",
+      "Bash(quarto:*)",
+      "Bash(R:*)",
+      "Bash(rm:*)",
+      "Bash(Rscript:*)",
+      "Bash(sed:*)",
+      "Skill",
+      "WebFetch(domain:cran.r-project.org)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:raw.githubusercontent.com)"
+    ],
+    "deny": [
+      "Read(.Renviron)",
+      "Read(.env)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,15 +201,12 @@ See `DESCRIPTION` for versions and imports.
 
 ### Update package version and news
 
-- Edit `DESCRIPTION` version field (e.g., `0.0.0.9010` → `0.0.0.9011`).
-- Add a note to `NEWS.md` (or use fledge: `fledge::bump_version()` to automate).
-- Commit with a note referencing the change.
+`NEWS.md` and the dev version are managed by [fledge](https://fledge.cynkra.com) — **do not hand-edit `NEWS.md`** (its header says as much). Entries are generated from commit messages and grouped by Conventional Commit type (Features, Bug fixes, Chore, Refactoring), so the way to shape a changelog entry is to write a clear, conventionally-typed commit message (see Pull Requests below).
 
-`NEWS.md` bullet conventions:
-- Every user-facing change gets a bullet. Skip small documentation tweaks, internal refactorings, and fixes to bugs introduced in the current dev version.
-- A bullet briefly describes the change to the end user and references the related issue in parentheses. It may span multiple sentences but must **not** contain new lines (do not line-wrap).
-- If the change relates to a function, put the function name early in the bullet.
-- Order bullets alphabetically by function name; bullets that don't mention a function go first.
+- `fledge::bump_version()` bumps the `DESCRIPTION` version and assembles `NEWS.md` from the commits since the last bump; a scheduled GitHub Action (`.github/workflows/fledge.yaml`) also runs this on `main`.
+- Reference the related issue in the commit message (e.g. `(#64)`) so it carries through to the changelog.
+
+> **Deviation from tidyverse/r-lib**: those packages have contributors hand-add a `NEWS.md` bullet (and order bullets alphabetically by function). This package does **not** — fledge derives the changelog from commits, so skip the manual bullet entirely and put the effort into the commit message instead.
 
 ## Pull Requests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,26 +50,54 @@ chk::chk_range(nrow, c(5, 1000))
 chk::chk_character(dataset_names)
 ```
 
+### Coding rules
+
+- Always run `air format .` after generating or editing code.
+- Use the base pipe operator (`|>`), not the magrittr pipe (`%>%`).
+- Use `\() ...` for single-line anonymous functions. For all other cases, use `function() {...}`.
+- Permissions for the common tooling (`air`, `R`, `Rscript`, read-only `git`/`gh`,
+  `quarto`, `Skill`) are pre-approved in `.claude/settings.json`, so these run
+  without a prompt.
+
 ## Development Workflow
 
 ### Setup
 
-```bash
+```r
 # Install development dependencies
 devtools::install_dev_deps()
 
 # Load the package for interactive use
 devtools::load_all()
 
-# Run tests
+# Run all tests
 devtools::test()
 
-# Build documentation
+# Run all tests for files starting with {name}
+devtools::test(filter = "^{name}")
+
+# Run all tests for R/{name}.R
+devtools::test_active_file("R/{name}.R")
+
+# Run a single test "blah" for R/{name}.R
+devtools::test_active_file("R/{name}.R", desc = "blah")
+
+# (Re)build documentation
 devtools::document()
+
+# Check that all topics are in the reference index
+pkgdown::check_pkgdown()
+
+# Format code
+air format .
 
 # Full check
 devtools::check()
 ```
+
+> When invoking R from the shell, use `Rscript --no-environ -e "..."`. Without
+> `--no-environ` the sandbox blocks reads of `~/.Renviron` and R fails to create
+> its `tempdir()`.
 
 ### RNG Discipline
 
@@ -86,15 +114,21 @@ When touching RNG-consuming code:
 
 ### Testing
 
-- Write snapshot tests for any output that should be stable (use `testthat::expect_snapshot()`).
-- Tests live in `tests/testthat/test-*.R`; run with `devtools::test()`.
-- Snapshots update with `testthat::snapshot_review()`.
-- RNG-touching tests must pin the seed explicitly.
+- Tests for `R/{name}.R` go in `tests/testthat/test-{name}.R`; place new tests next to similar existing ones.
+- All new code should have an accompanying test. Keep tests minimal with few comments.
+- Never put code in a `test-{name}.R` file outside a `test_that()` block; use `tests/testthat/helper.R` (or `helper-{name}.R`) instead.
+- Write snapshot tests for any output that should be stable (use `testthat::expect_snapshot()`); update with `testthat::snapshot_review()`.
+- Prefer specific expectations over `expect_true()` / `expect_false()` — they give better failure messages.
+- When testing errors and warnings, do **not** use `expect_error()` / `expect_warning()`. Use `expect_snapshot(error = TRUE)` for errors and `expect_snapshot()` for warnings so the full text is reviewable.
+- Avoid the `.package` argument to `local_mocked_bindings()` (it mutates another package's namespace); create a mockable wrapper in this package instead.
+- RNG-touching tests must pin the seed explicitly (`withr::with_seed()` or `local_lecuyer_cmrg_seed()`).
 
 ### Documentation
 
-- Functions are documented inline with roxygen comments (`#' @param`, `#' @return`, etc.).
-- Run `devtools::document()` to generate `man/` pages and update `NAMESPACE`.
+- Functions are documented inline with roxygen comments (`#' @param`, `#' @return`, etc.); wrap roxygen comments at 80 characters.
+- Every user-facing function should be exported and documented; internal functions should not have roxygen documentation.
+- Run `devtools::document()` to generate `man/` pages and update `NAMESPACE` — always re-document after changing a roxygen comment, and never edit `man/` or `NAMESPACE` by hand.
+- Whenever you add a new (non-internal) topic, add it to `_pkgdown.yml` and confirm with `pkgdown::check_pkgdown()`.
 - Examples in `@examples` are part of the spec — keep them small and runnable.
 
 ## OpenSpec Workflow
@@ -167,6 +201,12 @@ See `DESCRIPTION` for versions and imports.
 - Edit `DESCRIPTION` version field (e.g., `0.0.0.9010` → `0.0.0.9011`).
 - Add a note to `NEWS.md` (or use fledge: `fledge::bump_version()` to automate).
 - Commit with a note referencing the change.
+
+`NEWS.md` bullet conventions:
+- Every user-facing change gets a bullet. Skip small documentation tweaks, internal refactorings, and fixes to bugs introduced in the current dev version.
+- A bullet briefly describes the change to the end user and references the related issue in parentheses. It may span multiple sentences but must **not** contain new lines (do not line-wrap).
+- If the change relates to a function, put the function name early in the bullet.
+- Order bullets alphabetically by function name; bullets that don't mention a function go first.
 
 ## Pull Requests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,9 +88,6 @@ devtools::document()
 # Check that all topics are in the reference index
 pkgdown::check_pkgdown()
 
-# Format code
-air format .
-
 # Full check
 devtools::check()
 ```
@@ -98,6 +95,12 @@ devtools::check()
 > When invoking R from the shell, use `Rscript --no-environ -e "..."`. Without
 > `--no-environ` the sandbox blocks reads of `~/.Renviron` and R fails to create
 > its `tempdir()`.
+
+Format code from the shell:
+
+```bash
+air format .
+```
 
 ### RNG Discipline
 


### PR DESCRIPTION
## Why

Adopt the Claude configuration pattern used across the r-lib, tidyverse, and tidymodels ecosystems. A review of `dplyr`, `usethis`, `testthat`, `cli`, `recipes`, and `parsnip` found a uniform convention: a single consolidated `CLAUDE.md` paired with a `.claude/settings.json` permission allow-list. (Notably, **none** of those repos use directory-local/subdirectory `CLAUDE.md` files, so none are added here.) `ssdsims` had the `CLAUDE.md` but was missing the `settings.json`, and its `CLAUDE.md` lacked several of the operational rules peers rely on.

## Changes

**`.claude/settings.json` (new file):**
- Pre-approves the common R dev tooling so it runs without permission prompts: `air`, `R`, `Rscript`, read-only `git`/`gh`, `quarto`, and `Skill`, plus `WebFetch` to CRAN/GitHub.
- Denies reads of `.Renviron` and `.env`.

**`CLAUDE.md`** — folds in the ecosystem's operational rules while preserving the existing design narrative (RNG discipline, targets redesign, OpenSpec workflow):
- "Coding rules": `air format` after edits, base pipe `|>`, `\()` only for one-liners, pointer to the new `settings.json`.
- Granular test recipes: `devtools::test(filter=)`, `devtools::test_active_file(desc=)`, plus a `Rscript --no-environ` note.
- Testing conventions: `expect_snapshot(error = TRUE)` over `expect_error()`/`expect_warning()`, specific expectations over `expect_true()`, `local_mocked_bindings()` guidance, RNG seed pinning.
- Documentation: roxygen 80-char wrapping, re-document after roxygen edits, add topics to `_pkgdown.yml` + `pkgdown::check_pkgdown()`.
- `NEWS.md` bullet conventions: one bullet per user-facing change, no line-wrapping, function name early, alphabetical ordering.

## Notes

- The `--no-environ` note reflects the Claude Code web sandbox (which blocks reads of `~/.Renviron`); it's kept as a harmless defensive habit that matches `usethis`'s own `CLAUDE.md`, even though some sessions have no `~/.Renviron` to trip over.
- Left for a possible follow-up: de-duplicating the openspec tooling that currently lives in both `.claude/` and `.github/`.

## Test plan

N/A — documentation and configuration changes only.

https://claude.ai/code/session_01Nx3tiohqfLWkGHbidQQsgW