### PR TITLE
docs: add scenario-definition example script and Quarto vignette

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,7 +13,7 @@
 ^LICENSE\.md$
 ^_pkgdown\.yml$
 ^README\.Rmd$
-^.*\.html$
+^[^/]*\.html$
 ^air\.toml$
 ^\.ccache$
 ^CLAUDE\.md$

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -97,7 +97,7 @@ runs:
     - uses: r-lib/actions/setup-pandoc@v2
 
     # Required to build the Quarto vignettes (VignetteBuilder: quarto)
-    - uses: r-lib/actions/setup-quarto@v2
+    - uses: quarto-dev/quarto-actions/setup@v2
 
     - uses: r-lib/actions/setup-r@v2
       with:

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -96,6 +96,9 @@ runs:
 
     - uses: r-lib/actions/setup-pandoc@v2
 
+    # Required to build the Quarto vignettes (VignetteBuilder: quarto)
+    - uses: r-lib/actions/setup-quarto@v2
+
     - uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ inputs.r-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ docs
 
 /.quarto/
 .ccache/
+
+# Quarto vignette build artifacts
+vignettes/.quarto/
+vignettes/*_files/
+vignettes/*_cache/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Imports:
     tidyr,
     withr
 Suggests: 
+    knitr,
     quarto,
     readr,
     ssddata,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,9 +25,11 @@ Imports:
     tidyr,
     withr
 Suggests: 
+    quarto,
     readr,
     ssddata,
     testthat (>= 3.0.0)
+VignetteBuilder: quarto
 Remotes:
     poissonconsulting/ssdtools@dev
 Config/testthat/edition: 3

--- a/scripts/example2.R
+++ b/scripts/example2.R
@@ -1,0 +1,85 @@
+## Example scenario (new declarative API)
+##
+## A companion to scripts/example.R, rebuilt on the targets-bound API that
+## landed with `ssd_define_scenario()` (TARGETS-DESIGN.md section 1). Where
+## example.R drives the legacy `ssd_run_scenario()` straight to results, this
+## script walks the three stages the new pipeline separates:
+##
+##   1. assemble + validate the data        -> ssd_data()
+##   2. declare the scenario (no RNG, no IO) -> ssd_define_scenario()
+##   3. expand into per-step task tables     -> ssd_scenario_tasks()
+##   4. run the baseline in-process loop      -> ssd_run_scenario_baseline()
+##
+## Stages 1-3 are pure and side-effect-free: no random numbers are drawn and
+## nothing is written. Only the baseline runner (stage 4) touches the RNG, and
+## it draws from the ambient stream, so pin it with `withr::with_seed()` for a
+## reproducible local run.
+
+library(ssdsims)
+
+# --- 1. Assemble and validate the datasets --------------------------
+# `ssd_data()` is the single input entry point: it checks each frame for a
+# numeric `Conc` column and names the collection (here from the argument
+# names). A scenario can also take a bare data frame directly.
+datasets <- ssd_data(
+  boron = ssddata::ccme_boron,
+  cadmium = ssddata::ccme_cadmium
+)
+
+# --- 2. Declare the scenario ----------------------------------------
+# Purely declarative: stores the seed, the replicate count, the sample sizes,
+# the dataset *names*, and the fit/hc argument grids. `min_pmix` is kept by
+# name only. `ci = c(FALSE, TRUE)` is the deliberate way to ask for both the
+# point estimate and bootstrap intervals -- a bare `ci = FALSE` forbids the
+# bootstrap-only knobs (`nboot`, `ci_method`, `parametric`).
+scenario <- ssd_define_scenario(
+  datasets,
+  nsim = 3L,
+  nrow = c(5L, 10L, 20L),
+  seed = 42L,
+  dists = c("lnorm", "gamma"),
+  proportion = c(0.05, 0.2),
+  ci = c(FALSE, TRUE),
+  nboot = c(10L, 100L),
+  est_method = "multi",
+  ci_method = "weighted_samples"
+)
+print(scenario)
+
+# --- 3. Expand into the four per-step task tables -------------------
+# Still RNG-free. Each table carries a path-style `<step>_id` primary key and
+# its parent's id as a foreign key. The single expensive draw lives in the
+# `sample` step (keyed by dataset/sim/replace); `nrow` is just a cross-join
+# axis of the cheap `data` truncation, so one draw is shared across sizes.
+tasks <- ssd_scenario_tasks(scenario)
+print(tasks)
+
+# The bootstrap-only knobs collapse to NA on the `ci = FALSE` rows and fan out
+# only on the `ci = TRUE` rows -- inspect the hc table to see the asymmetry.
+print(tasks$hc)
+
+# Per-step derivations are also available individually:
+ssd_scenario_sample_tasks(scenario)
+
+# --- 4. Run the baseline in-process loop ----------------------------
+# The no-frills runner: in-process, no `targets`, no shards, no Parquet. It is
+# not reproducible on its own, so pin the ambient RNG for a deterministic run.
+withr::with_seed(42L, {
+  out <- ssd_run_scenario_baseline(scenario)
+})
+
+# Each element is the task table augmented with a per-task result list column.
+out$hc
+
+# Unnest the hazard-concentration estimates back onto their task identities.
+# `proportion` is not a task axis -- it is passed whole to each hc call, so
+# every hc result already carries its own `proportion` column.
+hcs <- tidyr::unnest(
+  out$hc[c("dataset", "sim", "nrow", "ci", "est_method", "hc")],
+  hc,
+  names_sep = "_"
+)
+print(
+  hcs[c("dataset", "sim", "nrow", "ci", "hc_proportion", "hc_est")],
+  n = Inf
+)

--- a/vignettes/defining-a-scenario.qmd
+++ b/vignettes/defining-a-scenario.qmd
@@ -1,0 +1,278 @@
+---
+title: "Defining a Scenario"
+vignette: >
+  %\VignetteIndexEntry{Defining a Scenario}
+  %\VignetteEngine{quarto::html}
+  %\VignetteEncoding{UTF-8}
+knitr:
+  opts_chunk:
+    collapse: true
+    comment: "#>"
+---
+
+```{r}
+#| label: setup
+#| include: false
+# The vignette exercises the live API, so it needs the optional fitting
+# dependencies. Skip evaluation gracefully if they are unavailable (e.g. on a
+# minimal CI runner) rather than failing the build.
+evaluate <- requireNamespace("ssddata", quietly = TRUE) &&
+  requireNamespace("ssdtools", quietly = TRUE)
+knitr::opts_chunk$set(eval = evaluate)
+```
+
+```{r}
+#| label: library
+library(ssdsims)
+```
+
+## Why a declarative scenario?
+
+ssdsims is moving from running a simulation study *immediately* (the legacy
+`ssd_run_scenario()`) to a cluster-friendly [targets](https://docs.ropensci.org/targets/)
+pipeline. The root of that pipeline is a **scenario**: a small, purely
+declarative description of the study you want to run. It contains only the
+knobs --- a seed, the number of simulations, the sample sizes, the dataset
+*names*, and the fit/hc argument grids. It draws **no** random numbers, expands
+**no** tasks, writes **nothing**, and has **no** dependency on `targets`.
+
+Keeping the scenario declarative buys two things:
+
+- It **serialises to a compact manifest** --- no data frames, no RNG state, no
+  function bodies --- so it can be shipped to a cluster and stored alongside
+  results.
+- The set of work a pipeline expands to is a **pure function of the scenario**,
+  so the same scenario always describes the same study.
+
+This vignette walks the stages that work *today*, in order. It is intended to
+grow: as roadmap features land (per-task seeding, shards, the `targets`
+backend), new sections will document them here. See `TARGETS-DESIGN.md` for the
+north-star design.
+
+The four stages this vignette covers:
+
+1. **Assemble** the data with `ssd_data()`.
+2. **Declare** the scenario with `ssd_define_scenario()`.
+3. **Expand** it into per-step task tables with `ssd_scenario_tasks()`.
+4. **Run** the baseline in-process loop with `ssd_run_scenario_baseline()`.
+
+Stages 1--3 are side-effect-free. Only stage 4 touches the RNG.
+
+## Stage 1: assemble the data
+
+`ssd_data()` is the single entry point for dataset input. It validates each
+data frame --- every dataset must carry a numeric `Conc` column, the species
+sensitivity distribution convention --- and assembles them into a named
+collection.
+
+```{r}
+#| label: ssd-data
+datasets <- ssd_data(
+  boron = ssddata::ccme_boron,
+  cadmium = ssddata::ccme_cadmium
+)
+datasets
+```
+
+Names come from the argument names where you supply them; otherwise they are
+derived from the argument expression by symbol capture (so a bare
+`ssddata::ccme_boron` becomes `"ccme_boron"`). Names must be unique, and a
+literal with no derivable name (e.g. a bare `data.frame(...)`) must be given an
+explicit name.
+
+`ssd_data()` is the extensible input point. A planned change
+(`scenario-input-types`) will let each input also be a data *generator* --- a
+`fitdists`/`tmbfit` object, a generator function, or a function-name string ---
+materialised by a dataset registry. For now each input must be a data frame.
+
+## Stage 2: declare the scenario
+
+`ssd_define_scenario()` is the constructor. Its required arguments are the
+dataset input, `nsim` (the replicate count), and `seed` (the RNG root --- it has
+no default because changing it fully re-roots every draw). Everything else is a
+knob with a sensible default.
+
+```{r}
+#| label: define-scenario
+scenario <- ssd_define_scenario(
+  datasets,
+  nsim = 3L,
+  nrow = c(5L, 10L, 20L),
+  seed = 42L,
+  dists = c("lnorm", "gamma"),
+  proportion = c(0.05, 0.2),
+  ci = c(FALSE, TRUE),
+  nboot = c(10L, 100L),
+  est_method = "multi",
+  ci_method = "weighted_samples"
+)
+scenario
+```
+
+The `print()` method shows the declarative fields: the scalar `seed` and
+`nsim`, the `nrow` sample sizes, the dataset names, and the two argument grids
+(`fit` and `hc`). Note what is *not* shown --- the data frames themselves are
+retained for the local runner but are not part of the declarative identity; the
+cluster path carries only the names.
+
+### Dataset input is flexible
+
+The preferred form is an `ssd_data()` collection (above), which owns validation
+and naming. For convenience the constructor also accepts bare data frame input,
+routed through the same `Conc` validation, in several forms:
+
+```{r}
+#| label: input-forms
+# 1. A single data frame; name derived from the expression ("ccme_boron").
+ssd_define_scenario(ssddata::ccme_boron, nsim = 2L, seed = 1L)
+
+# 2. A single data frame with an explicit name.
+ssd_define_scenario(ssddata::ccme_boron, name = "boron", nsim = 2L, seed = 1L)
+```
+
+A named list (`list(boron = ..., cadmium = ...)`) takes names from the list; an
+unnamed list derives them per element. Supplying both a named list and `name=`
+is an error.
+
+### `min_pmix` is referenced by name
+
+The `min_pmix` knob is stored **by name**, never as a function body, so the
+scenario stays serialisable. You can pass a character vector of names directly,
+or a function (or list of functions) whose name is derived by symbol capture
+--- mirroring dataset naming. The default `ssdtools::ssd_min_pmix` is stored as
+`"ssd_min_pmix"`:
+
+```{r}
+#| label: min-pmix
+scenario$fit$min_pmix
+```
+
+The registry that resolves a name back to a function is a future roadmap step;
+the baseline runner resolves names against `ssdtools` in the meantime.
+
+### The `ci = FALSE` rule
+
+When `ci = FALSE` is the *only* confidence-interval value, the bootstrap-only
+knobs (`nboot`, `ci_method`, `parametric`) are meaningless, so passing any of
+them is an error:
+
+```{r}
+#| label: ci-false-error
+#| error: true
+ssd_define_scenario(
+  ssddata::ccme_boron,
+  nsim = 2L,
+  seed = 1L,
+  ci = FALSE,
+  nboot = 1000
+)
+```
+
+To ask for *both* a point estimate and bootstrap intervals --- the common case
+--- set `ci = c(FALSE, TRUE)` (as in the scenario above) rather than a bare
+`ci = TRUE`. This keeps the study symmetric: the `ci = FALSE` row is retained
+and collapses its bootstrap knobs to `NA` at expansion time, while the
+`ci = TRUE` rows fan out across the full bootstrap grid.
+
+## Stage 3: expand into task tables
+
+`ssd_scenario_tasks()` expands the scenario into the four per-step task tables
+--- `sample`, `data`, `fit`, and `hc` --- bundled into a task set. This is
+still RNG-free: no draws happen here.
+
+```{r}
+#| label: tasks
+tasks <- ssd_scenario_tasks(scenario)
+tasks
+```
+
+The counts show how each step fans out from its parent. The key design choice
+is that the single expensive **random draw** is its own `sample` task, keyed
+only by `(dataset, sim, replace)`. The draw is of `n_max = max(nrow)` rows;
+every `nrow` value is then a cheap, RNG-free `head()` *sub-truncation* of that
+one draw at the `data` step. So `nrow` is an ordinary cross-join axis of the
+`data` step and never multiplies the underlying draw --- one draw is shared
+across all sample sizes.
+
+Each row carries a path-style `<step>_id` primary key (the Hive partition path)
+plus its parent step's id as a foreign key, so dependencies are explicit and
+joinable:
+
+```{r}
+#| label: sample-table
+tasks$sample
+```
+
+The `ci = FALSE` collapse is visible in the `hc` table: the `ci = FALSE` rows
+carry `NA` for the bootstrap-only knobs and are not multiplied across them,
+while the `ci = TRUE` rows fan out fully.
+
+```{r}
+#| label: hc-table
+tasks$hc
+```
+
+The per-step derivations are also available individually
+(`ssd_scenario_sample_tasks()`, `ssd_scenario_data_tasks()`,
+`ssd_scenario_fit_tasks()`, `ssd_scenario_hc_tasks()`) when you only need one
+table.
+
+## Stage 4: run the baseline loop
+
+`ssd_run_scenario_baseline()` is the no-frills runner. It executes the four
+task tables in dependency order, threading each task's result forward to its
+children by the foreign-key id. It runs **in-process**, with no `targets`, no
+shard grouping, and no Parquet I/O.
+
+It is also **not reproducible on its own** --- no per-task RNG seeding happens
+yet (that arrives with the `state-primitives` roadmap step). The runner draws
+from the *ambient* RNG, so pin it for a deterministic local run:
+
+```{r}
+#| label: run-baseline
+withr::with_seed(42L, {
+  out <- ssd_run_scenario_baseline(scenario)
+})
+names(out)
+```
+
+Each element is the corresponding task table augmented with a list column of
+per-task results --- `sample` draws, `data` truncations, `fits` objects, and
+`hc` tibbles:
+
+```{r}
+#| label: hc-out
+out$hc
+```
+
+Unnest the hazard-concentration estimates back onto their task identities to
+get a tidy results table. `proportion` is not a task axis --- it is passed
+whole to each `hc` call, so every result already carries its own `proportion`
+column:
+
+```{r}
+#| label: unnest
+hcs <- tidyr::unnest(
+  out$hc[c("dataset", "sim", "nrow", "ci", "est_method", "hc")],
+  hc,
+  names_sep = "_"
+)
+hcs[c("dataset", "sim", "nrow", "ci", "hc_proportion", "hc_est")]
+```
+
+## What is not here yet
+
+This vignette tracks *what currently works*. The targets pipeline is landing in
+dependency order (`TARGETS-DESIGN.md` §12); the pieces still ahead include:
+
+- **Per-task RNG seeding** --- a primer derived from `rlang::hash(task_params)`,
+  seeded via `dqrng::dqset.seed(seed, stream = primer)`, making each task
+  reproducible independently of run order.
+- **Shards and Parquet I/O** --- grouping tasks by the `partition_by` axes into
+  a Hive-partitioned directory tree.
+- **The `targets` backend** --- static branching (`tar_map()`) by default, with
+  dynamic branching as an escape hatch for extreme fan-outs.
+- **The `min_pmix` and dataset registries** --- resolving name references back
+  to functions and data.
+
+As each lands, a new section will document it here.


### PR DESCRIPTION
## Summary

Documents the declarative scenario API end-to-end, in two artefacts:

- **`scripts/example2.R`** — a companion to `scripts/example.R`, rebuilt on the new API. Where `example.R` drives the legacy `ssd_run_scenario()` straight to results, this script walks the four stages the targets-bound pipeline separates:
  1. `ssd_data()` — assemble + validate datasets
  2. `ssd_define_scenario()` — declare the scenario (no RNG, no I/O)
  3. `ssd_scenario_tasks()` — expand into the four per-step task tables
  4. `ssd_run_scenario_baseline()` — run the in-process loop (pinned with `withr::with_seed()`)

- **`vignettes/defining-a-scenario.qmd`** — a Quarto vignette documenting the scenario-definition process in detail: assembling data, the declarative constructor and its input forms, `min_pmix`-by-name, the `ci = FALSE` rule (with a live error chunk), task-table expansion (the shared-draw sub-truncation property and the `ci = FALSE` collapse), and the baseline runner. It is framed as a **growing description of what currently works**, closing with a "What is not here yet" section pointing at the roadmap pieces still ahead (per-task seeding, shards/Parquet, the `targets` backend, registries).

## Wiring

- Add `quarto` to `Suggests` and set `VignetteBuilder: quarto` in `DESCRIPTION`.
- Ignore Quarto vignette build artifacts (`vignettes/.quarto/`, `*_files/`, `*_cache/`).

## Verification

- `scripts/example2.R` runs end-to-end against `ccme_boron`/`ccme_cadmium`.
- The vignette renders cleanly through every chunk via the `quarto` engine (with the package installed, mirroring `R CMD build`).

https://claude.ai/code/session_01NfdDXs3iAaPhL77HDDuqhc

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfdDXs3iAaPhL77HDDuqhc)_