### PR TITLE
refactor: make `ci` a scalar flag, not a grid axis

### DIFF
--- a/R/hc-sims.R
+++ b/R/hc-sims.R
@@ -26,6 +26,10 @@ ssd_hc_sims <- function(
   chk::check_names(x, "fits")
   chk::chk_null_or(save_to, vld = chk::vld_dir)
 
+  # `ci` is a scalar flag (applied uniformly, not part of the factorial
+  # expansion below), so a vector `ci` is rejected here too.
+  chk::chk_flag(ci)
+
   chk::chk_whole_numeric(nboot)
   chk::chk_not_any_na(nboot)
   chk::chk_gt(nboot)

--- a/R/params.R
+++ b/R/params.R
@@ -8,7 +8,10 @@
 #' A string is a non-missing character scalar.
 #'
 #' @param args A named list of the argument values.
-#' @param ci A flag specifying whether to estimate confidence intervals (by bootstrapping).
+#' @param ci A scalar flag specifying whether to estimate confidence intervals
+#' (by bootstrapping). It is not a cross-join axis; the point estimate is
+#' identical whether `TRUE` or `FALSE`, so `ci = TRUE` is a superset of
+#' `ci = FALSE`.
 #' @param ci_method A character vector specifying the method to use for estimating the confidence limits.
 #' `ssdtools::ssd_ci_methods()` returns the possible values.
 #' @param dist_sim A character vector specifying the distributions in the fitdists object or `"all"``

--- a/R/scenario.R
+++ b/R/scenario.R
@@ -32,12 +32,17 @@
 #'
 #' Supplying both a named list and `name=` is an error.
 #'
-#' # `ci = FALSE`
+#' # `ci`
 #'
-#' When `ci = FALSE` is the only confidence-interval value, the bootstrap-only
-#' knobs `nboot`, `ci_method`, and `parametric` are meaningless. Passing any of
-#' them in that case is an error; set `ci = c(FALSE, TRUE)` to enable bootstrap,
-#' or omit the knobs.
+#' `ci` is a scalar flag (not a cross-join axis): the point estimate `est` is
+#' invariant to `ci` - it is computed analytically from the fit, independent of
+#' the bootstrap and RNG - so a single `ci = TRUE` run is a strict superset of
+#' `ci = FALSE` (same `est`, plus the `se`/`lcl`/`ucl` columns). The choice is
+#' scenario-wide either/or: `ci = FALSE` for cheap, bootstrap-free point
+#' estimates, or `ci = TRUE` for estimates plus confidence intervals. When
+#' `ci = FALSE`, the bootstrap-only knobs `nboot`, `ci_method`, and `parametric`
+#' are meaningless; passing any of them in that case is an error, so set
+#' `ci = TRUE` to enable bootstrap, or omit the knobs.
 #'
 #' @inheritParams ssdtools::ssd_fit_dists
 #' @inheritParams ssdtools::ssd_hc
@@ -78,8 +83,9 @@
 #'   columns). Each entry must be unique, non-missing, and a subset of that
 #'   step's axis vocabulary: `sample` = `dataset`, `sim`, `replace`; `fit` adds
 #'   `nrow`, `rescale`, `computable`, `at_boundary_ok`, `min_pmix`,
-#'   `range_shape1`, `range_shape2`; `hc` adds `ci`, `nboot`, `est_method`,
-#'   `ci_method`, `parametric`. `"nrow"` is rejected only for `sample` (the
+#'   `range_shape1`, `range_shape2`; `hc` adds `nboot`, `est_method`,
+#'   `ci_method`, `parametric` (`ci` is a scalar hc flag, not an axis).
+#'   `"nrow"` is rejected only for `sample` (the
 #'   shared draw carries no `nrow` axis; the `fit` step truncates it inline), and
 #'   is a valid path axis for `fit`/`hc`. Steps partition **independently** -
 #'   there is no cross-step constraint; a step may be finer or coarser than its
@@ -120,12 +126,12 @@ ssd_define_scenario <- function(
   min_pmix = list(ssdtools::ssd_min_pmix),
   range_shape1 = list(c(0.05, 20)),
   range_shape2 = list(c(0.05, 20)),
-  proportion = 0.05,
-  ci = FALSE,
   nboot = 1000,
   est_method = "multi",
   ci_method = "weighted_samples",
   parametric = TRUE,
+  proportion = 0.05,
+  ci = FALSE,
   samples = FALSE,
   partition_by = NULL,
   bundle = NULL,
@@ -211,10 +217,10 @@ ssd_define_scenario <- function(
   chk::chk_range(proportion, c(0, 1))
   chk::chk_unique(proportion)
 
-  chk::chk_logical(ci)
-  chk::chk_not_any_na(ci)
-  chk::chk_unique(ci)
-  chk::chk_length(ci, upper = 2L)
+  # `ci` is a scalar flag (not a grid/task axis): the point estimate is
+  # invariant to `ci`, so `ci = TRUE` is a superset of `ci = FALSE` and the
+  # choice is scenario-wide either/or.
+  chk::chk_flag(ci)
 
   chk::chk_whole_numeric(nboot)
   chk::chk_not_any_na(nboot)
@@ -243,7 +249,7 @@ ssd_define_scenario <- function(
   chk::chk_flag(samples)
 
   # --- ci = FALSE rejects bootstrap-only knobs ---------------------------
-  if (length(ci) == 1L && isFALSE(ci)) {
+  if (isFALSE(ci)) {
     passed <- c(
       if (!missing(nboot)) "nboot",
       if (!missing(ci_method)) "ci_method",
@@ -256,7 +262,7 @@ ssd_define_scenario <- function(
         " (",
         chk::cc(passed, conj = " and "),
         ") cannot be set when `ci = FALSE`. ",
-        "Set `ci = c(FALSE, TRUE)` to enable bootstrap, or omit the knob",
+        "Set `ci = TRUE` to enable bootstrap, or omit the knob",
         if (length(passed) > 1L) "s" else "",
         ".",
         call = call
@@ -296,12 +302,12 @@ ssd_define_scenario <- function(
       ),
       min_pmix_fns = min_pmix_spec$fns,
       hc = list(
-        proportion = proportion,
-        ci = ci,
         nboot = nboot,
         est_method = est_method,
         ci_method = ci_method,
         parametric = parametric,
+        proportion = proportion,
+        ci = ci,
         samples = samples
       ),
       partition_by = partition_by,

--- a/R/targets-runner.R
+++ b/R/targets-runner.R
@@ -307,8 +307,9 @@ ssd_run_fit_step <- function(tasks, scenario, sample_dir, out_dir) {
 #' spans several fit shards), isolates each task's fit by `fit_id`,
 #' deserialises the `fitdists` object, and estimates the hazard concentration
 #' with the per-task `(seed, primer)` through `hc_data_task_primer()`. Each
-#' task's hc tibble (one or more rows - the `proportion` fan-out and the
-#' `ci = FALSE` collapse, section 1.2) is tagged with its `hc_id` and parent
+#' task's hc tibble (one or more rows - the `proportion` fan-out, with the
+#' scalar `ci` applied uniformly and bootstrap-only knobs `NA` when
+#' `ci = FALSE`) is tagged with its `hc_id` and parent
 #' `fit_id`, stacked, and written as one Parquet at the shard's partition path.
 #'
 #' @inheritParams ssd_run_sample_step

--- a/R/task-lists.R
+++ b/R/task-lists.R
@@ -79,25 +79,27 @@ ssd_scenario_fit_tasks <- function(scenario) {
 #' Derive the hc Task Table from a Scenario
 #'
 #' Crosses each fit-task identity with each row of the scenario's `hc` argument
-#' grid (`nboot`, `est_method`, `ci_method`, `parametric`). The expansion honours
-#' the construction-time `ci = FALSE` collapse (`TARGETS-DESIGN.md` section 1.2): rows
-#' where `ci = FALSE` are not multiplied across the bootstrap-only knobs
-#' (`nboot`, `ci_method`, `parametric`), which are stored as `NA`, while
-#' `ci = TRUE` rows fan out across the full grid.
+#' grid (`nboot`, `est_method`, `ci_method`, `parametric`). The scenario's
+#' scalar `ci` flag is applied uniformly to every hc row - it is not a cross-join
+#' axis (it is absent from `task_axes("hc")`) and rides as a carried column. When
+#' `ci = FALSE`, the bootstrap-only knobs (`nboot`, `ci_method`, `parametric`)
+#' are canonically `NA`, leaving `est_method` as the only fan-out axis; when
+#' `ci = TRUE`, the grid fans out across `nboot x est_method x ci_method x
+#' parametric`.
 #'
 #' Each row carries an `hc_id` primary key and a `fit_id` foreign key
 #' referencing its parent fit task.
 #'
 #' @inheritParams ssd_scenario_sample_tasks
 #' @return An `ssdsims_tasks` object recording the `"hc"` step, with one row per
-#'   fit-task identity crossed with the (collapsed) hc grid.
+#'   fit-task identity crossed with the hc grid.
 #' @export
 #' @examples
 #' scenario <- ssd_define_scenario(
 #'   ssddata::ccme_boron,
 #'   nsim = 2L,
 #'   seed = 42L,
-#'   ci = c(FALSE, TRUE),
+#'   ci = TRUE,
 #'   nboot = c(10L, 100L)
 #' )
 #' ssd_scenario_hc_tasks(scenario)
@@ -257,6 +259,8 @@ ssd_run_scenario_baseline <- function(scenario) {
   fit_out <- rlang::set_names(fit_tbl$fits, fit_tbl$fit_id)
 
   # --- hc step: seed then estimate hc for each fit against its hc-grid row ---
+  # `ci` is a carried column (single-valued, not an hc axis), read here just
+  # like the `n_max` carried column on `sample` tasks.
   hc_tbl <- tasks$hc
   hc_args <- hc_tbl[c("ci", "nboot", "est_method", "ci_method", "parametric")]
   hc_args$fits <- fit_out[hc_tbl$fit_id]
@@ -326,21 +330,22 @@ fit_task_table <- function(scenario) {
 
 hc_grid_tbl <- function(scenario) {
   hc <- scenario$hc
-  ci <- hc$ci
-  parts <- list()
-  if (any(ci == FALSE)) {
-    # Bootstrap-only knobs collapse to NA when ci = FALSE (TARGETS-DESIGN.md
-    # section 1.2); est_method stays an axis as it affects the point estimate too.
-    parts$false <- tidyr::expand_grid(
+  # Single grid keyed by the scalar `ci` flag (no `c(FALSE, TRUE)` collapse).
+  # `ci` is emitted as a (single-valued) carried column the runners read, but
+  # it is not an hc axis, so it never enters the per-task primer.
+  if (isFALSE(hc$ci)) {
+    # Bootstrap-only knobs are canonically NA when ci = FALSE so they cannot
+    # enter task identity; est_method stays a fan-out axis as it affects the
+    # point estimate.
+    tidyr::expand_grid(
       ci = FALSE,
       nboot = NA_integer_,
       est_method = hc$est_method,
       ci_method = NA_character_,
       parametric = NA
     )
-  }
-  if (any(ci == TRUE)) {
-    parts$true <- tidyr::expand_grid(
+  } else {
+    tidyr::expand_grid(
       ci = TRUE,
       nboot = as.integer(hc$nboot),
       est_method = hc$est_method,
@@ -348,7 +353,6 @@ hc_grid_tbl <- function(scenario) {
       parametric = hc$parametric
     )
   }
-  dplyr::bind_rows(parts)
 }
 
 # ---- task identity (cross-join axes, ids, foreign keys) --------------------
@@ -368,7 +372,11 @@ task_axes <- function(step) {
     "range_shape1",
     "range_shape2"
   )
-  hc <- c(fit, "ci", "nboot", "est_method", "ci_method", "parametric")
+  # `ci` is a scalar hc flag, not an axis: the point estimate is invariant to
+  # `ci`, so it carries no task-distinguishing information and is excluded from
+  # the hc vocabulary (and thus the primer/partition split). It rides as a
+  # carried column on the hc task table, like `n_max` on `sample` tasks.
+  hc <- c(fit, "nboot", "est_method", "ci_method", "parametric")
   switch(step, sample = sample, fit = fit, hc = hc)
 }
 

--- a/R/task-primer.R
+++ b/R/task-primer.R
@@ -88,8 +88,10 @@ normalize_task_row <- function(row) {
 #'   (`rescale`, `computable`, `at_boundary_ok`, `min_pmix` name,
 #'   `range_shape1`, `range_shape2`). `nrow` IS part of the fit primer: a fit on
 #'   a different truncation is a genuinely different computation.
-#' * **hc** -- the parent `fit` identity plus the hc-grid row (`ci`, `nboot`,
-#'   `est_method`, `ci_method`, `parametric`).
+#' * **hc** -- the parent `fit` identity plus the hc-grid row (`nboot`,
+#'   `est_method`, `ci_method`, `parametric`). `ci` is a scalar hc flag applied
+#'   uniformly, not part of the task identity, so it is a carried column rather
+#'   than a primer field.
 #'
 #' Function-valued parameters (e.g. `min_pmix`) MUST be referenced **by name**,
 #' not by function value, so a recompile or JIT does not move a task's primer.

--- a/R/task-shards.R
+++ b/R/task-shards.R
@@ -79,7 +79,7 @@ ssd_scenario_fit_shards <- function(scenario) {
 #'   ssddata::ccme_boron,
 #'   nsim = 2L,
 #'   seed = 42L,
-#'   ci = c(FALSE, TRUE)
+#'   ci = TRUE
 #' )
 #' ssd_scenario_hc_shards(scenario)
 ssd_scenario_hc_shards <- function(scenario) {

--- a/inst/targets-templates/large/scenario.R
+++ b/inst/targets-templates/large/scenario.R
@@ -1,6 +1,7 @@
 # The scenario for the large (fuller) targets example, adapted from `scripts/example.R`:
 # a wider study sweeping sample sizes, hazard proportions, estimation and CI
-# methods, and CI on/off. Shared by `_targets.R` (the targets pipeline) and
+# methods, with bootstrap CIs on (`ci` is a scalar flag). Shared by `_targets.R`
+# (the targets pipeline) and
 # `run-serial.R` (the single-core shard runner) so both run the same study and
 # their results can be compared. Edit to taste.
 library(ssdsims)
@@ -11,7 +12,7 @@ scenario <- ssd_define_scenario(
   nrow = c(5L, 10L), # c(5L, 6L, 10L, 20L, 50L),
   proportion = c(0.01, 0.05, 0.1, 0.2),
   est_method = c("arithmetic", "geometric", "multi"),
-  ci = c(FALSE, TRUE),
+  ci = TRUE,
   ci_method = c(
     "arithmetic_samples",
     "geometric_samples",

--- a/man/params.Rd
+++ b/man/params.Rd
@@ -11,7 +11,10 @@
 
 \item{args}{A named list of the argument values.}
 
-\item{ci}{A flag specifying whether to estimate confidence intervals (by bootstrapping).}
+\item{ci}{A scalar flag specifying whether to estimate confidence intervals
+(by bootstrapping). It is not a cross-join axis; the point estimate is
+identical whether \code{TRUE} or \code{FALSE}, so \code{ci = TRUE} is a superset of
+\code{ci = FALSE}.}
 
 \item{ci_method}{A character vector specifying the method to use for estimating the confidence limits.
 \code{ssdtools::ssd_ci_methods()} returns the possible values.}

--- a/man/ssd_define_scenario.Rd
+++ b/man/ssd_define_scenario.Rd
@@ -19,12 +19,12 @@ ssd_define_scenario(
   min_pmix = list(ssdtools::ssd_min_pmix),
   range_shape1 = list(c(0.05, 20)),
   range_shape2 = list(c(0.05, 20)),
-  proportion = 0.05,
-  ci = FALSE,
   nboot = 1000,
   est_method = "multi",
   ci_method = "weighted_samples",
   parametric = TRUE,
+  proportion = 0.05,
+  ci = FALSE,
   samples = FALSE,
   partition_by = NULL,
   bundle = NULL,
@@ -78,10 +78,6 @@ upper bounds for the shape1 parameter.}
 \item{range_shape2}{A list of numeric vectors of length two of the lower and
 upper bounds for the shape2 parameter.}
 
-\item{proportion}{A numeric vector of proportion values to estimate hazard concentrations for.}
-
-\item{ci}{A flag specifying whether to estimate confidence intervals (by bootstrapping).}
-
 \item{nboot}{A count of the number of bootstrap samples to use to estimate the confidence limits. A value of 10,000 is recommended for official guidelines.}
 
 \item{est_method}{A string specifying whether to estimate directly from
@@ -112,6 +108,10 @@ calculate the confidence limits (and SE) from the single set of samples.}
 
 \item{parametric}{A flag specifying whether to perform parametric bootstrapping as opposed to non-parametrically resampling the original data with replacement.}
 
+\item{proportion}{A numeric vector of proportion values to estimate hazard concentrations for.}
+
+\item{ci}{A flag specifying whether to estimate confidence intervals (by bootstrapping).}
+
 \item{samples}{A logical scalar (default \code{FALSE}): retain the bootstrap draws
 in the hc result's \code{samples} list-column (passed to \code{\link[ssdtools:ssd_hc]{ssdtools::ssd_hc()}}).
 This is \strong{output retention only} - it does not change the estimates or the
@@ -126,8 +126,9 @@ that step (one shard per path cell; the inner complement rides as Parquet
 columns). Each entry must be unique, non-missing, and a subset of that
 step's axis vocabulary: \code{sample} = \code{dataset}, \code{sim}, \code{replace}; \code{fit} adds
 \code{nrow}, \code{rescale}, \code{computable}, \code{at_boundary_ok}, \code{min_pmix},
-\code{range_shape1}, \code{range_shape2}; \code{hc} adds \code{ci}, \code{nboot}, \code{est_method},
-\code{ci_method}, \code{parametric}. \code{"nrow"} is rejected only for \code{sample} (the
+\code{range_shape1}, \code{range_shape2}; \code{hc} adds \code{nboot}, \code{est_method},
+\code{ci_method}, \code{parametric} (\code{ci} is a scalar hc flag, not an axis).
+\code{"nrow"} is rejected only for \code{sample} (the
 shared draw carries no \code{nrow} axis; the \code{fit} step truncates it inline), and
 is a valid path axis for \code{fit}/\code{hc}. Steps partition \strong{independently} -
 there is no cross-step constraint; a step may be finer or coarser than its
@@ -186,11 +187,16 @@ accepted in four forms (routed through the same \code{Conc} validation):
 Supplying both a named list and \verb{name=} is an error.
 }
 
-\section{\code{ci = FALSE}}{
-When \code{ci = FALSE} is the only confidence-interval value, the bootstrap-only
-knobs \code{nboot}, \code{ci_method}, and \code{parametric} are meaningless. Passing any of
-them in that case is an error; set \code{ci = c(FALSE, TRUE)} to enable bootstrap,
-or omit the knobs.
+\section{\code{ci}}{
+\code{ci} is a scalar flag (not a cross-join axis): the point estimate \code{est} is
+invariant to \code{ci} - it is computed analytically from the fit, independent of
+the bootstrap and RNG - so a single \code{ci = TRUE} run is a strict superset of
+\code{ci = FALSE} (same \code{est}, plus the \code{se}/\code{lcl}/\code{ucl} columns). The choice is
+scenario-wide either/or: \code{ci = FALSE} for cheap, bootstrap-free point
+estimates, or \code{ci = TRUE} for estimates plus confidence intervals. When
+\code{ci = FALSE}, the bootstrap-only knobs \code{nboot}, \code{ci_method}, and \code{parametric}
+are meaningless; passing any of them in that case is an error, so set
+\code{ci = TRUE} to enable bootstrap, or omit the knobs.
 }
 
 \examples{

--- a/man/ssd_run_hc_step.Rd
+++ b/man/ssd_run_hc_step.Rd
@@ -26,8 +26,9 @@ Runs the \code{hc} tasks bundled into one shard: reads the distinct set of paren
 spans several fit shards), isolates each task's fit by \code{fit_id},
 deserialises the \code{fitdists} object, and estimates the hazard concentration
 with the per-task \verb{(seed, primer)} through \code{hc_data_task_primer()}. Each
-task's hc tibble (one or more rows - the \code{proportion} fan-out and the
-\code{ci = FALSE} collapse, section 1.2) is tagged with its \code{hc_id} and parent
+task's hc tibble (one or more rows - the \code{proportion} fan-out, with the
+scalar \code{ci} applied uniformly and bootstrap-only knobs \code{NA} when
+\code{ci = FALSE}) is tagged with its \code{hc_id} and parent
 \code{fit_id}, stacked, and written as one Parquet at the shard's partition path.
 }
 \examples{

--- a/man/ssd_scenario_hc_shards.Rd
+++ b/man/ssd_scenario_hc_shards.Rd
@@ -24,7 +24,7 @@ scenario <- ssd_define_scenario(
   ssddata::ccme_boron,
   nsim = 2L,
   seed = 42L,
-  ci = c(FALSE, TRUE)
+  ci = TRUE
 )
 ssd_scenario_hc_shards(scenario)
 }

--- a/man/ssd_scenario_hc_tasks.Rd
+++ b/man/ssd_scenario_hc_tasks.Rd
@@ -11,15 +11,16 @@ ssd_scenario_hc_tasks(scenario)
 }
 \value{
 An \code{ssdsims_tasks} object recording the \code{"hc"} step, with one row per
-fit-task identity crossed with the (collapsed) hc grid.
+fit-task identity crossed with the hc grid.
 }
 \description{
 Crosses each fit-task identity with each row of the scenario's \code{hc} argument
-grid (\code{nboot}, \code{est_method}, \code{ci_method}, \code{parametric}). The expansion honours
-the construction-time \code{ci = FALSE} collapse (\code{TARGETS-DESIGN.md} section 1.2): rows
-where \code{ci = FALSE} are not multiplied across the bootstrap-only knobs
-(\code{nboot}, \code{ci_method}, \code{parametric}), which are stored as \code{NA}, while
-\code{ci = TRUE} rows fan out across the full grid.
+grid (\code{nboot}, \code{est_method}, \code{ci_method}, \code{parametric}). The scenario's
+scalar \code{ci} flag is applied uniformly to every hc row - it is not a cross-join
+axis (it is absent from \code{task_axes("hc")}) and rides as a carried column. When
+\code{ci = FALSE}, the bootstrap-only knobs (\code{nboot}, \code{ci_method}, \code{parametric})
+are canonically \code{NA}, leaving \code{est_method} as the only fan-out axis; when
+\code{ci = TRUE}, the grid fans out across \verb{nboot x est_method x ci_method x parametric}.
 }
 \details{
 Each row carries an \code{hc_id} primary key and a \code{fit_id} foreign key
@@ -30,7 +31,7 @@ scenario <- ssd_define_scenario(
   ssddata::ccme_boron,
   nsim = 2L,
   seed = 42L,
-  ci = c(FALSE, TRUE),
+  ci = TRUE,
   nboot = c(10L, 100L)
 )
 ssd_scenario_hc_tasks(scenario)

--- a/man/task_primer.Rd
+++ b/man/task_primer.Rd
@@ -57,8 +57,10 @@ excluding \code{nrow} is load-bearing for the sub-truncation property
 (\code{rescale}, \code{computable}, \code{at_boundary_ok}, \code{min_pmix} name,
 \code{range_shape1}, \code{range_shape2}). \code{nrow} IS part of the fit primer: a fit on
 a different truncation is a genuinely different computation.
-\item \strong{hc} -- the parent \code{fit} identity plus the hc-grid row (\code{ci}, \code{nboot},
-\code{est_method}, \code{ci_method}, \code{parametric}).
+\item \strong{hc} -- the parent \code{fit} identity plus the hc-grid row (\code{nboot},
+\code{est_method}, \code{ci_method}, \code{parametric}). \code{ci} is a scalar hc flag applied
+uniformly, not part of the task identity, so it is a carried column rather
+than a primer field.
 }
 
 Function-valued parameters (e.g. \code{min_pmix}) MUST be referenced \strong{by name},

--- a/openspec/changes/scalar-ci-flag/tasks.md
+++ b/openspec/changes/scalar-ci-flag/tasks.md
@@ -1,64 +1,64 @@
 ## 1. Constructor and validation (`R/scenario.R`)
 
-- [ ] 1.1 Replace the `ci` validation (`chk_logical` + `chk_not_any_na` + `chk_unique` + `chk_length(ci, upper = 2L)`) with `chk::chk_flag(ci)`; keep the default `ci = FALSE`
-- [ ] 1.2 Simplify the bootstrap-knob guard from `if (length(ci) == 1L && isFALSE(ci))` to `if (isFALSE(ci))`, and change the message escape hatch from "Set `ci = c(FALSE, TRUE)` to enable bootstrap" to "Set `ci = TRUE` to enable bootstrap"
-- [ ] 1.3 Update the `ssd_define_scenario()` roxygen: the *"# `ci = FALSE`"* section (scalar flag; estimate invariant; `ci = TRUE` superset; `ci = FALSE` cheap/bootstrap-free) **and** the `@param partition_by` line that enumerates the hc vocabulary (`hc` adds `ci`, `nboot`, …) — drop `ci` there
-- [ ] 1.4 Reorder the `ssd_define_scenario()` signature by role so the **simulation settings** are contiguous: keep data/`seed`/`nsim`/`name` first, then the cross-join axes (`nrow`, `replace`, `dists`, `rescale`, `computable`, `at_boundary_ok`, `min_pmix`, `range_shape1`, `range_shape2`, `nboot`, `est_method`, `ci_method`, `parametric`), then the simulation settings (`proportion`, `ci`, `samples`), then `partition_by`, `bundle`, `upload`. Concretely, move `proportion = 0.05` and `ci = FALSE` down from inside the hc axes to sit before `samples = FALSE`
-- [ ] 1.5 Mirror the role order in the stored `hc` list (`scenario$hc <- list(nboot, est_method, ci_method, parametric, proportion, ci, samples)`) and reorder the roxygen `@param`/`@inheritParams` so the generated `man/` lists `proportion`/`ci`/`samples` together
-- [ ] 1.6 Confirm `print.ssdsims_scenario()` renders the hc knobs in the new role order — hc axes first, then the simulation settings `proportion`/`ci`/`samples` (covered by the print snapshot in §9)
+- [x] 1.1 Replace the `ci` validation (`chk_logical` + `chk_not_any_na` + `chk_unique` + `chk_length(ci, upper = 2L)`) with `chk::chk_flag(ci)`; keep the default `ci = FALSE`
+- [x] 1.2 Simplify the bootstrap-knob guard from `if (length(ci) == 1L && isFALSE(ci))` to `if (isFALSE(ci))`, and change the message escape hatch from "Set `ci = c(FALSE, TRUE)` to enable bootstrap" to "Set `ci = TRUE` to enable bootstrap"
+- [x] 1.3 Update the `ssd_define_scenario()` roxygen: the *"# `ci = FALSE`"* section (scalar flag; estimate invariant; `ci = TRUE` superset; `ci = FALSE` cheap/bootstrap-free) **and** the `@param partition_by` line that enumerates the hc vocabulary (`hc` adds `ci`, `nboot`, …) — drop `ci` there
+- [x] 1.4 Reorder the `ssd_define_scenario()` signature by role so the **simulation settings** are contiguous: keep data/`seed`/`nsim`/`name` first, then the cross-join axes (`nrow`, `replace`, `dists`, `rescale`, `computable`, `at_boundary_ok`, `min_pmix`, `range_shape1`, `range_shape2`, `nboot`, `est_method`, `ci_method`, `parametric`), then the simulation settings (`proportion`, `ci`, `samples`), then `partition_by`, `bundle`, `upload`. Concretely, move `proportion = 0.05` and `ci = FALSE` down from inside the hc axes to sit before `samples = FALSE`
+- [x] 1.5 Mirror the role order in the stored `hc` list (`scenario$hc <- list(nboot, est_method, ci_method, parametric, proportion, ci, samples)`) and reorder the roxygen `@param`/`@inheritParams` so the generated `man/` lists `proportion`/`ci`/`samples` together
+- [x] 1.6 Confirm `print.ssdsims_scenario()` renders the hc knobs in the new role order — hc axes first, then the simulation settings `proportion`/`ci`/`samples` (covered by the print snapshot in §9)
 
 ## 2. Task axes and hc grid (`R/task-lists.R`)
 
-- [ ] 2.1 Remove `"ci"` from `task_axes("hc")` (hc vocabulary becomes the fit axes plus `nboot`, `est_method`, `ci_method`, `parametric`)
-- [ ] 2.2 Rewrite `hc_grid_tbl()` as a single-branch grid keyed by the scalar `scenario$hc$ci`: `ci = FALSE` → one row per `est_method` with `nboot = NA_integer_`, `ci_method = NA_character_`, `parametric = NA`; `ci = TRUE` → `expand_grid` over `nboot × est_method × ci_method × parametric`. Drop the `any(ci == FALSE)` / `any(ci == TRUE)` `bind_rows` branching. Keep emitting `ci` as a (now single-valued) **carried column** so the runners can read it
-- [ ] 2.3 Update the `ssd_scenario_hc_tasks()` roxygen (the collapse description and the `ci = c(FALSE, TRUE)` example) to the scalar-`ci` ground truth
-- [ ] 2.4 Verify the in-memory baseline runner path (`hc_args <- hc_tbl[c("ci", "nboot", …)]` → `pmap(hc_data_task_primer, …)`) still reads `ci` from the carried column — **no change expected** (this is the `n_max` carried-column pattern); add a comment if it aids clarity
+- [x] 2.1 Remove `"ci"` from `task_axes("hc")` (hc vocabulary becomes the fit axes plus `nboot`, `est_method`, `ci_method`, `parametric`)
+- [x] 2.2 Rewrite `hc_grid_tbl()` as a single-branch grid keyed by the scalar `scenario$hc$ci`: `ci = FALSE` → one row per `est_method` with `nboot = NA_integer_`, `ci_method = NA_character_`, `parametric = NA`; `ci = TRUE` → `expand_grid` over `nboot × est_method × ci_method × parametric`. Drop the `any(ci == FALSE)` / `any(ci == TRUE)` `bind_rows` branching. Keep emitting `ci` as a (now single-valued) **carried column** so the runners can read it
+- [x] 2.3 Update the `ssd_scenario_hc_tasks()` roxygen (the collapse description and the `ci = c(FALSE, TRUE)` example) to the scalar-`ci` ground truth
+- [x] 2.4 Verify the in-memory baseline runner path (`hc_args <- hc_tbl[c("ci", "nboot", …)]` → `pmap(hc_data_task_primer, …)`) still reads `ci` from the carried column — **no change expected** (this is the `n_max` carried-column pattern); add a comment if it aids clarity
 
 ## 3. Step runner shared by the single-core and targets pipelines (`R/targets-runner.R`, `R/shard-runner.R`)
 
-- [ ] 3.1 `ssd_run_hc_step()` reads `ci = t$ci` from the carried column — confirm this still holds with `ci` out of `task_axes("hc")` (**no code change expected**, since the column persists); this one function backs both `ssd_run_scenario_sharded()` (single-core) and the `tar_map` hc target
-- [ ] 3.2 Update `ssd_run_hc_step()` roxygen (the *"`ci = FALSE` collapse, section 1.2"* mention) to "scalar `ci`; bootstrap-only knobs `NA` when `ci = FALSE`"
-- [ ] 3.3 Confirm the shard write/read round-trips `ci` as a non-axis carried column exactly as it already does for `n_max` (no path-key/partition involvement); add a targeted check in §9 rather than new runner code
+- [x] 3.1 `ssd_run_hc_step()` reads `ci = t$ci` from the carried column — confirm this still holds with `ci` out of `task_axes("hc")` (**no code change expected**, since the column persists); this one function backs both `ssd_run_scenario_sharded()` (single-core) and the `tar_map` hc target
+- [x] 3.2 Update `ssd_run_hc_step()` roxygen (the *"`ci = FALSE` collapse, section 1.2"* mention) to "scalar `ci`; bootstrap-only knobs `NA` when `ci = FALSE`"
+- [x] 3.3 Confirm the shard write/read round-trips `ci` as a non-axis carried column exactly as it already does for `n_max` (no path-key/partition involvement); add a targeted check in §9 rather than new runner code
 
 ## 4. Per-task primer identity (`R/task-primer.R`)
 
-- [ ] 4.1 Update the `task_primer()` roxygen (the hc bullet that lists `ci` among the hc-grid identity fields) to drop `ci` — it is a carried column, not part of task identity
+- [x] 4.1 Update the `task_primer()` roxygen (the hc bullet that lists `ci` among the hc-grid identity fields) to drop `ci` — it is a carried column, not part of task identity
 
 ## 5. Partitioning / sharding vocabulary (`R/scenario.R`, `R/task-shards.R`)
 
-- [ ] 5.1 Because `task_axes("hc")` no longer contains `"ci"`, `partition_by$hc = c(..., "ci")` (and `bundle$hc` naming `"ci"`) now correctly hit the "unknown axis" path in `validate_axis_list()` — **no code change**, but add the regression test in §9
-- [ ] 5.2 Update the `ssd_scenario_hc_shards()` roxygen example in `R/task-shards.R` (`ci = c(FALSE, TRUE)` → scalar `ci = TRUE`)
+- [x] 5.1 Because `task_axes("hc")` no longer contains `"ci"`, `partition_by$hc = c(..., "ci")` (and `bundle$hc` naming `"ci"`) now correctly hit the "unknown axis" path in `validate_axis_list()` — **no code change**, but add the regression test in §9
+- [x] 5.2 Update the `ssd_scenario_hc_shards()` roxygen example in `R/task-shards.R` (`ci = c(FALSE, TRUE)` → scalar `ci = TRUE`)
 
 ## 6. Low-level entry point and legacy runner (`R/hc-sims.R`, `R/run-scenario.R`, `R/internal.R`)
 
-- [ ] 6.1 Add `chk::chk_flag(ci)` to `ssd_hc_sims()` so a vector `ci` is rejected at that layer (it already applies `ci` as a scalar — `ci` is not in its `expand_grid`)
-- [ ] 6.2 Confirm the legacy `ssd_run_scenario.*` methods and the `internal.R` `do.call(ssd_hc_sims, …)` helper pass `ci` straight through — a vector `ci` now surfaces the §6.1 flag error from `ssd_hc_sims()` (no axis logic of their own; no change beyond inheriting the validation)
+- [x] 6.1 Add `chk::chk_flag(ci)` to `ssd_hc_sims()` so a vector `ci` is rejected at that layer (it already applies `ci` as a scalar — `ci` is not in its `expand_grid`)
+- [x] 6.2 Confirm the legacy `ssd_run_scenario.*` methods and the `internal.R` `do.call(ssd_hc_sims, …)` helper pass `ci` straight through — a vector `ci` now surfaces the §6.1 flag error from `ssd_hc_sims()` (no axis logic of their own; no change beyond inheriting the validation)
 
 ## 7. Params, generated docs, and design docs
 
-- [ ] 7.1 `R/params.R`: tighten the `@param ci` text to "scalar flag … (not a cross-join axis; the point estimate is identical whether `TRUE`/`FALSE`)"
-- [ ] 7.2 Run `devtools::document()` so `man/ssd_define_scenario.Rd`, `man/ssd_hc_sims.Rd`, `man/ssd_scenario_hc_shards.Rd`, and the partition vocabulary docs regenerate
-- [ ] 7.3 (Done in this change) `TARGETS-DESIGN.md` §1.2 rewritten to "`ci` is a scalar flag (not an axis)"; §1/§5 sidebar, hash section, hc step-table row, and pitfall table updated; §12 Cleanup bullet + status snapshot added. `GLOSSARY.md` gains the **simulation setting** term and its `axis`/`ci` entries updated to point at it. Verify these read correctly against the final code
+- [x] 7.1 `R/params.R`: tighten the `@param ci` text to "scalar flag … (not a cross-join axis; the point estimate is identical whether `TRUE`/`FALSE`)"
+- [x] 7.2 Run `devtools::document()` so `man/ssd_define_scenario.Rd`, `man/ssd_hc_sims.Rd`, `man/ssd_scenario_hc_shards.Rd`, and the partition vocabulary docs regenerate
+- [x] 7.3 (Done in this change) `TARGETS-DESIGN.md` §1.2 rewritten to "`ci` is a scalar flag (not an axis)"; §1/§5 sidebar, hash section, hc step-table row, and pitfall table updated; §12 Cleanup bullet + status snapshot added. `GLOSSARY.md` gains the **simulation setting** term and its `axis`/`ci` entries updated to point at it. Verify these read correctly against the final code
 
 ## 8. Templates and example scripts
 
-- [ ] 8.1 `inst/targets-templates/large/scenario.R`: change `ci = c(FALSE, TRUE)` to a scalar (`ci = TRUE`); its `partition_by hc = c("ci_method", "est_method")` is unaffected (does not name `"ci"`)
-- [ ] 8.2 `scripts/example2.R`: change `ci = c(FALSE, TRUE)` to scalar and rewrite the accompanying comment (it currently calls `c(FALSE, TRUE)` "the deliberate way to ask for both") to explain the scalar either/or
-- [ ] 8.3 Sweep the remaining `scripts/example*.R` for `ci = c(FALSE, TRUE)` / collapse references and update to scalar
+- [x] 8.1 `inst/targets-templates/large/scenario.R`: change `ci = c(FALSE, TRUE)` to a scalar (`ci = TRUE`); its `partition_by hc = c("ci_method", "est_method")` is unaffected (does not name `"ci"`)
+- [x] 8.2 `scripts/example2.R`: change `ci = c(FALSE, TRUE)` to scalar and rewrite the accompanying comment (it currently calls `c(FALSE, TRUE)` "the deliberate way to ask for both") to explain the scalar either/or
+- [x] 8.3 Sweep the remaining `scripts/example*.R` for `ci = c(FALSE, TRUE)` / collapse references and update to scalar
 
 ## 9. Tests and snapshots
 
-- [ ] 9.1 `tests/testthat/test-scenario.R`: replace the "ci = c(FALSE, TRUE) retains bootstrap knobs" test (asserting `s$hc$ci == c(FALSE, TRUE)`) with: `ci = c(FALSE, TRUE)` (and any non-flag) aborts; a scalar `ci = TRUE` stores `s$hc$ci == TRUE` and retains bootstrap knobs; `ci = FALSE` + a bootstrap knob aborts with the "Set `ci = TRUE`" message. Update the other `ci = c(FALSE, TRUE)` call sites (e.g. line 705) to scalar
-- [ ] 9.2 `tests/testthat/test-scenario.R` axis-vocabulary assertions (the `task_axes("hc")` / path-vs-inner checks around lines 79, 465–480): drop `"ci"` from the expected hc vocabulary; add a case asserting `partition_by = list(hc = "ci")` is **rejected** as an unknown hc axis (and `bundle = list(hc = "ci")` likewise)
-- [ ] 9.3 `tests/testthat/test-task-lists.R`: rewrite the "ci = c(FALSE, TRUE) collapses the bootstrap-only knobs" test (and the `hc_tasks$ci == FALSE` filter) for scalar `ci`: a `ci = FALSE` scenario yields one row per `est_method` with `NA` bootstrap knobs; a `ci = TRUE` scenario fans out; assert `!"ci" %in% task_axes("hc")`. Update remaining `ci = c(FALSE, TRUE)` call sites to scalar
-- [ ] 9.4 `tests/testthat/test-task-shards.R`: update the `ci = c(FALSE, TRUE)` scenario to scalar; assert `ci` is a carried column (present, not a path/inner axis) on the hc shards
-- [ ] 9.5 `tests/testthat/test-hc-sims.R`: assert `ssd_hc_sims(..., ci = c(FALSE, TRUE))` aborts; assert `est` is byte-identical between `ci = FALSE` and `ci = TRUE`; re-baseline the `hc_sims1` / `hc_sims1ci` snapshots (CI columns shift because `ci` left the primer; `est` unchanged)
-- [ ] 9.6 `tests/testthat/test-run-scenario.R` and the single-core/targets runner tests: confirm byte-identical results across baseline / sharded / targets for a scalar-`ci` scenario (the cross-runner oracle), and that `ci` round-trips as a carried column through the Parquet shards
-- [ ] 9.7 Regenerate the affected snapshots: `_snaps/scenario.md` (the three "Set `ci = …`" error messages → "Set `ci = TRUE`"; the scenario-`print` grids that showed `ci = c(FALSE, TRUE)`), `_snaps/task-lists.md` (the `task_axes("hc")` listing that includes `"ci"`; the scenario-`print` and hc-task snapshots), and any hc-task/shard fixtures. Confirm only CI-bearing columns (`se`/`lcl`/`ucl`) and `nboot` move; `est`/`wt`/`dist`/`proportion`/`pboot` stay identical
+- [x] 9.1 `tests/testthat/test-scenario.R`: replace the "ci = c(FALSE, TRUE) retains bootstrap knobs" test (asserting `s$hc$ci == c(FALSE, TRUE)`) with: `ci = c(FALSE, TRUE)` (and any non-flag) aborts; a scalar `ci = TRUE` stores `s$hc$ci == TRUE` and retains bootstrap knobs; `ci = FALSE` + a bootstrap knob aborts with the "Set `ci = TRUE`" message. Update the other `ci = c(FALSE, TRUE)` call sites (e.g. line 705) to scalar
+- [x] 9.2 `tests/testthat/test-scenario.R` axis-vocabulary assertions (the `task_axes("hc")` / path-vs-inner checks around lines 79, 465–480): drop `"ci"` from the expected hc vocabulary; add a case asserting `partition_by = list(hc = "ci")` is **rejected** as an unknown hc axis (and `bundle = list(hc = "ci")` likewise)
+- [x] 9.3 `tests/testthat/test-task-lists.R`: rewrite the "ci = c(FALSE, TRUE) collapses the bootstrap-only knobs" test (and the `hc_tasks$ci == FALSE` filter) for scalar `ci`: a `ci = FALSE` scenario yields one row per `est_method` with `NA` bootstrap knobs; a `ci = TRUE` scenario fans out; assert `!"ci" %in% task_axes("hc")`. Update remaining `ci = c(FALSE, TRUE)` call sites to scalar
+- [x] 9.4 `tests/testthat/test-task-shards.R`: update the `ci = c(FALSE, TRUE)` scenario to scalar; assert `ci` is a carried column (present, not a path/inner axis) on the hc shards
+- [x] 9.5 `tests/testthat/test-hc-sims.R`: assert `ssd_hc_sims(..., ci = c(FALSE, TRUE))` aborts; assert `est` is byte-identical between `ci = FALSE` and `ci = TRUE`; re-baseline the `hc_sims1` / `hc_sims1ci` snapshots (CI columns shift because `ci` left the primer; `est` unchanged)
+- [x] 9.6 `tests/testthat/test-run-scenario.R` and the single-core/targets runner tests: confirm byte-identical results across baseline / sharded / targets for a scalar-`ci` scenario (the cross-runner oracle), and that `ci` round-trips as a carried column through the Parquet shards
+- [x] 9.7 Regenerate the affected snapshots: `_snaps/scenario.md` (the three "Set `ci = …`" error messages → "Set `ci = TRUE`"; the scenario-`print` grids that showed `ci = c(FALSE, TRUE)`), `_snaps/task-lists.md` (the `task_axes("hc")` listing that includes `"ci"`; the scenario-`print` and hc-task snapshots), and any hc-task/shard fixtures. Confirm only CI-bearing columns (`se`/`lcl`/`ucl`) and `nboot` move; `est`/`wt`/`dist`/`proportion`/`pboot` stay identical
 
 ## 10. Checks
 
-- [ ] 10.1 Run `air format .`
-- [ ] 10.2 Run `devtools::document()` and confirm `NAMESPACE`/`man/` are clean
-- [ ] 10.3 Run `devtools::test()` (all snapshots intentionally re-baselined) and `devtools::check()`
-- [ ] 10.4 Run `openspec validate scalar-ci-flag --strict` and confirm it passes
+- [x] 10.1 Run `air format .`
+- [x] 10.2 Run `devtools::document()` and confirm `NAMESPACE`/`man/` are clean
+- [x] 10.3 Run `devtools::test()` (all snapshots intentionally re-baselined) and `devtools::check()`
+- [x] 10.4 Run `openspec validate scalar-ci-flag --strict` and confirm it passes

--- a/scripts/example2.R
+++ b/scripts/example2.R
@@ -29,9 +29,10 @@ datasets <- ssd_data(
 # --- 2. Declare the scenario ----------------------------------------
 # Purely declarative: stores the seed, the replicate count, the sample sizes,
 # the dataset *names*, and the fit/hc argument grids. `min_pmix` is kept by
-# name only. `ci = c(FALSE, TRUE)` is the deliberate way to ask for both the
-# point estimate and bootstrap intervals -- a bare `ci = FALSE` forbids the
-# bootstrap-only knobs (`nboot`, `ci_method`, `parametric`).
+# name only. `ci` is a scalar flag, an either/or choice: `ci = TRUE` for
+# estimates plus bootstrap intervals, or `ci = FALSE` for cheap point estimates
+# only (which forbids the bootstrap-only knobs `nboot`, `ci_method`,
+# `parametric`). A `ci = TRUE` run is a superset of `ci = FALSE`.
 scenario <- ssd_define_scenario(
   datasets,
   nsim = 3L,
@@ -39,7 +40,7 @@ scenario <- ssd_define_scenario(
   seed = 42L,
   dists = c("lnorm", "gamma"),
   proportion = c(0.05, 0.2),
-  ci = c(FALSE, TRUE),
+  ci = TRUE,
   nboot = c(10L, 100L),
   est_method = "multi",
   ci_method = "weighted_samples"
@@ -54,8 +55,9 @@ print(scenario)
 tasks <- ssd_scenario_tasks(scenario)
 print(tasks)
 
-# The bootstrap-only knobs collapse to NA on the `ci = FALSE` rows and fan out
-# only on the `ci = TRUE` rows -- inspect the hc table to see the asymmetry.
+# With the scalar `ci = TRUE` the hc grid fans out over the bootstrap knobs
+# (`nboot x est_method x ci_method x parametric`); a `ci = FALSE` scenario would
+# instead give one row per `est_method` with the bootstrap knobs `NA`.
 print(tasks$hc)
 
 # Per-step derivations are also available individually:

--- a/tests/testthat/_snaps/hc-sims.md
+++ b/tests/testthat/_snaps/hc-sims.md
@@ -1,0 +1,8 @@
+# hazard-concentrations: a vector ci is rejected
+
+    Code
+      ssd_hc_sims(sims, ci = c(FALSE, TRUE))
+    Condition
+      Error in `ssd_hc_sims()`:
+      ! `ci` must be a flag (TRUE or FALSE).
+

--- a/tests/testthat/_snaps/scenario.md
+++ b/tests/testthat/_snaps/scenario.md
@@ -83,6 +83,24 @@
       Error in `ssd_define_scenario()`:
       ! `partition_by$sample` names unknown axis '"nboot"'; valid axes for the `sample` step are '"dataset"', '"sim"' and '"replace"'.
 
+# scenario-definition: partition_by rejects ci as an hc axis
+
+    Code
+      ssd_define_scenario(ssddata::ccme_boron, nsim = 2L, seed = 1L, partition_by = list(
+        hc = c("dataset", "sim", "ci")))
+    Condition
+      Error in `ssd_define_scenario()`:
+      ! `partition_by$hc` names unknown axis '"ci"'; valid axes for the `hc` step are '"dataset"', '"sim"', '"replace"', '"nrow"', '"rescale"', '"computable"', '"at_boundary_ok"', '"min_pmix"', ... and '"parametric"'.
+
+# scenario-definition: bundle rejects ci as an hc axis
+
+    Code
+      ssd_define_scenario(ssddata::ccme_boron, nsim = 2L, seed = 1L, bundle = list(
+        hc = "ci"))
+    Condition
+      Error in `ssd_define_scenario()`:
+      ! `bundle$hc` names unknown axis '"ci"'; valid axes for the `hc` step are '"dataset"', '"sim"', '"replace"', '"nrow"', '"rescale"', '"computable"', '"at_boundary_ok"', '"min_pmix"', ... and '"parametric"'.
+
 # scenario-definition: partition_by rejects nrow under the sample step
 
     Code
@@ -173,7 +191,7 @@
       nboot = 500)
     Condition
       Error in `ssd_define_scenario()`:
-      ! Bootstrap-only knob ('nboot') cannot be set when `ci = FALSE`. Set `ci = c(FALSE, TRUE)` to enable bootstrap, or omit the knob.
+      ! Bootstrap-only knob ('nboot') cannot be set when `ci = FALSE`. Set `ci = TRUE` to enable bootstrap, or omit the knob.
 
 # scenario-definition: ci = FALSE rejects ci_method and parametric
 
@@ -182,7 +200,7 @@
       ci_method = "MACL")
     Condition
       Error in `ssd_define_scenario()`:
-      ! Bootstrap-only knob ('ci_method') cannot be set when `ci = FALSE`. Set `ci = c(FALSE, TRUE)` to enable bootstrap, or omit the knob.
+      ! Bootstrap-only knob ('ci_method') cannot be set when `ci = FALSE`. Set `ci = TRUE` to enable bootstrap, or omit the knob.
 
 ---
 
@@ -191,7 +209,16 @@
       parametric = FALSE)
     Condition
       Error in `ssd_define_scenario()`:
-      ! Bootstrap-only knob ('parametric') cannot be set when `ci = FALSE`. Set `ci = c(FALSE, TRUE)` to enable bootstrap, or omit the knob.
+      ! Bootstrap-only knob ('parametric') cannot be set when `ci = FALSE`. Set `ci = TRUE` to enable bootstrap, or omit the knob.
+
+# scenario-definition: a vector ci is rejected
+
+    Code
+      ssd_define_scenario(ssddata::ccme_boron, nsim = 2L, seed = 1L, ci = c(FALSE,
+        TRUE))
+    Condition
+      Error in `ssd_define_scenario()`:
+      ! `ci` must be a flag (TRUE or FALSE).
 
 # scenario-definition: seed is required
 
@@ -269,12 +296,12 @@
           range_shape1: {0.05, 20}
           range_shape2: {0.05, 20}
         hc grid:
-          proportion: 0.05
-          ci: FALSE
           nboot: 1000
           est_method: multi
           ci_method: weighted_samples
           parametric: TRUE
+          proportion: 0.05
+          ci: FALSE
           samples: FALSE
         partition_by:
           sample: dataset, sim, replace
@@ -283,7 +310,7 @@
         bundle:
           sample: 
           fit: replace, computable, at_boundary_ok, min_pmix, range_shape1, range_shape2
-          hc: replace, nrow, rescale, computable, at_boundary_ok, min_pmix, range_shape1, range_shape2, ci, nboot, est_method, ci_method, parametric
+          hc: replace, nrow, rescale, computable, at_boundary_ok, min_pmix, range_shape1, range_shape2, nboot, est_method, ci_method, parametric
 
 # scenario-definition: print is stable for multiple datasets and vector knobs
 
@@ -291,9 +318,9 @@
       ssd_define_scenario(list(boron = ssddata::ccme_boron, cadmium = ssddata::ccme_cadmium),
       nsim = 50L, nrow = c(5L, 6L, 10L), seed = 1L, rescale = c(FALSE, TRUE),
       computable = c(FALSE, TRUE), at_boundary_ok = c(TRUE, FALSE), range_shape1 = list(
-        c(0.05, 20), c(0.1, 10)), proportion = c(0.05, 0.1), ci = c(FALSE, TRUE),
-      nboot = c(100, 1000), est_method = c("multi", "geometric"), ci_method = c(
-        "weighted_samples", "MACL"), parametric = c(TRUE, FALSE))
+        c(0.05, 20), c(0.1, 10)), proportion = c(0.05, 0.1), ci = TRUE, nboot = c(100,
+        1000), est_method = c("multi", "geometric"), ci_method = c("weighted_samples",
+        "MACL"), parametric = c(TRUE, FALSE))
     Output
       <ssdsims_scenario>
         seed:     1
@@ -310,12 +337,12 @@
           range_shape1: {0.05, 20; 0.1, 10}
           range_shape2: {0.05, 20}
         hc grid:
-          proportion: 0.05, 0.1
-          ci: FALSE, TRUE
           nboot: 100, 1000
           est_method: multi, geometric
           ci_method: weighted_samples, MACL
           parametric: TRUE, FALSE
+          proportion: 0.05, 0.1
+          ci: TRUE
           samples: FALSE
         partition_by:
           sample: dataset, sim, replace
@@ -324,7 +351,7 @@
         bundle:
           sample: 
           fit: replace, computable, at_boundary_ok, min_pmix, range_shape1, range_shape2
-          hc: replace, nrow, rescale, computable, at_boundary_ok, min_pmix, range_shape1, range_shape2, ci, nboot, est_method, ci_method, parametric
+          hc: replace, nrow, rescale, computable, at_boundary_ok, min_pmix, range_shape1, range_shape2, nboot, est_method, ci_method, parametric
 
 # scenario-definition: samples must be a flag
 

--- a/tests/testthat/_snaps/task-lists.md
+++ b/tests/testthat/_snaps/task-lists.md
@@ -36,17 +36,16 @@
 
     Code
       ssd_scenario_hc_tasks(ssd_define_scenario(ssddata::ccme_boron, nsim = 1L, seed = 42L,
-      ci = c(FALSE, TRUE), nboot = c(10L, 100L)))
+      ci = TRUE, nboot = c(10L, 100L)))
     Output
       <ssdsims_tasks: hc>
-        axes:  dataset, sim, replace, nrow, rescale, computable, at_boundary_ok, min_pmix, range_shape1, range_shape2, ci, nboot, est_method, ci_method, parametric
-        tasks: 3
-      # A tibble: 3 x 17
+        axes:  dataset, sim, replace, nrow, rescale, computable, at_boundary_ok, min_pmix, range_shape1, range_shape2, nboot, est_method, ci_method, parametric
+        tasks: 2
+      # A tibble: 2 x 17
         dataset      sim replace  nrow rescale computable at_boundary_ok min_pmix    
         <chr>      <int> <lgl>   <int> <lgl>   <lgl>      <lgl>          <chr>       
       1 ccme_boron     1 FALSE       6 FALSE   FALSE      TRUE           ssd_min_pmix
       2 ccme_boron     1 FALSE       6 FALSE   FALSE      TRUE           ssd_min_pmix
-      3 ccme_boron     1 FALSE       6 FALSE   FALSE      TRUE           ssd_min_pmix
       # i 9 more variables: range_shape1 <list>, range_shape2 <list>, ci <lgl>,
       #   nboot <int>, est_method <chr>, ci_method <chr>, parametric <lgl>,
       #   hc_id <chr>, fit_id <chr>
@@ -55,13 +54,13 @@
 
     Code
       ssd_scenario_tasks(ssd_define_scenario(ssddata::ccme_boron, nsim = 2L, nrow = c(
-        5L, 10L), seed = 42L, rescale = c(FALSE, TRUE), ci = c(FALSE, TRUE), nboot = c(
-        10L, 100L)))
+        5L, 10L), seed = 42L, rescale = c(FALSE, TRUE), ci = TRUE, nboot = c(10L,
+        100L)))
     Output
       <ssdsims_task_set>
         sample tasks: 2
         fit    tasks: 8
-        hc     tasks: 24
+        hc     tasks: 16
 
 # task-lists: task-table column contracts are pinned
 

--- a/tests/testthat/test-hc-sims.R
+++ b/tests/testthat/test-hc-sims.R
@@ -17,3 +17,26 @@ test_that("hc_sims 1 sim ci", {
   sims <- tidyr::unnest(sims, cols = c(hc))
   expect_snapshot_data(sims, "hc_sims1ci")
 })
+
+test_that("hazard-concentrations: a vector ci is rejected", {
+  withr::with_seed(42, {
+    sims <- ssd_sim_data("rlnorm", seed = 10, nsim = 1L)
+    sims <- ssd_fit_dists_sims(sims, seed = 10)
+  })
+  expect_snapshot(error = TRUE, {
+    ssd_hc_sims(sims, ci = c(FALSE, TRUE))
+  })
+})
+
+test_that("hazard-concentrations: est is identical for ci = FALSE and ci = TRUE", {
+  withr::with_seed(42, {
+    sims <- ssd_sim_data("rlnorm", seed = 10, nsim = 1L)
+    sims <- ssd_fit_dists_sims(sims, seed = 10)
+    no_ci <- ssd_hc_sims(sims, ci = FALSE)
+    with_ci <- ssd_hc_sims(sims, ci = TRUE, nboot = 2L)
+  })
+  expect_identical(
+    tidyr::unnest(no_ci, cols = c(hc))$est,
+    tidyr::unnest(with_ci, cols = c(hc))$est
+  )
+})

--- a/tests/testthat/test-scenario.R
+++ b/tests/testthat/test-scenario.R
@@ -84,6 +84,7 @@ test_that("scenario-definition: minimal construction stores declarative fields",
       "samples"
     )
   )
+  expect_identical(s$hc$ci, FALSE)
 })
 
 test_that("scenario-definition: stores dataset names, not data frames", {

--- a/tests/testthat/test-scenario.R
+++ b/tests/testthat/test-scenario.R
@@ -75,12 +75,12 @@ test_that("scenario-definition: minimal construction stores declarative fields",
   expect_named(
     s$hc,
     c(
-      "proportion",
-      "ci",
       "nboot",
       "est_method",
       "ci_method",
       "parametric",
+      "proportion",
+      "ci",
       "samples"
     )
   )
@@ -312,6 +312,28 @@ test_that("scenario-definition: partition_by rejects an unknown axis", {
         fit = c("dataset", "sim"),
         hc = c("dataset", "sim")
       )
+    )
+  })
+})
+
+test_that("scenario-definition: partition_by rejects ci as an hc axis", {
+  expect_snapshot(error = TRUE, {
+    ssd_define_scenario(
+      ssddata::ccme_boron,
+      nsim = 2L,
+      seed = 1L,
+      partition_by = list(hc = c("dataset", "sim", "ci"))
+    )
+  })
+})
+
+test_that("scenario-definition: bundle rejects ci as an hc axis", {
+  expect_snapshot(error = TRUE, {
+    ssd_define_scenario(
+      ssddata::ccme_boron,
+      nsim = 2L,
+      seed = 1L,
+      bundle = list(hc = "ci")
     )
   })
 })
@@ -629,16 +651,27 @@ test_that("scenario-definition: ci = FALSE alone is fine with default knobs", {
   )
 })
 
-test_that("scenario-definition: ci = c(FALSE, TRUE) retains bootstrap knobs", {
+test_that("scenario-definition: a vector ci is rejected", {
+  expect_snapshot(error = TRUE, {
+    ssd_define_scenario(
+      ssddata::ccme_boron,
+      nsim = 2L,
+      seed = 1L,
+      ci = c(FALSE, TRUE)
+    )
+  })
+})
+
+test_that("scenario-definition: scalar ci = TRUE retains bootstrap knobs", {
   s <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 2L,
     seed = 1L,
-    ci = c(FALSE, TRUE),
+    ci = TRUE,
     nboot = c(100, 1000),
     ci_method = "weighted_samples"
   )
-  expect_identical(s$hc$ci, c(FALSE, TRUE))
+  expect_identical(s$hc$ci, TRUE)
   expect_identical(s$hc$nboot, c(100, 1000))
 })
 
@@ -702,7 +735,7 @@ test_that("scenario-definition: print is stable for multiple datasets and vector
       at_boundary_ok = c(TRUE, FALSE),
       range_shape1 = list(c(0.05, 20), c(0.1, 10)),
       proportion = c(0.05, 0.1),
-      ci = c(FALSE, TRUE),
+      ci = TRUE,
       nboot = c(100, 1000),
       est_method = c("multi", "geometric"),
       ci_method = c("weighted_samples", "MACL"),

--- a/tests/testthat/test-task-lists.R
+++ b/tests/testthat/test-task-lists.R
@@ -103,24 +103,41 @@ test_that("task-lists: hc table has K * H rows", {
   expect_identical(nrow(hc_tasks), nrow(fit_tasks) * 4L)
 })
 
-test_that("task-lists: ci = c(FALSE, TRUE) collapses the bootstrap-only knobs", {
+test_that("task-lists: ci is not an hc axis", {
+  expect_false("ci" %in% task_axes("hc"))
+})
+
+test_that("task-lists: ci = FALSE leaves bootstrap-only knobs NA", {
   scenario <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 2L,
     seed = 42L,
-    ci = c(FALSE, TRUE),
+    ci = FALSE,
+    est_method = c("arithmetic", "multi")
+  )
+  fit_tasks <- ssd_scenario_fit_tasks(scenario)
+  hc_tasks <- ssd_scenario_hc_tasks(scenario)
+  # One row per est_method, no fan-out over the bootstrap-only knobs.
+  expect_identical(nrow(hc_tasks), nrow(fit_tasks) * 2L)
+  expect_true(all(hc_tasks$ci == FALSE))
+  expect_true(all(is.na(hc_tasks$nboot)))
+  expect_true(all(is.na(hc_tasks$ci_method)))
+  expect_true(all(is.na(hc_tasks$parametric)))
+})
+
+test_that("task-lists: ci = TRUE fans out over the bootstrap knobs", {
+  scenario <- ssd_define_scenario(
+    ssddata::ccme_boron,
+    nsim = 2L,
+    seed = 42L,
+    ci = TRUE,
     nboot = c(10L, 100L)
   )
   fit_tasks <- ssd_scenario_fit_tasks(scenario)
   hc_tasks <- ssd_scenario_hc_tasks(scenario)
-  # Per fit task: 1 collapsed ci = FALSE row + 2 ci = TRUE rows (nboot) = 3,
-  # not the naive 2 ci * 2 nboot = 4 full cross-join.
-  expect_identical(nrow(hc_tasks), nrow(fit_tasks) * 3L)
-  false_rows <- hc_tasks[hc_tasks$ci == FALSE, ]
-  expect_identical(nrow(false_rows), nrow(fit_tasks))
-  expect_true(all(is.na(false_rows$nboot)))
-  expect_true(all(is.na(false_rows$ci_method)))
-  expect_true(all(is.na(false_rows$parametric)))
+  # 2 nboot * 1 est_method * 1 ci_method * 1 parametric = 2 per fit task.
+  expect_identical(nrow(hc_tasks), nrow(fit_tasks) * 2L)
+  expect_true(all(hc_tasks$ci == TRUE))
 })
 
 # ---- task ids / foreign keys -----------------------------------------------
@@ -197,7 +214,7 @@ test_that("task-lists: printing a task table is informative", {
         ssddata::ccme_boron,
         nsim = 1L,
         seed = 42L,
-        ci = c(FALSE, TRUE),
+        ci = TRUE,
         nboot = c(10L, 100L)
       )
     )
@@ -213,7 +230,7 @@ test_that("task-lists: ssd_scenario_tasks bundles the three task tables", {
     nrow = c(5L, 10L),
     seed = 42L,
     rescale = c(FALSE, TRUE),
-    ci = c(FALSE, TRUE)
+    ci = TRUE
   )
   tasks <- ssd_scenario_tasks(scenario)
   expect_s3_class(tasks, "ssdsims_task_set")
@@ -232,7 +249,7 @@ test_that("task-lists: printing a task set reports per-step counts", {
         nrow = c(5L, 10L),
         seed = 42L,
         rescale = c(FALSE, TRUE),
-        ci = c(FALSE, TRUE),
+        ci = TRUE,
         nboot = c(10L, 100L)
       )
     )
@@ -437,7 +454,7 @@ test_that("task-lists: task-table column contracts are pinned", {
     nsim = 1L,
     nrow = c(5L, 10L),
     seed = 42L,
-    ci = c(FALSE, TRUE)
+    ci = TRUE
   )
   expect_snapshot({
     names(ssd_scenario_sample_tasks(scenario))
@@ -455,7 +472,7 @@ test_that("scenario-definition: samples = TRUE retains hc draws but keeps estima
     nrow = 6L,
     seed = 42L,
     dists = "lnorm",
-    ci = c(FALSE, TRUE),
+    ci = TRUE,
     nboot = 2L
   )
   out_no <- ssd_run_scenario_baseline(do.call(ssd_define_scenario, args))
@@ -472,7 +489,7 @@ test_that("scenario-definition: samples = TRUE retains hc draws but keeps estima
 test_that("scenario-definition: samples = TRUE works with multiple dists and ci = FALSE", {
   # Regression: `samples = TRUE` retains the *bootstrap* draws, which only exist
   # for `ci = TRUE`. With multiple dists (model averaging), asking ssdtools to
-  # keep a non-existent `samples` column on the `ci = FALSE` rows errored
+  # keep a non-existent `samples` column on the `ci = FALSE` path errored
   # ("Can't select columns that don't exist"). The no-CI path must therefore
   # never request samples, whatever the scenario flag.
   scenario <- ssd_define_scenario(
@@ -481,13 +498,11 @@ test_that("scenario-definition: samples = TRUE works with multiple dists and ci 
     nrow = 6L,
     seed = 42L,
     dists = c("lnorm", "gamma"),
-    ci = c(FALSE, TRUE),
-    nboot = 2L,
+    ci = FALSE,
     samples = TRUE
   )
   expect_no_error(out <- ssd_run_scenario_baseline(scenario))
-  # ci = TRUE rows keep draws; ci = FALSE rows have an empty samples column.
+  # The no-CI path never retains samples, so every samples column is empty.
   lens <- unlist(lapply(out$hc$hc, function(h) lengths(h$samples)))
-  expect_true(any(lens > 0L))
-  expect_true(any(lens == 0L))
+  expect_true(all(lens == 0L))
 })

--- a/tests/testthat/test-task-shards.R
+++ b/tests/testthat/test-task-shards.R
@@ -26,7 +26,7 @@ test_that("task-shards: union of a step's shard tasks equals its task table", {
     nsim = 2L,
     nrow = c(5L, 10L),
     seed = 42L,
-    ci = c(FALSE, TRUE),
+    ci = TRUE,
     nboot = 10L
   )
   for (step in c("sample", "fit", "hc")) {
@@ -41,6 +41,23 @@ test_that("task-shards: union of a step's shard tasks equals its task table", {
     union_ids <- sort(unlist(lapply(shards$tasks, function(t) t[[id]])))
     expect_identical(union_ids, sort(tasks[[id]]))
   }
+})
+
+test_that("task-shards: ci rides as a carried column on the hc shards", {
+  scenario <- ssd_define_scenario(
+    ssddata::ccme_boron,
+    nsim = 1L,
+    seed = 42L,
+    ci = TRUE,
+    nboot = 10L
+  )
+  tasks <- ssd_scenario_hc_shards(scenario)$tasks[[1]]
+  # `ci` is present as a column the runner reads, but it is neither a path nor
+  # an inner axis (it is absent from the hc vocabulary).
+  expect_true("ci" %in% names(tasks))
+  expect_false("ci" %in% task_axes("hc"))
+  expect_false("ci" %in% scenario_partition_axes(scenario, "hc")$path)
+  expect_false("ci" %in% scenario_partition_axes(scenario, "hc")$inner)
 })
 
 test_that("task-shards: a coarser partition_by bundles more tasks per shard", {

--- a/vignettes/defining-a-scenario.qmd
+++ b/vignettes/defining-a-scenario.qmd
@@ -101,7 +101,7 @@ scenario <- ssd_define_scenario(
   seed = 42L,
   dists = c("lnorm", "gamma"),
   proportion = c(0.05, 0.2),
-  ci = c(FALSE, TRUE),
+  ci = TRUE,
   nboot = c(10L, 100L),
   est_method = "multi",
   ci_method = "weighted_samples"
@@ -166,11 +166,18 @@ bodies produce byte-identical task identities --- the split that lets a cluster
 worker resolve `min_pmix` off the transported scenario with no shared
 interactive environment.
 
-### The `ci = FALSE` rule
+### The `ci` flag
 
-When `ci = FALSE` is the *only* confidence-interval value, the bootstrap-only
-knobs (`nboot`, `ci_method`, `parametric`) are meaningless, so passing any of
-them is an error:
+`ci` is a scalar flag, not a cross-join axis. The point estimate is computed
+analytically from the fit and is identical whether `ci` is `TRUE` or `FALSE`,
+so a `ci = TRUE` run is a strict superset of `ci = FALSE` (the same estimate,
+plus the `se`/`lcl`/`ucl` columns). The choice is a scenario-wide either/or:
+`ci = TRUE` for estimates plus bootstrap intervals (as in the scenario above),
+or `ci = FALSE` for cheap, bootstrap-free point estimates only.
+
+When `ci = FALSE`, the bootstrap-only knobs (`nboot`, `ci_method`,
+`parametric`) are meaningless, so passing any of them is an error --- set
+`ci = TRUE` to enable the bootstrap, or omit the knob:
 
 ```{r}
 #| label: ci-false-error
@@ -183,12 +190,6 @@ ssd_define_scenario(
   nboot = 1000
 )
 ```
-
-To ask for *both* a point estimate and bootstrap intervals --- the common case
---- set `ci = c(FALSE, TRUE)` (as in the scenario above) rather than a bare
-`ci = TRUE`. This keeps the study symmetric: the `ci = FALSE` row is retained
-and collapses its bootstrap knobs to `NA` at expansion time, while the
-`ci = TRUE` rows fan out across the full bootstrap grid.
 
 ## Stage 3: expand into task tables
 
@@ -219,9 +220,10 @@ joinable:
 tasks$sample
 ```
 
-The `ci = FALSE` collapse is visible in the `hc` table: the `ci = FALSE` rows
-carry `NA` for the bootstrap-only knobs and are not multiplied across them,
-while the `ci = TRUE` rows fan out fully.
+The scalar `ci` is carried uniformly on the `hc` table (it is not an axis). With
+`ci = TRUE` the bootstrap knobs fan out fully; a `ci = FALSE` scenario would
+instead give one row per `est_method`, carrying `NA` for the bootstrap-only
+knobs.
 
 ```{r}
 #| label: hc-table


### PR DESCRIPTION
## Why

`ci` was a length-2 grid/task axis (`c(FALSE, TRUE)`): `ssd_define_scenario()` accepted `chk_length(ci, upper = 2L)`, `task_axes("hc")` listed `"ci"`, and a dedicated *`ci = FALSE` collapse* kept the no-bootstrap portion of a mixed grid from fanning out across the bootstrap-only knobs.

That axis treatment rested on a false premise. Verified against `ssdtools` 2.6.0.9002, the point estimate `est` from `ssd_hc()` is **byte-identical** whether `ci = TRUE` or `ci = FALSE`, across every `ci_method` and independent of the RNG state — it is computed analytically from the fit and never touches the bootstrap. A `ci = TRUE` run is therefore a strict **superset** of `ci = FALSE` (same `est`/`wt`/`dist`/`proportion`/`pboot`, plus the populated `se`/`lcl`/`ucl`). Crossing both in one scenario only doubles the hc work for a redundant point-estimate row per fit-task.

This is the same *"a single `TRUE` is a superset of `FALSE`"* property the design already uses to keep `samples` a scalar, non-axis knob. This change brings `ci` into line.

## What changed

- **`ci` is a scalar flag** (`chk::chk_flag`, default `FALSE`) on `ssd_define_scenario()` and validated as a flag on `ssd_hc_sims()`. A vector `ci` now aborts.
- **`ci` leaves `task_axes("hc")`** — it is neither a path nor an inner axis and does not enter the per-task RNG primer. It rides as a **carried column** (the established `n_max` pattern), so both runners read it unchanged.
- **The `ci = FALSE` collapse is retired.** `hc_grid_tbl()` is now a single-branch grid keyed by the scalar `ci` (no `bind_rows` branching); bootstrap-only knobs stay canonically `NA` when `ci = FALSE`.
- **The bootstrap-knob guard stays**, simplified, with `ci = TRUE` as the enablement path (was `ci = c(FALSE, TRUE)`).
- **The constructor signature is regrouped by role** so the simulation settings (`proportion`, `ci`, `samples`) are contiguous after the cross-join axes; the stored `scenario$hc` list and `print()` follow suit.

## Impact

- **Behaviour (breaking, pre-release):** `ci = c(FALSE, TRUE)` now errors; callers pick a scalar. Estimates are unchanged. Because `ci` leaves the primer, the per-task RNG stream for the hc step shifts, so bootstrap CIs (`lcl`/`ucl`/`se`) change value for a given seed — point estimates do not. Snapshots (`scenario.md`, `task-lists.md`, new `hc-sims.md`) re-baseline.
- Docs (`R/params.R`, regenerated `man/`), the large targets template, `scripts/example2.R`, and the `defining-a-scenario` vignette all move from `ci = c(FALSE, TRUE)` to a scalar. `TARGETS-DESIGN.md`/`GLOSSARY.md` were already updated as part of the change artifacts.

## Verification

- `air format .` clean
- `devtools::document()` regenerates `man/` cleanly
- `devtools::test()` — all pass (493)
- `devtools::check()` — 0 errors, 0 notes (1 environment-only `qpdf` warning)
- `openspec validate scalar-ci-flag --strict` passes

Implements the `scalar-ci-flag` OpenSpec change.

https://claude.ai/code/session_01R98starGj3A5kiZxUwHVmj

---
_Generated by [Claude Code](https://claude.ai/code/session_01R98starGj3A5kiZxUwHVmj)_