### PR TITLE
ci: require R >= 4.3 and fix Windows Quarto vignette builds

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,12 +4,6 @@
 # NOTE: This workflow is overkill for most R packages and
 # check-standard.yaml is likely a better choice.
 # usethis::use_github_action("check-standard") will install it.
-#
-# TEMPORARY: The smoke test job and dynamic matrix generation have been
-# removed. The rcc-full matrix is pinned to all Windows branches
-# (devel/release/oldrel-1) plus R 4.2 on Linux, and rcc-suggests is pinned to
-# a single entry ("without quarto"). Revert to restore the full matrix and
-# smoke test.
 on:
   push:
     branches:
@@ -57,30 +51,264 @@ concurrency:
 name: rcc
 
 jobs:
+  rcc-smoke:
+    runs-on: ubuntu-24.04
+
+    outputs:
+      sha: ${{ steps.commit.outputs.sha }}
+      versions-matrix: ${{ steps.versions-matrix.outputs.matrix }}
+      dep-suggests-matrix: ${{ steps.dep-suggests-matrix.outputs.matrix }}
+
+    name: "Smoke test: stock R"
+
+    permissions:
+      contents: write
+      statuses: write
+      pull-requests: write
+      actions: write
+
+    # Begin custom: services
+    # End custom: services
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Update status for rcc
+        if: github.actor != 'Copilot' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        # FIXME: Wrap into action
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Actor: ${{ github.actor }}"
+
+          # Check status of this workflow
+          state="pending"
+          sha=${{ inputs.ref }}
+          if [ -z "${sha}" ]; then
+            sha=${{ github.sha }}
+          fi
+          sha=$(git rev-parse ${sha})
+
+          html_url=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            repos/${{ github.repository }}/actions/runs/${{ github.run_id }} | jq -r .html_url)
+
+          description="${{ github.workflow }} / ${{ github.job }}"
+
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            repos/${{ github.repository }}/statuses/${sha} \
+            -f "state=${state}" -f "target_url=${html_url}" -f "description=${description}" -f "context=rcc"
+        shell: bash
+
+      - uses: ./.github/workflows/rate-limit
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/workflows/git-identity
+
+      - uses: ./.github/workflows/custom/before-install
+        if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
+
+      - uses: ./.github/workflows/install
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cache-version: rcc-smoke-2
+          needs: build, check, website
+          # Beware of using dev pkgdown here, has brought in dev dependencies in the past
+          extra-packages: any::rcmdcheck r-lib/roxygen2 any::decor r-lib/pkgdown deps::.
+
+      - uses: ./.github/workflows/custom/after-install
+        if: hashFiles('.github/workflows/custom/after-install/action.yml') != ''
+
+      # Must come after the custom after-install workflow
+      - name: Install package
+        run: |
+          _R_SHLIB_STRIP_=true R CMD INSTALL .
+        shell: bash
+
+      - id: versions-matrix
+        # Only run for:
+        # - pull requests if the base repo is different from the head repo
+        # - pull requests if the branch name starts with "cran-"
+        # Do not run for:
+        # - workflow_dispatch if not requested
+        # Always run for other events.
+        if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || startsWith(github.head_ref, 'cran-')) && (github.event_name != 'workflow_dispatch' || inputs.versions-matrix)
+        uses: ./.github/workflows/versions-matrix
+
+      - id: dep-suggests-matrix
+        # Not for workflow_dispatch if not requested, always run for other events
+        if: github.event_name != 'workflow_dispatch' || inputs.dep-suggests-matrix
+        uses: ./.github/workflows/dep-suggests-matrix
+
+      - id: repo-state
+        name: Determine repository state
+        uses: ./.github/workflows/repo-state
+
+      # Styling on foreign PRs works through the format-suggest workflow
+      - uses: ./.github/workflows/style
+        if: steps.repo-state.outputs.foreign != 'true' || steps.repo-state.outputs.is_pr != 'true'
+
+      # Snapshot tests can't work in a way similar to format-suggests
+      # because it requires running code which is a security risk on pull_request_target workflows
+      - uses: ./.github/workflows/update-snapshots
+        with:
+          base: ${{ inputs.ref || github.head_ref }}
+
+      - uses: ./.github/workflows/roxygenize
+
+      - name: Remove config files from previous iteration
+        run: |
+          rm -f .github/dep-suggests-matrix.json .github/versions-matrix.json
+        shell: bash
+
+      - id: commit
+        uses: ./.github/workflows/commit
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/workflows/check
+        with:
+          results: ${{ runner.os }}-smoke-test
+
+      - uses: ./.github/workflows/pkgdown-build
+        if: github.event_name != 'push'
+
+      # Deliberately deploy only on push
+      # Deployment on schedule adds too much noise.
+      # Deployment on pull_request is not possible because it requires a token with write permissions, which is not available in pull_request workflows for security reasons.
+      # Deployment on workflow_dispatch is available via the pkgdown workflow
+      - uses: ./.github/workflows/pkgdown-deploy
+        if: github.event_name == 'push'
+
+      # Upload sha as artifact
+      - run: |
+          echo -n "${{ steps.commit.outputs.sha }}" > rcc-smoke-sha.txt
+        shell: bash
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: rcc-smoke-sha
+          path: rcc-smoke-sha.txt
+
+      - name: Update status for rcc
+        # FIXME: Wrap into action
+        if: always() && (github.actor != 'Copilot') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check status of this workflow
+          if [ "${{ job.status }}" == "success" ]; then
+            state="success"
+          else
+            state="failure"
+          fi
+
+          sha=${{ steps.commit.outputs.sha }}
+          if [ -z "${sha}" ]; then
+            sha=${{ inputs.ref }}
+          fi
+          if [ -z "${sha}" ]; then
+            sha=${{ github.sha }}
+          fi
+            sha=$(git rev-parse ${sha})
+
+          html_url=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            repos/${{ github.repository }}/actions/runs/${{ github.run_id }} | jq -r .html_url)
+
+          description="${{ github.workflow }} / ${{ github.job }}"
+
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            repos/${{ github.repository }}/statuses/${sha} \
+            -f "state=${state}" -f "target_url=${html_url}" -f "description=${description}" -f "context=rcc"
+        shell: bash
+
+      - name: Update status for rcc (Copilot)
+        # Update status directly when triggered by Copilot or bots, since they can't dispatch workflows
+        if: always() && (github.actor == 'Copilot')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Set status to success if job succeeded, failure otherwise
+          if [ "${{ job.status }}" == "success" ]; then
+            state="success"
+          else
+            state="failure"
+          fi
+          sha=${{ inputs.ref }}
+          if [ -z "${sha}" ]; then
+            sha=${{ github.sha }}
+          fi
+          sha=$(git rev-parse ${sha})
+
+          html_url=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            repos/${{ github.repository }}/actions/runs/${{ github.run_id }} | jq -r .html_url)
+
+          description="${{ github.workflow }} / ${{ github.job }}"
+
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            repos/${{ github.repository }}/statuses/${sha} \
+            -f "state=${state}" -f "target_url=${html_url}" -f "description=${description}" -f "context=rcc"
+        shell: bash
+
+  rcc-smoke-check-matrix:
+    runs-on: ubuntu-24.04
+
+    name: "Check matrix"
+
+    needs:
+      - rcc-smoke
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.rcc-smoke.outputs.sha }}
+
+      - uses: ./.github/workflows/matrix-check
+        with:
+          matrix: ${{ needs.rcc-smoke.outputs.versions-matrix }}
+
+      - uses: ./.github/workflows/matrix-check
+        with:
+          matrix: ${{ needs.rcc-smoke.outputs.dep-suggests-matrix }}
+
   rcc-full:
+    needs:
+      - rcc-smoke
+
     runs-on: ${{ matrix.os }}
+
+    if: ${{ needs.rcc-smoke.outputs.versions-matrix != '' }}
 
     name: 'rcc: ${{ matrix.os }} (${{ matrix.r }}) ${{ matrix.desc }}'
 
     # Begin custom: services
     # End custom: services
 
-    # TEMPORARY: pinned to all Windows branches + R 4.2 on Linux
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - os: windows-latest
-            r: devel
-          - os: windows-latest
-            r: release
-          - os: windows-latest
-            r: oldrel-1
-          - os: ubuntu-24.04
-            r: "4.2"
+      matrix: ${{fromJson(needs.rcc-smoke.outputs.versions-matrix)}}
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.rcc-smoke.outputs.sha }}
 
       - uses: ./.github/workflows/custom/before-install
         if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
@@ -125,19 +353,21 @@ jobs:
 # The status update is taken care of by R-CMD-check-status.yaml
 
   rcc-suggests:
+    needs:
+      - rcc-smoke
+
     runs-on: ubuntu-24.04
+
+    if: ${{ needs.rcc-smoke.outputs.dep-suggests-matrix != '' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run-rcc-suggests)) }}
 
     name: Without ${{ matrix.package }}
 
     # Begin custom: services
     # End custom: services
 
-    # TEMPORARY: pinned to a single entry ("without quarto")
     strategy:
       fail-fast: false
-      matrix:
-        package:
-          - quarto
+      matrix: ${{fromJson(needs.rcc-smoke.outputs.dep-suggests-matrix)}}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,6 +4,12 @@
 # NOTE: This workflow is overkill for most R packages and
 # check-standard.yaml is likely a better choice.
 # usethis::use_github_action("check-standard") will install it.
+#
+# TEMPORARY: The smoke test job and dynamic matrix generation have been
+# removed. The rcc-full matrix is pinned to all Windows branches
+# (devel/release/oldrel-1) plus R 4.2 on Linux, and rcc-suggests is pinned to
+# a single entry ("without quarto"). Revert to restore the full matrix and
+# smoke test.
 on:
   push:
     branches:
@@ -51,264 +57,30 @@ concurrency:
 name: rcc
 
 jobs:
-  rcc-smoke:
-    runs-on: ubuntu-24.04
-
-    outputs:
-      sha: ${{ steps.commit.outputs.sha }}
-      versions-matrix: ${{ steps.versions-matrix.outputs.matrix }}
-      dep-suggests-matrix: ${{ steps.dep-suggests-matrix.outputs.matrix }}
-
-    name: "Smoke test: stock R"
-
-    permissions:
-      contents: write
-      statuses: write
-      pull-requests: write
-      actions: write
-
-    # Begin custom: services
-    # End custom: services
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.ref }}
-
-      - name: Update status for rcc
-        if: github.actor != 'Copilot' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        # FIXME: Wrap into action
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Actor: ${{ github.actor }}"
-
-          # Check status of this workflow
-          state="pending"
-          sha=${{ inputs.ref }}
-          if [ -z "${sha}" ]; then
-            sha=${{ github.sha }}
-          fi
-          sha=$(git rev-parse ${sha})
-
-          html_url=$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            repos/${{ github.repository }}/actions/runs/${{ github.run_id }} | jq -r .html_url)
-
-          description="${{ github.workflow }} / ${{ github.job }}"
-
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            repos/${{ github.repository }}/statuses/${sha} \
-            -f "state=${state}" -f "target_url=${html_url}" -f "description=${description}" -f "context=rcc"
-        shell: bash
-
-      - uses: ./.github/workflows/rate-limit
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: ./.github/workflows/git-identity
-
-      - uses: ./.github/workflows/custom/before-install
-        if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
-
-      - uses: ./.github/workflows/install
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          cache-version: rcc-smoke-2
-          needs: build, check, website
-          # Beware of using dev pkgdown here, has brought in dev dependencies in the past
-          extra-packages: any::rcmdcheck r-lib/roxygen2 any::decor r-lib/pkgdown deps::.
-
-      - uses: ./.github/workflows/custom/after-install
-        if: hashFiles('.github/workflows/custom/after-install/action.yml') != ''
-
-      # Must come after the custom after-install workflow
-      - name: Install package
-        run: |
-          _R_SHLIB_STRIP_=true R CMD INSTALL .
-        shell: bash
-
-      - id: versions-matrix
-        # Only run for:
-        # - pull requests if the base repo is different from the head repo
-        # - pull requests if the branch name starts with "cran-"
-        # Do not run for:
-        # - workflow_dispatch if not requested
-        # Always run for other events.
-        if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || startsWith(github.head_ref, 'cran-')) && (github.event_name != 'workflow_dispatch' || inputs.versions-matrix)
-        uses: ./.github/workflows/versions-matrix
-
-      - id: dep-suggests-matrix
-        # Not for workflow_dispatch if not requested, always run for other events
-        if: github.event_name != 'workflow_dispatch' || inputs.dep-suggests-matrix
-        uses: ./.github/workflows/dep-suggests-matrix
-
-      - id: repo-state
-        name: Determine repository state
-        uses: ./.github/workflows/repo-state
-
-      # Styling on foreign PRs works through the format-suggest workflow
-      - uses: ./.github/workflows/style
-        if: steps.repo-state.outputs.foreign != 'true' || steps.repo-state.outputs.is_pr != 'true'
-
-      # Snapshot tests can't work in a way similar to format-suggests
-      # because it requires running code which is a security risk on pull_request_target workflows
-      - uses: ./.github/workflows/update-snapshots
-        with:
-          base: ${{ inputs.ref || github.head_ref }}
-
-      - uses: ./.github/workflows/roxygenize
-
-      - name: Remove config files from previous iteration
-        run: |
-          rm -f .github/dep-suggests-matrix.json .github/versions-matrix.json
-        shell: bash
-
-      - id: commit
-        uses: ./.github/workflows/commit
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: ./.github/workflows/check
-        with:
-          results: ${{ runner.os }}-smoke-test
-
-      - uses: ./.github/workflows/pkgdown-build
-        if: github.event_name != 'push'
-
-      # Deliberately deploy only on push
-      # Deployment on schedule adds too much noise.
-      # Deployment on pull_request is not possible because it requires a token with write permissions, which is not available in pull_request workflows for security reasons.
-      # Deployment on workflow_dispatch is available via the pkgdown workflow
-      - uses: ./.github/workflows/pkgdown-deploy
-        if: github.event_name == 'push'
-
-      # Upload sha as artifact
-      - run: |
-          echo -n "${{ steps.commit.outputs.sha }}" > rcc-smoke-sha.txt
-        shell: bash
-
-      - uses: actions/upload-artifact@v5
-        with:
-          name: rcc-smoke-sha
-          path: rcc-smoke-sha.txt
-
-      - name: Update status for rcc
-        # FIXME: Wrap into action
-        if: always() && (github.actor != 'Copilot') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Check status of this workflow
-          if [ "${{ job.status }}" == "success" ]; then
-            state="success"
-          else
-            state="failure"
-          fi
-
-          sha=${{ steps.commit.outputs.sha }}
-          if [ -z "${sha}" ]; then
-            sha=${{ inputs.ref }}
-          fi
-          if [ -z "${sha}" ]; then
-            sha=${{ github.sha }}
-          fi
-            sha=$(git rev-parse ${sha})
-
-          html_url=$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            repos/${{ github.repository }}/actions/runs/${{ github.run_id }} | jq -r .html_url)
-
-          description="${{ github.workflow }} / ${{ github.job }}"
-
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            repos/${{ github.repository }}/statuses/${sha} \
-            -f "state=${state}" -f "target_url=${html_url}" -f "description=${description}" -f "context=rcc"
-        shell: bash
-
-      - name: Update status for rcc (Copilot)
-        # Update status directly when triggered by Copilot or bots, since they can't dispatch workflows
-        if: always() && (github.actor == 'Copilot')
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Set status to success if job succeeded, failure otherwise
-          if [ "${{ job.status }}" == "success" ]; then
-            state="success"
-          else
-            state="failure"
-          fi
-          sha=${{ inputs.ref }}
-          if [ -z "${sha}" ]; then
-            sha=${{ github.sha }}
-          fi
-          sha=$(git rev-parse ${sha})
-
-          html_url=$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            repos/${{ github.repository }}/actions/runs/${{ github.run_id }} | jq -r .html_url)
-
-          description="${{ github.workflow }} / ${{ github.job }}"
-
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            repos/${{ github.repository }}/statuses/${sha} \
-            -f "state=${state}" -f "target_url=${html_url}" -f "description=${description}" -f "context=rcc"
-        shell: bash
-
-  rcc-smoke-check-matrix:
-    runs-on: ubuntu-24.04
-
-    name: "Check matrix"
-
-    needs:
-      - rcc-smoke
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.rcc-smoke.outputs.sha }}
-
-      - uses: ./.github/workflows/matrix-check
-        with:
-          matrix: ${{ needs.rcc-smoke.outputs.versions-matrix }}
-
-      - uses: ./.github/workflows/matrix-check
-        with:
-          matrix: ${{ needs.rcc-smoke.outputs.dep-suggests-matrix }}
-
   rcc-full:
-    needs:
-      - rcc-smoke
-
     runs-on: ${{ matrix.os }}
-
-    if: ${{ needs.rcc-smoke.outputs.versions-matrix != '' }}
 
     name: 'rcc: ${{ matrix.os }} (${{ matrix.r }}) ${{ matrix.desc }}'
 
     # Begin custom: services
     # End custom: services
 
+    # TEMPORARY: pinned to all Windows branches + R 4.2 on Linux
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.rcc-smoke.outputs.versions-matrix)}}
+      matrix:
+        include:
+          - os: windows-latest
+            r: devel
+          - os: windows-latest
+            r: release
+          - os: windows-latest
+            r: oldrel-1
+          - os: ubuntu-24.04
+            r: "4.2"
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.rcc-smoke.outputs.sha }}
 
       - uses: ./.github/workflows/custom/before-install
         if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
@@ -353,21 +125,19 @@ jobs:
 # The status update is taken care of by R-CMD-check-status.yaml
 
   rcc-suggests:
-    needs:
-      - rcc-smoke
-
     runs-on: ubuntu-24.04
-
-    if: ${{ needs.rcc-smoke.outputs.dep-suggests-matrix != '' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run-rcc-suggests)) }}
 
     name: Without ${{ matrix.package }}
 
     # Begin custom: services
     # End custom: services
 
+    # TEMPORARY: pinned to a single entry ("without quarto")
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.rcc-smoke.outputs.dep-suggests-matrix)}}
+      matrix:
+        package:
+          - quarto
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/check/action.yml
+++ b/.github/workflows/check/action.yml
@@ -7,12 +7,37 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # Quarto renders package vignettes from the *installed* package rather than
-    # R CMD build's temporary library, so `library(<pkg>)` fails during the
-    # build's vignette re-render unless the package is installed first - most
-    # visibly on Windows. Install it up front, mirroring quarto-dev/quarto-r,
-    # which adds `local::.` "as we register vignette engine".
-    - name: Install the package so quarto resolves it when re-building vignettes
+    # On Windows, Quarto re-builds vignettes in a separate R process spawned by
+    # the Quarto CLI. That process only sees env-conveyed libraries
+    # (R_LIBS_USER), not R CMD build's temporary install library, so
+    # `library(<pkg>)` fails with "there is no package called '<pkg>'" while
+    # building Quarto vignettes - unless the package is already installed in the
+    # regular library. Install it up front to work around this. We mirror
+    # quarto-dev/quarto-r, which adds `local::.` to its check dependencies "as we
+    # register vignette engine". Restricted to Windows + a Quarto vignette
+    # builder, since that is the only place the failure occurs.
+    # Refs:
+    # - https://github.com/r-lib/pkgdown/issues/2830
+    # - https://github.com/quarto-dev/quarto-cli/discussions/2307
+    # - https://github.com/quarto-dev/quarto-r/blob/main/.github/workflows/R-CMD-check.yaml
+    - name: Detect a Quarto vignette builder
+      id: quarto-vignette
+      if: runner.os == 'Windows'
+      run: |
+        builders <- strsplit(
+          desc::desc_get_field("VignetteBuilder", default = ""),
+          "[[:space:]]*,[[:space:]]*"
+        )[[1]]
+        uses_quarto <- if ("quarto" %in% builders) "true" else "false"
+        cat(
+          sprintf("uses-quarto=%s\n", uses_quarto),
+          file = Sys.getenv("GITHUB_OUTPUT"),
+          append = TRUE
+        )
+      shell: Rscript {0}
+
+    - name: Install the package so Quarto resolves it when re-building vignettes
+      if: runner.os == 'Windows' && steps.quarto-vignette.outputs.uses-quarto == 'true'
       run: _R_SHLIB_STRIP_=true R CMD INSTALL .
       shell: bash
 

--- a/.github/workflows/check/action.yml
+++ b/.github/workflows/check/action.yml
@@ -7,6 +7,15 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Quarto renders package vignettes from the *installed* package rather than
+    # R CMD build's temporary library, so `library(<pkg>)` fails during the
+    # build's vignette re-render unless the package is installed first - most
+    # visibly on Windows. Install it up front, mirroring quarto-dev/quarto-r,
+    # which adds `local::.` "as we register vignette engine".
+    - name: Install the package so quarto resolves it when re-building vignettes
+      run: _R_SHLIB_STRIP_=true R CMD INSTALL .
+      shell: bash
+
     - uses: r-lib/actions/check-r-package@v2
       with:
         # Fails on R 3.6 on Windows, remove when this job is removed?

--- a/.github/workflows/dep-suggests-matrix/action.R
+++ b/.github/workflows/dep-suggests-matrix/action.R
@@ -6,16 +6,40 @@ get_deps <- function() {
   }
 
   deps_df <- desc::desc_get_deps()
-  deps_df_optional <- deps_df$package[deps_df$type %in% c("Suggests", "Enhances")]
-  deps_df_hard <- deps_df$package[deps_df$type %in% c("Depends", "Imports", "LinkingTo")]
+  deps_df_optional <- deps_df$package[
+    deps_df$type %in% c("Suggests", "Enhances")
+  ]
+  deps_df_hard <- deps_df$package[
+    deps_df$type %in% c("Depends", "Imports", "LinkingTo")
+  ]
   deps_df_base <- unlist(tools::standard_package_names(), use.names = FALSE)
+
+  # Vignette builders can't be excluded: `R CMD build` (run by R CMD check)
+  # re-builds the vignettes, which fails outright when the declared
+  # VignetteBuilder package (e.g. quarto) is missing. Treat them as off-limits.
+  vignette_builders <- strsplit(
+    desc::desc_get_field("VignetteBuilder", default = ""),
+    "[[:space:]]*,[[:space:]]*"
+  )[[1]]
+  vignette_builders <- vignette_builders[nzchar(vignette_builders)]
 
   packages <- sort(deps_df_optional)
   packages <- intersect(packages, rownames(available.packages()))
 
   # Too big to fail, or can't be avoided:
-  off_limits <- c("testthat", "rmarkdown", "rcmdcheck", deps_df_hard, deps_df_base)
-  off_limits_dep <- unlist(tools::package_dependencies(off_limits, recursive = TRUE, which = "strong"))
+  off_limits <- c(
+    "testthat",
+    "rmarkdown",
+    "rcmdcheck",
+    vignette_builders,
+    deps_df_hard,
+    deps_df_base
+  )
+  off_limits_dep <- unlist(tools::package_dependencies(
+    off_limits,
+    recursive = TRUE,
+    which = "strong"
+  ))
   setdiff(packages, c(off_limits, off_limits_dep))
 }
 
@@ -31,7 +55,9 @@ if (Sys.getenv("GITHUB_BASE_REF") != "") {
     writeLines(diff_lines)
     packages <- get_deps()
   } else {
-    writeLines("No changes using :: found in R/ or tests/, not checking without suggested packages")
+    writeLines(
+      "No changes using :: found in R/ or tests/, not checking without suggested packages"
+    )
     packages <- character()
   }
 } else {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ License: Apache License (== 2.0) | file LICENSE
 URL: https://poissonconsulting.github.io/ssdsims/
 BugReports: https://github.com/poissonconsulting/ssdsims/issues
 Depends: 
-    R (>= 4.1)
+    R (>= 4.3)
 Imports: 
     chk,
     dplyr,


### PR DESCRIPTION
## What this fixes

`R CMD check` was failing on Windows and on R 4.2. The net change is three fixes; the temporary `rcc`-matrix pin used to surface them was reverted, so the diff is just:

| File | Fix |
|---|---|
| `DESCRIPTION` | **Require R >= 4.3.** On R 4.2 duckplyr/duckdb can't materialize the `VARCHAR[]` `dists` list-column when writing the hc-step Parquet (`as_duckdb_tibble()`: *no type for altrep: VARCHAR[]*), which broke the `sharded-pipeline` vignette. R ≥ 4.3 (duckplyr 1.2.1 / duckdb 1.5.2) handles it. This is a deliberate, user-facing minimum-version bump. |
| `.github/workflows/dep-suggests-matrix/action.R` | **Never exclude the `VignetteBuilder`.** The "drop each Suggests package, then check" matrix would drop quarto, which breaks `R CMD build` outright. Vignette builders are now treated as off-limits (detected with `desc`). |
| `.github/workflows/check/action.yml` | **Install the package before check — Windows + Quarto only.** Quarto rebuilds vignettes in an R subprocess spawned by the Quarto CLI that sees `R_LIBS_USER` but not `R CMD build`'s temp library, so `library(ssdsims)` failed on Windows (*there is no package called 'ssdsims'*). Gated via `runner.os == 'Windows'` + a `desc`-detected `quarto` `VignetteBuilder`; mirrors [`quarto-dev/quarto-r`](https://github.com/quarto-dev/quarto-r) (`local::.`). |

## Verification

- Same-repo PRs run the **smoke test only** (Ubuntu, stock R) — **green** here (vignettes build, check passes, pkgdown builds). The full OS/R `rcc-full` matrix and `rcc-suggests` run on push to `main`, on schedule, and on foreign/`cran-*` PRs.
- The Windows fix was verified directly on the temporary pinned matrix: `windows-latest` *release* and *oldrel-1* passed the full check including the Quarto vignette build.
- Non-Windows jobs are intentionally **not** pre-installed — on Unix `R CMD build`'s `R_LIBS` reaches Quarto's R subprocess, so the package resolves without it.

## Refs
- https://github.com/r-lib/pkgdown/issues/2830
- https://github.com/quarto-dev/quarto-cli/discussions/2307
- https://github.com/quarto-dev/quarto-r/blob/main/.github/workflows/R-CMD-check.yaml

https://claude.ai/code/session_01AjDVGfUYVvWF4bgeyusMjD