### PR TITLE
test: use minimal nboot in bootstrap-executing tests

### DIFF
--- a/tests/testthat/_snaps/hc-sims/hc_sims1ci.csv
+++ b/tests/testthat/_snaps/hc-sims/hc_sims1ci.csv
@@ -1,2 +1,2 @@
 sim,stream,nrow,args,data,rescale,computable,at_boundary_ok,min_pmix,range_shape1,range_shape2,fits,nboot,est_method,ci_method,parametric,dist,proportion,est,se,lcl,ucl,wt,level,boot_method,pboot,dists,samples
-1,1,6,list,list,FALSE,FALSE,TRUE,list,list,list,list,1000,multi,weighted_samples,TRUE,average,0.05,0.514363,0.400775,0.132964,1.70397,1,0.95,parametric,1,list,list
+1,1,6,list,list,FALSE,FALSE,TRUE,list,list,list,list,2,multi,weighted_samples,TRUE,average,0.05,0.514363,0.0266076,0.453017,0.488764,1,0.95,parametric,1,list,list

--- a/tests/testthat/test-hc-sims.R
+++ b/tests/testthat/test-hc-sims.R
@@ -12,7 +12,7 @@ test_that("hc_sims 1 sim ci", {
   withr::with_seed(42, {
     sims <- ssd_sim_data("rlnorm", seed = 10, nsim = 1L)
     sims <- ssd_fit_dists_sims(sims, seed = 10)
-    sims <- ssd_hc_sims(sims, ci = TRUE)
+    sims <- ssd_hc_sims(sims, ci = TRUE, nboot = 2L)
   })
   sims <- tidyr::unnest(sims, cols = c(hc))
   expect_snapshot_data(sims, "hc_sims1ci")

--- a/tests/testthat/test-run-scenario.R
+++ b/tests/testthat/test-run-scenario.R
@@ -51,7 +51,7 @@ test_that("ssd_run_scenario.data.frame errors min_pboot", {
       nrow = 5,
       nsim = 1,
       ci = TRUE,
-      nboot = 3,
+      nboot = 2L,
       min_pboot = 0
     ),
     "`min_pboot` is fixed at 0 in ssdsims and cannot be set by the user\\."

--- a/tests/testthat/test-task-lists.R
+++ b/tests/testthat/test-task-lists.R
@@ -387,7 +387,7 @@ test_that("parallel-safe-seeding: fit/hc wrappers reproduce under a fixed (seed,
     fit1,
     proportion = 0.05,
     ci = TRUE,
-    nboot = 10L,
+    nboot = 2L,
     est_method = "multi",
     ci_method = "weighted_samples",
     parametric = TRUE,
@@ -398,7 +398,7 @@ test_that("parallel-safe-seeding: fit/hc wrappers reproduce under a fixed (seed,
     fit1,
     proportion = 0.05,
     ci = TRUE,
-    nboot = 10L,
+    nboot = 2L,
     est_method = "multi",
     ci_method = "weighted_samples",
     parametric = TRUE,
@@ -456,7 +456,7 @@ test_that("scenario-definition: samples = TRUE retains hc draws but keeps estima
     seed = 42L,
     dists = "lnorm",
     ci = c(FALSE, TRUE),
-    nboot = 10L
+    nboot = 2L
   )
   out_no <- ssd_run_scenario_baseline(do.call(ssd_define_scenario, args))
   out_yes <- ssd_run_scenario_baseline(
@@ -482,7 +482,7 @@ test_that("scenario-definition: samples = TRUE works with multiple dists and ci 
     seed = 42L,
     dists = c("lnorm", "gamma"),
     ci = c(FALSE, TRUE),
-    nboot = 10L,
+    nboot = 2L,
     samples = TRUE
   )
   expect_no_error(out <- ssd_run_scenario_baseline(scenario))


### PR DESCRIPTION
## What

Speeds up the test suite by using a minimal bootstrap count (`nboot = 2L`) in the tests that actually **execute** a bootstrap.

## Why

Profiling the suite showed one test dominated it:

| Test | Before |
|------|--------|
| `hc_sims 1 sim ci` (`test-hc-sims.R`) | **6.46s — ~27% of the whole suite** |

It ran the production default `nboot = 1000` (1000 parametric bootstrap fits) purely to snapshot the CI code path. A snapshot test verifies structure/values of the code path, not statistical convergence, so it doesn't need 1000 reps. `nboot` was confirmed to be the sole driver (1000 → ~6s, 10 → ~1.1s).

## Changes

Set `nboot = 2L` (the minimal value that still yields a non-degenerate interval — `nboot = 1` collapses `lcl == ucl`) in every test that executes a bootstrap:

- `test-hc-sims.R` — `ssd_hc_sims(ci = TRUE)` (was the default `1000`)
- `test-task-lists.R` — `hc_data_task_primer` reproducibility check and the two `ci = c(FALSE, TRUE)` baseline runs (were `10L`)
- `test-run-scenario.R` — the `min_pboot` error test (was `3`; never actually executes a bootstrap, aligned for consistency)

Inert `nboot` metadata in scenario / task-table **definition** tests is intentionally left untouched — there the value is asserted as plumbing (e.g. retention of `c(100, 1000)`), carries no runtime cost, and reducing it would only churn snapshots and weaken intent. The only snapshot that changes is `hc_sims1ci.csv`.

## Result

Local `testthat` suite (192 tests, 0 failures):

| | Total test time | `test-hc-sims.R` |
|--|--|--|
| Before | ~24.3s | 6.67s |
| After | ~16.5s | 0.74s |

≈ **32% faster**, compounding under `covr` (which re-runs the instrumented suite).

https://claude.ai/code/session_017ZtCSaGyqYhjDn2m8Hvnba

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZtCSaGyqYhjDn2m8Hvnba)_