### PR TITLE
refactor: canonicalise `seed` position in `ssd_define_scenario()` call sites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,14 @@ chk::chk_character(dataset_names)
   `rlang::is_function()` over `get()` / `getExportedValue()` / `is.function()`.
 - Reserve the `with_`/`local_` prefixes for RAII (withr-style) scope helpers; do
   not use them for ordinary transforms (e.g. name a column-adder `add_*()`).
+- **Canonical argument order**: at every call site, pass arguments in signature
+  order. In particular, lead `ssd_define_scenario()` calls with its three
+  required arguments — `data` (positional), then `nsim =`, then `seed =` — before
+  any `...` knob (`nrow`, `dists`, `rescale`, …). `seed` is the scenario's RNG
+  root (an RNG term, **not** a simulation setting/grid knob — see `GLOSSARY.md`),
+  so it belongs up front with `data`/`nsim`, never wedged between knobs like
+  `nrow`. A full package-wide sweep of remaining call sites for this and the
+  other public constructors is a `TARGETS-DESIGN.md` §12 cleanup item.
 - Permissions for the common tooling (`air`, `R`, `Rscript`, read-only `git`/`gh`,
   `quarto`, `Skill`) are pre-approved in `.claude/settings.json`, so these run
   without a prompt.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -6,7 +6,11 @@ Terminology used throughout `ssdsims`.
 
 - **seed**: A scalar integer passed to `base::set.seed()` (or the
   `seed` argument of `dqrng::dqset.seed()`). Both base R and dqrng
-  accept a single integer as the seed.
+  accept a single integer as the seed. In `ssd_define_scenario()` it is
+  the scenario's RNG root — one of the three **required positional**
+  arguments (`data, nsim, seed`), **not** a grid **axis** or a
+  **simulation setting** (below). Its canonical call-site slot is third,
+  immediately after `nsim` and before any `...` knob (e.g. `nrow`).
 - **state**: The full internal state of an RNG. For L'Ecuyer-CMRG,
   the state is a length-7 integer vector assignable to
   `.Random.seed` (it cannot be passed to `set.seed()`). For dqrng,

--- a/R/scenario.R
+++ b/R/scenario.R
@@ -110,7 +110,7 @@
 #' @return An S3 object of class `ssdsims_scenario`.
 #' @export
 #' @examples
-#' ssd_define_scenario(ssddata::ccme_boron, nsim = 100L, nrow = c(5L, 10L), seed = 42L)
+#' ssd_define_scenario(ssddata::ccme_boron, nsim = 100L, seed = 42L, nrow = c(5L, 10L))
 ssd_define_scenario <- function(
   data,
   nsim,

--- a/TARGETS-DESIGN.md
+++ b/TARGETS-DESIGN.md
@@ -2091,6 +2091,17 @@ public-API or ergonomics gaps.
   name resolution, remaining `*apply()` loops) for the same convention, so new
   and existing code read consistently. Surfaced in PR #101 review. Independent
   tidy-up with no dependants; not on the dependency DAG.
+- **`canonical-call-sites`** — Sweep call sites of the public constructors so
+  arguments are passed in signature order. The first pass canonicalised every
+  `ssd_define_scenario()` call (R examples, tests, fixtures, scripts, vignettes,
+  and the shipped `inst/targets-templates/`) to lead with the required trio
+  `data, nsim, seed` before any `...` knob — `seed` is the scenario's RNG root,
+  not a grid axis or simulation setting, so it sits third rather than wedged
+  between knobs like `nrow`. The convention is recorded in `AGENTS.md` (Coding
+  rules) and `GLOSSARY.md` (the `seed` entry). This item revisits the remaining
+  constructors (`ssd_data()`, the `ssd_run_*`/`ssd_scenario_*` family) for the
+  same ordering. Independent tidy-up with no dependants; not on the dependency
+  DAG.
 
 ### Archived
 

--- a/inst/targets-templates/large/scenario.R
+++ b/inst/targets-templates/large/scenario.R
@@ -9,6 +9,7 @@ library(ssdsims)
 scenario <- ssd_define_scenario(
   ssddata::ccme_boron,
   nsim = 2L,
+  seed = 42L,
   nrow = c(5L, 10L), # c(5L, 6L, 10L, 20L, 50L),
   proportion = c(0.01, 0.05, 0.1, 0.2),
   est_method = c("arithmetic", "geometric", "multi"),
@@ -25,7 +26,6 @@ scenario <- ssd_define_scenario(
   parametric = TRUE,
   nboot = c(5, 50), # c(1, 5, 10, 50, 100, 500), # * 100,
   samples = TRUE,
-  seed = 42L,
   bundle = list(
     hc = c("ci_method", "est_method")
   )

--- a/inst/targets-templates/small/scenario.R
+++ b/inst/targets-templates/small/scenario.R
@@ -7,7 +7,7 @@ library(ssdsims)
 scenario <- ssd_define_scenario(
   ssddata::ccme_boron,
   nsim = 2L,
+  seed = 42L,
   nrow = c(5L, 10L),
-  rescale = c(FALSE, TRUE),
-  seed = 42L
+  rescale = c(FALSE, TRUE)
 )

--- a/man/ssd_define_scenario.Rd
+++ b/man/ssd_define_scenario.Rd
@@ -200,5 +200,5 @@ are meaningless; passing any of them in that case is an error, so set
 }
 
 \examples{
-ssd_define_scenario(ssddata::ccme_boron, nsim = 100L, nrow = c(5L, 10L), seed = 42L)
+ssd_define_scenario(ssddata::ccme_boron, nsim = 100L, seed = 42L, nrow = c(5L, 10L))
 }

--- a/scripts/example2.R
+++ b/scripts/example2.R
@@ -36,8 +36,8 @@ datasets <- ssd_data(
 scenario <- ssd_define_scenario(
   datasets,
   nsim = 3L,
-  nrow = c(5L, 10L, 20L),
   seed = 42L,
+  nrow = c(5L, 10L, 20L),
   dists = c("lnorm", "gamma"),
   proportion = c(0.05, 0.2),
   ci = TRUE,

--- a/tests/testthat/_snaps/scenario.md
+++ b/tests/testthat/_snaps/scenario.md
@@ -143,8 +143,8 @@
 # scenario-definition: ssd_data() collection plus name= is an error
 
     Code
-      ssd_define_scenario(ssd_data(boron = ssddata::ccme_boron), nsim = 2L, name = "x",
-      seed = 1L)
+      ssd_define_scenario(ssd_data(boron = ssddata::ccme_boron), nsim = 2L, seed = 1L,
+      name = "x")
     Condition
       Error in `ssd_define_scenario()`:
       ! `name` must not be supplied when `data` is an `ssd_data()` collection.
@@ -161,8 +161,8 @@
 # scenario-definition: named list plus name= is an error
 
     Code
-      ssd_define_scenario(list(boron = ssddata::ccme_boron), nsim = 2L, name = "x",
-      seed = 1L)
+      ssd_define_scenario(list(boron = ssddata::ccme_boron), nsim = 2L, seed = 1L,
+      name = "x")
     Condition
       Error in `ssd_define_scenario()`:
       ! `name` must not be supplied with a named list of datasets.
@@ -279,7 +279,8 @@
 # scenario-definition: print is stable for a single dataset
 
     Code
-      ssd_define_scenario(ssddata::ccme_boron, nsim = 100L, nrow = c(5L, 10L), seed = 42L)
+      ssd_define_scenario(ssddata::ccme_boron, nsim = 100L, seed = 42L, nrow = c(5L,
+        10L))
     Output
       <ssdsims_scenario>
         seed:     42
@@ -316,7 +317,7 @@
 
     Code
       ssd_define_scenario(list(boron = ssddata::ccme_boron, cadmium = ssddata::ccme_cadmium),
-      nsim = 50L, nrow = c(5L, 6L, 10L), seed = 1L, rescale = c(FALSE, TRUE),
+      nsim = 50L, seed = 1L, nrow = c(5L, 6L, 10L), rescale = c(FALSE, TRUE),
       computable = c(FALSE, TRUE), at_boundary_ok = c(TRUE, FALSE), range_shape1 = list(
         c(0.05, 20), c(0.1, 10)), proportion = c(0.05, 0.1), ci = TRUE, nboot = c(100,
         1000), est_method = c("multi", "geometric"), ci_method = c("weighted_samples",

--- a/tests/testthat/_snaps/task-lists.md
+++ b/tests/testthat/_snaps/task-lists.md
@@ -17,7 +17,7 @@
 
     Code
       ssd_scenario_fit_tasks(ssd_define_scenario(ssddata::ccme_boron, nsim = 1L,
-      nrow = c(5L, 10L), seed = 42L, rescale = c(FALSE, TRUE)))
+      seed = 42L, nrow = c(5L, 10L), rescale = c(FALSE, TRUE)))
     Output
       <ssdsims_tasks: fit>
         axes:  dataset, sim, replace, nrow, rescale, computable, at_boundary_ok, min_pmix, range_shape1, range_shape2
@@ -53,9 +53,8 @@
 # task-lists: printing a task set reports per-step counts
 
     Code
-      ssd_scenario_tasks(ssd_define_scenario(ssddata::ccme_boron, nsim = 2L, nrow = c(
-        5L, 10L), seed = 42L, rescale = c(FALSE, TRUE), ci = TRUE, nboot = c(10L,
-        100L)))
+      ssd_scenario_tasks(ssd_define_scenario(ssddata::ccme_boron, nsim = 2L, seed = 42L,
+      nrow = c(5L, 10L), rescale = c(FALSE, TRUE), ci = TRUE, nboot = c(10L, 100L)))
     Output
       <ssdsims_task_set>
         sample tasks: 2

--- a/tests/testthat/fixtures/byte-identity-targets.R
+++ b/tests/testthat/fixtures/byte-identity-targets.R
@@ -8,8 +8,8 @@ library(ssdsims)
 scenario <- ssd_define_scenario(
   ssd_data(d = readRDS("data.rds")),
   nsim = 2L,
-  nrow = c(5L, 10L),
   seed = 42L,
+  nrow = c(5L, 10L),
   rescale = c(FALSE, TRUE),
   dists = c("lnorm", "gamma")
 )

--- a/tests/testthat/fixtures/dataset-growth-targets.R
+++ b/tests/testthat/fixtures/dataset-growth-targets.R
@@ -15,8 +15,8 @@ datasets <- readRDS("datasets.rds")
 scenario <- ssd_define_scenario(
   do.call(ssd_data, datasets),
   nsim = 1L,
-  nrow = 6L,
   seed = 42L,
+  nrow = 6L,
   dists = "lnorm",
   partition_by = list(
     sample = c("dataset", "sim"),

--- a/tests/testthat/fixtures/error-null-targets.R
+++ b/tests/testthat/fixtures/error-null-targets.R
@@ -11,8 +11,8 @@ boom <- function(n) stop("boom")
 scenario <- ssd_define_scenario(
   ssd_data(d = readRDS("data.rds")),
   nsim = 2L,
-  nrow = 6L,
   seed = 42L,
+  nrow = 6L,
   dists = "lnorm",
   min_pmix = boom
 )

--- a/tests/testthat/fixtures/factory-invalidation-targets.R
+++ b/tests/testthat/fixtures/factory-invalidation-targets.R
@@ -10,8 +10,8 @@ library(ssdsims)
 scenario <- ssd_define_scenario(
   ssd_data(d = readRDS("data.rds")),
   nsim = 2L,
-  nrow = 6L,
   seed = 42L,
+  nrow = 6L,
   dists = "lnorm",
   partition_by = list(
     sample = c("dataset", "sim"),

--- a/tests/testthat/fixtures/inner-growth-targets.R
+++ b/tests/testthat/fixtures/inner-growth-targets.R
@@ -24,8 +24,8 @@ min_pmix <- if (isTRUE(readRDS("grow.rds"))) {
 scenario <- ssd_define_scenario(
   ssd_data(d = readRDS("data.rds")),
   nsim = 2L,
-  nrow = 6L,
   seed = 42L,
+  nrow = 6L,
   dists = "lnorm",
   min_pmix = min_pmix,
   partition_by = list(

--- a/tests/testthat/fixtures/nsim-growth-targets.R
+++ b/tests/testthat/fixtures/nsim-growth-targets.R
@@ -12,8 +12,8 @@ library(ssdsims)
 scenario <- ssd_define_scenario(
   ssd_data(d = readRDS("data.rds")),
   nsim = readRDS("nsim.rds"),
-  nrow = 6L,
   seed = 42L,
+  nrow = 6L,
   dists = "lnorm",
   partition_by = list(
     sample = c("dataset", "sim"),

--- a/tests/testthat/fixtures/slice-invalidation-targets.R
+++ b/tests/testthat/fixtures/slice-invalidation-targets.R
@@ -13,8 +13,8 @@ knobs <- readRDS("knobs.rds")
 scenario <- ssd_define_scenario(
   ssd_data(d = readRDS("data.rds")),
   nsim = 1L,
-  nrow = 6L,
   seed = 42L,
+  nrow = 6L,
   dists = knobs$dists,
   samples = knobs$samples,
   partition_by = list(

--- a/tests/testthat/test-accessors.R
+++ b/tests/testthat/test-accessors.R
@@ -53,8 +53,8 @@ test_that("scenario-accessors: baseline runner's default min_pmix is unchanged",
   scenario <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 1L,
-    nrow = 6L,
     seed = 42L,
+    nrow = 6L,
     dists = "lnorm"
   )
   out1 <- ssd_run_scenario_baseline(scenario)

--- a/tests/testthat/test-path-axis-growth.R
+++ b/tests/testthat/test-path-axis-growth.R
@@ -37,8 +37,8 @@ test_that("path-axis-growth: appending a dataset builds only the new dataset's s
   scenario <- ssd_define_scenario(
     ssd_data(d1 = numeric_dataset()),
     nsim = 1L,
-    nrow = 6L,
     seed = 42L,
+    nrow = 6L,
     dists = "lnorm",
     partition_by = growth_partition_by
   )
@@ -92,8 +92,8 @@ test_that("path-axis-growth: growing nsim builds only the new sim cells' shards 
   scenario <- ssd_define_scenario(
     ssd_data(d = numeric_dataset()),
     nsim = 2L,
-    nrow = 6L,
     seed = 42L,
+    nrow = 6L,
     dists = "lnorm",
     partition_by = growth_partition_by
   )

--- a/tests/testthat/test-scenario.R
+++ b/tests/testthat/test-scenario.R
@@ -52,8 +52,8 @@ test_that("scenario-definition: minimal construction stores declarative fields",
   s <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 100L,
-    nrow = c(5L, 10L),
-    seed = 42L
+    seed = 42L,
+    nrow = c(5L, 10L)
   )
   expect_s3_class(s, "ssdsims_scenario")
   expect_identical(s$seed, 42L)
@@ -236,15 +236,15 @@ test_that("scenario-accessors: materialisation does not change fit-task primers"
   s_a <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 1L,
-    nrow = 6L,
     seed = 1L,
+    nrow = 6L,
     min_pmix = list(shared = f_a)
   )
   s_b <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 1L,
-    nrow = 6L,
     seed = 1L,
+    nrow = 6L,
     min_pmix = list(shared = f_b)
   )
   # The stored functions differ, but the name (the identity surface) does not.
@@ -534,8 +534,8 @@ test_that("scenario-definition: ssd_data() collection plus name= is an error", {
     ssd_define_scenario(
       ssd_data(boron = ssddata::ccme_boron),
       nsim = 2L,
-      name = "x",
-      seed = 1L
+      seed = 1L,
+      name = "x"
     )
   })
 })
@@ -549,8 +549,8 @@ test_that("scenario-definition: single data frame accepts an explicit name", {
   s <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 2L,
-    name = "boron_data",
-    seed = 1L
+    seed = 1L,
+    name = "boron_data"
   )
   expect_identical(s$datasets, "boron_data")
 })
@@ -588,8 +588,8 @@ test_that("scenario-definition: named list plus name= is an error", {
     ssd_define_scenario(
       list(boron = ssddata::ccme_boron),
       nsim = 2L,
-      name = "x",
-      seed = 1L
+      seed = 1L,
+      name = "x"
     )
   })
 })
@@ -718,8 +718,8 @@ test_that("scenario-definition: print is stable for a single dataset", {
     ssd_define_scenario(
       ssddata::ccme_boron,
       nsim = 100L,
-      nrow = c(5L, 10L),
-      seed = 42L
+      seed = 42L,
+      nrow = c(5L, 10L)
     )
   )
 })
@@ -729,8 +729,8 @@ test_that("scenario-definition: print is stable for multiple datasets and vector
     ssd_define_scenario(
       list(boron = ssddata::ccme_boron, cadmium = ssddata::ccme_cadmium),
       nsim = 50L,
-      nrow = c(5L, 6L, 10L),
       seed = 1L,
+      nrow = c(5L, 6L, 10L),
       rescale = c(FALSE, TRUE),
       computable = c(FALSE, TRUE),
       at_boundary_ok = c(TRUE, FALSE),

--- a/tests/testthat/test-shard-runner.R
+++ b/tests/testthat/test-shard-runner.R
@@ -25,8 +25,8 @@ test_that("shard-runner: per-task results match the in-memory baseline", {
   scenario <- ssd_define_scenario(
     ssd_data(d = sr_dataset()),
     nsim = 2L,
-    nrow = c(5L, 10L),
     seed = 42L,
+    nrow = c(5L, 10L),
     rescale = c(FALSE, TRUE),
     dists = c("lnorm", "gamma")
   )
@@ -94,8 +94,8 @@ test_that("shard-runner: a fit shard reads several sample shards (inner replace)
   scenario <- ssd_define_scenario(
     ssd_data(d = sr_dataset()),
     nsim = 1L,
-    nrow = 6L,
     seed = 42L,
+    nrow = 6L,
     replace = c(FALSE, TRUE),
     dists = "lnorm"
   )
@@ -120,8 +120,8 @@ test_that("shard-runner: an hc shard reads several fit shards (coarse hc)", {
   scenario <- ssd_define_scenario(
     ssd_data(d = sr_dataset()),
     nsim = 1L,
-    nrow = c(5L, 10L),
     seed = 42L,
+    nrow = c(5L, 10L),
     rescale = c(FALSE, TRUE),
     dists = "lnorm"
   )
@@ -143,8 +143,8 @@ test_that("shard-runner: shard count equals the path-cell count, not task count"
   scenario <- ssd_define_scenario(
     ssd_data(d = sr_dataset()),
     nsim = 2L,
-    nrow = c(5L, 10L),
     seed = 42L,
+    nrow = c(5L, 10L),
     rescale = c(FALSE, TRUE),
     dists = "lnorm"
   )
@@ -172,8 +172,8 @@ test_that("shard-runner: re-running yields identical per-task results", {
   scenario <- ssd_define_scenario(
     ssd_data(d = sr_dataset()),
     nsim = 2L,
-    nrow = 6L,
     seed = 42L,
+    nrow = 6L,
     dists = "lnorm"
   )
   run1 <- ssd_run_scenario_shards(scenario, dir = withr::local_tempdir())
@@ -224,8 +224,8 @@ test_that("shard-runner: fit step aborts when a parent sample draw is missing", 
   scenario <- ssd_define_scenario(
     ssd_data(d = sr_dataset()),
     nsim = 1L,
-    nrow = 6L,
     seed = 42L,
+    nrow = 6L,
     dists = "lnorm"
   )
   dir <- withr::local_tempdir()

--- a/tests/testthat/test-task-lists.R
+++ b/tests/testthat/test-task-lists.R
@@ -4,8 +4,8 @@ test_that("task-lists: sample table has D * nsim * R rows with axes populated", 
   scenario <- ssd_define_scenario(
     ssd_data(boron = ssddata::ccme_boron, cadmium = ssddata::ccme_cadmium),
     nsim = 3L,
-    nrow = c(5L, 10L),
-    seed = 42L
+    seed = 42L,
+    nrow = c(5L, 10L)
   )
   tasks <- ssd_scenario_sample_tasks(scenario)
   # D = 2 datasets, nsim = 3, R = 1 (replace defaults to FALSE)
@@ -32,8 +32,8 @@ test_that("task-lists: nrow does not multiply the sample draw; n_max is carried"
   scenario <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 4L,
-    nrow = c(5L, 10L, 20L),
-    seed = 42L
+    seed = 42L,
+    nrow = c(5L, 10L, 20L)
   )
   tasks <- ssd_scenario_sample_tasks(scenario)
   # 1 dataset * 4 sims * 1 replace = 4, not multiplied by the 3 nrow values
@@ -57,8 +57,8 @@ test_that("task-lists: fit table crosses sample identity x nrow x fit grid", {
   scenario <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 3L,
-    nrow = c(5L, 10L),
     seed = 42L,
+    nrow = c(5L, 10L),
     rescale = c(FALSE, TRUE)
   )
   sample_tasks <- ssd_scenario_sample_tasks(scenario)
@@ -146,8 +146,8 @@ test_that("task-lists: each table carries a path-style id and parent foreign key
   scenario <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 2L,
-    nrow = c(5L, 10L),
-    seed = 42L
+    seed = 42L,
+    nrow = c(5L, 10L)
   )
   tasks <- ssd_scenario_tasks(scenario)
   # path-style primary keys
@@ -202,8 +202,8 @@ test_that("task-lists: printing a task table is informative", {
       ssd_define_scenario(
         ssddata::ccme_boron,
         nsim = 1L,
-        nrow = c(5L, 10L),
         seed = 42L,
+        nrow = c(5L, 10L),
         rescale = c(FALSE, TRUE)
       )
     )
@@ -227,8 +227,8 @@ test_that("task-lists: ssd_scenario_tasks bundles the three task tables", {
   scenario <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 2L,
-    nrow = c(5L, 10L),
     seed = 42L,
+    nrow = c(5L, 10L),
     rescale = c(FALSE, TRUE),
     ci = TRUE
   )
@@ -246,8 +246,8 @@ test_that("task-lists: printing a task set reports per-step counts", {
       ssd_define_scenario(
         ssddata::ccme_boron,
         nsim = 2L,
-        nrow = c(5L, 10L),
         seed = 42L,
+        nrow = c(5L, 10L),
         rescale = c(FALSE, TRUE),
         ci = TRUE,
         nboot = c(10L, 100L)
@@ -262,8 +262,8 @@ test_that("task-lists: baseline runner threads sample -> fit -> hc", {
   scenario <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 1L,
-    nrow = c(5L, 6L),
     seed = 42L,
+    nrow = c(5L, 6L),
     dists = "lnorm"
   )
   tmp <- withr::local_tempdir()
@@ -288,8 +288,8 @@ test_that("task-lists: sub-truncation property holds across nrow", {
   scenario <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 1L,
-    nrow = c(5L, 10L),
     seed = 42L,
+    nrow = c(5L, 10L),
     dists = "lnorm"
   )
   out <- ssd_run_scenario_baseline(scenario)
@@ -306,8 +306,8 @@ test_that("parallel-safe-seeding: baseline runner is reproducible without an ext
   scenario <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 2L,
-    nrow = c(5L, 6L),
     seed = 42L,
+    nrow = c(5L, 6L),
     dists = "lnorm"
   )
   set.seed(1L)
@@ -333,8 +333,8 @@ test_that("parallel-safe-seeding: baseline runner results are order-independent"
   scenario <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 3L,
-    nrow = 6L,
     seed = 42L,
+    nrow = 6L,
     dists = "lnorm"
   )
   out <- ssd_run_scenario_baseline(scenario)
@@ -452,8 +452,8 @@ test_that("task-lists: task-table column contracts are pinned", {
   scenario <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 1L,
-    nrow = c(5L, 10L),
     seed = 42L,
+    nrow = c(5L, 10L),
     ci = TRUE
   )
   expect_snapshot({
@@ -495,8 +495,8 @@ test_that("scenario-definition: samples = TRUE works with multiple dists and ci 
   scenario <- ssd_define_scenario(
     ssd_data(d = data.frame(Conc = exp(seq(-1, 2, length.out = 20)))),
     nsim = 1L,
-    nrow = 6L,
     seed = 42L,
+    nrow = 6L,
     dists = c("lnorm", "gamma"),
     ci = FALSE,
     samples = TRUE

--- a/tests/testthat/test-task-shards.R
+++ b/tests/testthat/test-task-shards.R
@@ -7,8 +7,8 @@ test_that("task-shards: one shard row per partition_by path cell", {
   scenario <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 2L,
-    nrow = c(5L, 10L),
     seed = 42L,
+    nrow = c(5L, 10L),
     rescale = c(FALSE, TRUE)
   )
   fit_shards <- ssd_scenario_fit_shards(scenario)
@@ -24,8 +24,8 @@ test_that("task-shards: union of a step's shard tasks equals its task table", {
   scenario <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 2L,
-    nrow = c(5L, 10L),
     seed = 42L,
+    nrow = c(5L, 10L),
     ci = TRUE,
     nboot = 10L
   )
@@ -64,15 +64,15 @@ test_that("task-shards: a coarser partition_by bundles more tasks per shard", {
   base <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 2L,
-    nrow = c(5L, 10L),
     seed = 42L,
+    nrow = c(5L, 10L),
     rescale = c(FALSE, TRUE)
   )
   coarse <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 2L,
-    nrow = c(5L, 10L),
     seed = 42L,
+    nrow = c(5L, 10L),
     rescale = c(FALSE, TRUE),
     partition_by = list(
       sample = c("dataset", "sim", "replace"),
@@ -131,8 +131,8 @@ test_that("task-shards: step runners write one Parquet and read upstream by path
   scenario <- ssd_define_scenario(
     ssd_data(d = numeric_dataset()),
     nsim = 1L,
-    nrow = 6L,
     seed = 42L,
+    nrow = 6L,
     dists = "lnorm"
   )
   ss <- ssd_scenario_sample_shards(scenario)
@@ -175,8 +175,8 @@ test_that("task-shards: ssd_summarize unions landed hc shards without recomputat
   scenario <- ssd_define_scenario(
     ssd_data(d = numeric_dataset()),
     nsim = 2L,
-    nrow = 6L,
     seed = 42L,
+    nrow = 6L,
     dists = "lnorm"
   )
   ss <- ssd_scenario_sample_shards(scenario)
@@ -263,8 +263,8 @@ test_that("task-shards: pipeline per-task results equal the baseline runner", {
   scenario <- ssd_define_scenario(
     ssd_data(d = numeric_dataset()),
     nsim = 2L,
-    nrow = c(5L, 10L),
     seed = 42L,
+    nrow = c(5L, 10L),
     rescale = c(FALSE, TRUE),
     dists = c("lnorm", "gamma")
   )
@@ -378,8 +378,8 @@ test_that("hive: each child shard names exactly the parent shards it reads (m:n)
   scenario <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 2L,
-    nrow = 6L,
     seed = 42L,
+    nrow = 6L,
     dists = "lnorm",
     partition_by = list(
       sample = c("dataset", "sim"),
@@ -463,15 +463,15 @@ test_that("hive: widening max(nrow) changes the sample shard command (rewrite tr
   base <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 1L,
-    nrow = 6L,
     seed = 42L,
+    nrow = 6L,
     dists = "lnorm"
   )
   wide <- ssd_define_scenario(
     ssddata::ccme_boron,
     nsim = 1L,
-    nrow = c(6L, 12L),
     seed = 42L,
+    nrow = c(6L, 12L),
     dists = "lnorm"
   )
   s1 <- ssd_scenario_targets(base)[[1L]][["sample_step"]][[1L]]$command$expr
@@ -650,8 +650,8 @@ test_that("task-shards: factory per-task results equal the baseline (slice drops
   scenario <- ssd_define_scenario(
     ssd_data(d = numeric_dataset()),
     nsim = 1L,
-    nrow = 6L,
     seed = 42L,
+    nrow = 6L,
     dists = "lnorm",
     partition_by = list(
       sample = c("dataset", "sim"),

--- a/vignettes/defining-a-scenario.qmd
+++ b/vignettes/defining-a-scenario.qmd
@@ -97,8 +97,8 @@ knob with a sensible default.
 scenario <- ssd_define_scenario(
   datasets,
   nsim = 3L,
-  nrow = c(5L, 10L, 20L),
   seed = 42L,
+  nrow = c(5L, 10L, 20L),
   dists = c("lnorm", "gamma"),
   proportion = c(0.05, 0.2),
   ci = TRUE,

--- a/vignettes/sharded-pipeline.qmd
+++ b/vignettes/sharded-pipeline.qmd
@@ -60,8 +60,8 @@ per step, with at most one of `partition_by`/`bundle` naming a given step.
 scenario <- ssd_define_scenario(
   ssddata::ccme_boron,
   nsim = 2L,
-  nrow = c(5L, 10L),
   seed = 42L,
+  nrow = c(5L, 10L),
   rescale = c(FALSE, TRUE),
   dists = c("lnorm", "gamma")
 )


### PR DESCRIPTION
## Why

`seed` is the scenario's RNG root — an **RNG term**, not a grid axis or a
**simulation setting** (those are `proportion`/`ci`/`samples`; see `GLOSSARY.md`).
In the `ssd_define_scenario(data, nsim, seed, ..., nrow, …)` signature it is one
of the three **required positional** arguments, so its canonical call-site slot
is third — immediately after `nsim` and before any `...` knob.

Call sites had drifted: only short single-line calls used `data, nsim, seed`,
while the multi-line calls wedged `nrow` (a knob) **between** `nsim` and `seed`,
treating `seed` as if it were a mid-grid knob.

## What changes

- **Canonicalise ~54 call sites** so `seed` sits in position 3 (after `nsim`,
  before `nrow` and the other `...` knobs): R roxygen example, tests, fixtures,
  scripts, vignettes, and the shipped `inst/targets-templates/`.
- **Regenerate** `man/ssd_define_scenario.Rd` and **update two error-message
  snapshots** (`scenario.md`, `task-lists.md`) that echo the call expression.
- **Record the convention as a rule:**
  - `AGENTS.md` → Coding rules: a "Canonical argument order" bullet (primary home).
  - `GLOSSARY.md` → the `seed` entry: notes it is a required positional argument,
    not an axis/setting, with the canonical third slot.
  - `TARGETS-DESIGN.md` §12 Cleanup: a new `canonical-call-sites` tidy-up item
    recording this first pass and deferring the remaining constructors
    (`ssd_data()`, the `ssd_run_*`/`ssd_scenario_*` family) to the final cleanup.

## Behaviour

No behavioural change. The reorder touches only **named** arguments (R matches
these by name; only `data` stays positional and remains first), so results,
errors, and outputs are identical. Verified by 229 passing print/error/snapshot
tests. The targets-pipeline tests that fail in CI-less local runs do so only
because `tar_make()` subprocesses can't find the `load_all`'d package
(`packageNotFoundError`) — unrelated to this change and pre-existing.
