### PR TITLE
chore: rename `CLAUDE.md` to `AGENTS.md`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,7 +16,7 @@
 ^[^/]*\.html$
 ^air\.toml$
 ^\.ccache$
-^CLAUDE\.md$
+^AGENTS\.md$
 ^GLOSSARY\.md$
 ^openspec$
 ^\.claude$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ When touching RNG-consuming code:
 
 ### Testing
 
-Test-suite conventions live in **`tests/testthat/CLAUDE.md`** — file/naming
+Test-suite conventions live in **`tests/testthat/AGENTS.md`** — file/naming
 rules, error/warning and snapshot style, and RNG seeding. Read that before
 writing tests.
 
@@ -199,7 +199,7 @@ See `DESCRIPTION` for versions and imports.
 
 ### Add a new test file
 
-See **`tests/testthat/CLAUDE.md`** for the full test-suite conventions
+See **`tests/testthat/AGENTS.md`** for the full test-suite conventions
 (file/naming, expectations, snapshots, RNG seeding).
 
 ### Update package version and news

--- a/R/dqrng-backend.R
+++ b/R/dqrng-backend.R
@@ -62,7 +62,7 @@ dqrng_backend_active <- function() {
 # (returns invisibly on success) for dqrng-path helpers such as
 # `local_dqrng_state()` that are only meaningful while a `local_dqrng_backend()`
 # scope is open. `call` defaults to the calling frame so the error is reported
-# in the context of the user-facing function (CLAUDE.md error-call-origin rule).
+# in the context of the user-facing function (AGENTS.md error-call-origin rule).
 chk_dqrng_backend_active <- function(call = rlang::caller_call()) {
   if (!dqrng_backend_active()) {
     chk::abort_chk(

--- a/TARGETS-DESIGN.md
+++ b/TARGETS-DESIGN.md
@@ -1583,7 +1583,7 @@ Each scenario execution (via `ssd_run_scenario()` or a cluster step)
 installs dqrng as the base R RNG backend at entry and restores on exit
 via `on.exit(restore_methods())`. Tests and helper scripts that touch
 the methods mid-session (not inside a scenario runner) use the same
-`on.exit()` discipline — documented in CLAUDE.md (§RNG discipline).
+`on.exit()` discipline — documented in AGENTS.md (§RNG discipline).
 
 ---
 
@@ -1796,7 +1796,7 @@ shows where branches open and close.
   argument on `chk_*()` so the origin can be set without hand-rolling each
   check). Not on the dependency DAG — it can land at any time; the
   `ssd-define-scenario` work already follows the convention (see the
-  repo `CLAUDE.md` "Error origin" note).
+  repo `AGENTS.md` "Error origin" note).
 
 ### Cleanup
 

--- a/tests/testthat/AGENTS.md
+++ b/tests/testthat/AGENTS.md
@@ -1,6 +1,6 @@
 # Test conventions (tests/testthat)
 
-The home for all test-suite conventions. The repo-root `CLAUDE.md` points
+The home for all test-suite conventions. The repo-root `AGENTS.md` points
 here; keep test guidance in this file rather than there.
 
 ## Files & structure


### PR DESCRIPTION
## Summary

Renames the agent guide files from `CLAUDE.md` to `AGENTS.md` and keeps everything in sync:

- `CLAUDE.md` → `AGENTS.md` (repo root)
- `tests/testthat/CLAUDE.md` → `tests/testthat/AGENTS.md`
- `.Rbuildignore`: `^CLAUDE\.md$` → `^AGENTS\.md$`
- Updated internal references in `AGENTS.md`, `tests/testthat/AGENTS.md`, `TARGETS-DESIGN.md`, and `R/dqrng-backend.R`

Archived OpenSpec change history (`openspec/changes/archive/...`) is left untouched, as those are historical records.

https://claude.ai/code/session_01LXAbjNcQH8Jq7TBv5hdZCJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXAbjNcQH8Jq7TBv5hdZCJ)_