### PR TITLE
docs: Reclassify `dists` as fit-level simulation setting

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -81,12 +81,17 @@ Terminology used throughout `ssdsims`.
   per-task **primer**, or becomes a **shard**/**partition** level. Its effect
   is realised *inside* each task: it either fans out within the task's own
   output (`proportion` → one HC row per value) or is applied uniformly to
-  every task (`ci`, `samples`). Where an **axis** multiplies the *task graph*,
-  a simulation setting only shapes the *contents* of a task's result. "Scalar"
-  is a near-synonym but a misnomer for `proportion`, which is vector-valued
-  yet still not an axis. In the `ssd_define_scenario()` signature the
-  simulation settings (`proportion`, `ci`, `samples`) are grouped together,
-  after the axes and before the partitioning arguments.
+  every task (`dists`, `ci`, `samples`). Where an **axis** multiplies the
+  *task graph*, a simulation setting only shapes the *contents* of a task's
+  result. "Scalar" is a near-synonym but a misnomer for `proportion` (which is
+  vector-valued) and for `dists` (a character vector) — both are non-scalar
+  yet still not axes. Settings attach at different **steps**: `dists` is a
+  **fit**-level setting (the `dists` vector handed to every fit task), while
+  `proportion`, `ci`, and `samples` are **hc**-level. In the
+  `ssd_define_scenario()` signature the simulation settings (`dists`,
+  `proportion`, `ci`, `samples`) are grouped together, after the axes and
+  before the partitioning arguments (moving `dists` out of the fit-axis block
+  lands via the `dists-simulation-setting` change).
 - **partition**: A Hive directory level keyed by an axis value
   (e.g. `dataset=boron/sim=1/`). The Hive-partitioned layout is
   a *read-side* concept — query engines (duckplyr / DuckDB)
@@ -177,7 +182,13 @@ Terminology used throughout `ssdsims`.
 - **SSD**: Species sensitivity distribution: a distribution of species-level
   toxicity endpoints used in ecological risk assessment.
 - **`dists`**: The parametric distributions fit to the SSD data (e.g.
-  `lnorm`, `gamma`, `llogis`); see `ssdtools::ssd_fit_dists()`.
+  `lnorm`, `gamma`, `llogis`); see `ssdtools::ssd_fit_dists()`. A single
+  character vector defining *one* model-averaged fit, applied uniformly to
+  every fit task — a fit-level **simulation setting** (above), **not** a
+  cross-join **axis**: it is absent from `task_axes("fit")`, so it never
+  fans out, enters a **primer**, or becomes a **partition** level.
+  (Fanning out per-distribution would dissolve the model averaging that
+  defines a fit.)
 - **`fits`**: A `fitdists` object holding one or more fitted distributions.
 - **`hc`**: Hazard concentration: a quantile of the SSD at a given
   `proportion` (e.g. `hc5` is the 5% quantile); see `ssdtools::ssd_hc()`.
@@ -190,4 +201,10 @@ Terminology used throughout `ssdsims`.
 - **`ci_method`**: The method used to compute confidence intervals (e.g.
   `multi_fixed`, `weighted_samples`).
 - **`nboot`**: The number of bootstrap replicates used when computing
-  confidence intervals.
+  confidence intervals. An hc cross-join **axis** (`task_axes("hc")`):
+  distinct values fan out into separate tasks, primers, and shards, so
+  results can be partitioned by `nboot`. It enters the per-task **primer**,
+  giving each value an independent, reproducible bootstrap draw (the
+  bootstrap is the only RNG consumer in hc estimation; the point estimate is
+  analytic). See TARGETS-DESIGN.md §9 for why it stays in the primer rather
+  than sharing one stream across `nboot` values.

--- a/TARGETS-DESIGN.md
+++ b/TARGETS-DESIGN.md
@@ -1076,7 +1076,7 @@ rewritten with the new task set):
 | `nrow` value added (sub-trunc; not an axis) | rewrite all if `max(nrow)` grows; cached otherwise | inherits via prefix (open Q, §11) | inherits via prefix (open Q, §11) | re-run  |
 | `replace` value added (data path; fit/hc inner under default) | new shards only | rewrite all (`replace` ∈ fit inner) | rewrite all (`replace` ∈ hc inner) | re-run  |
 | `rescale` value added (fit path; hc inner under default) | cached    | new shards only                   | rewrite all (`rescale` ∈ hc inner) | re-run  |
-| `dists` change (fit inner)        | cached                            | rewrite all 4                     | rewrite all 2                     | re-run  |
+| `dists` change (fit setting, not an axis) | cached                    | rewrite all 4                     | rewrite all 2                     | re-run  |
 | `min_pmix` value (fit inner)      | cached                            | rewrite all 4                     | rewrite all 2                     | re-run  |
 | `nboot` value added (hc inner)    | cached                            | cached                            | rewrite all 2                     | re-run  |
 | `est_method` value added (hc inner) | cached                          | cached                            | rewrite all 2                     | re-run  |
@@ -1636,16 +1636,23 @@ comparison meaningful.
 | What you added             | Inner axis for…   | Cost                                  |
 | -------------------------- | ----------------- | ------------------------------------- |
 | new `min_pmix` name        | fit               | rewrite all fit shards (was K tasks each → now K+1) |
-| `dists` change             | fit               | rewrite all fit shards                 |
+| `dists` change             | fit (setting, not an axis — content rewrite) | rewrite all fit shards |
 | `nboot` value              | hc                | rewrite all hc shards                  |
 | `est_method` value         | hc                | rewrite all hc shards                  |
 | `ci_method` / `parametric` | hc                | rewrite all hc shards                  |
 
-**To avoid the rewrite cost**, move the axis into `partition_by`
+**To avoid the rewrite cost**, move the *axis* into `partition_by`
 for that step. The trade is shard count vs. cache reuse: pushing
 an axis into the path means future growth on that axis adds new
 shards instead of rewriting old ones, at the cost of producing
-more (smaller) Parquets up front.
+more (smaller) Parquets up front. This escape hatch applies only to
+the genuine inner *axes* (`min_pmix`, `nboot`, `est_method`,
+`ci_method`, `parametric`): they are in `task_axes(step)`, so they
+can be promoted to path axes. `dists` is in the table for its cost,
+not its category — it is a fit-level **simulation setting**, not an
+axis, so it cannot be a partition level and its rewrite is intrinsic
+(changing `dists` re-fits the *contents* of every fit task, rather
+than adding a row).
 
 ### 8.3 Pinning shards despite a code change — `tar_cue(depend = FALSE)`
 
@@ -1758,19 +1765,67 @@ sequence) is verified by `scripts/experiment-dqrng-hash.R`.
 
 Constraints the design lives with rather than solves.
 
-### `dists` and `nboot` are not fit/hc grid axes
+### No nested reuse of ssdtools' inner `dists` / `nboot` loops
 
 `dists` controls *which* distributions `ssdtools::ssd_fit_dists()`
 fits to a given data slice; `nboot` controls how many bootstrap
-iterations `ssdtools::ssd_hc()` runs. Both iterations live inside
-ssdtools and are not exposed at the ssdsims level. Adding a
-distribution to `dists` therefore invalidates every fit branch (the
-hash changes); raising `nboot` invalidates every hc branch. Reusing
-partial results — `nboot = 100` ⊂ `nboot = 1000` — would require
-either (a) wrapping each per-distribution / per-bootstrap iteration
-in ssdsims with its own dqrng stream and aggregating, or (b) an
-ssdtools change to expose the inner loops. Sketch only; out of
-scope.
+iterations `ssdtools::ssd_hc()` runs. Both loops live *inside*
+ssdtools and are not exposed at the ssdsims level, so neither
+nesting — `c("lnorm", "gamma") ⊂ c("lnorm", "gamma", "llogis")`,
+`nboot = 100 ⊂ nboot = 1000` — can be reused incrementally: a larger
+run re-fits or re-draws from scratch rather than extending the
+cached smaller one. Exploiting the nesting would require either (a)
+wrapping each per-distribution / per-bootstrap iteration in ssdsims
+with its own dqrng stream and aggregating, or (b) an ssdtools change
+to expose the inner loops. Sketch only; out of scope.
+
+The two knobs sit on **opposite** sides of the axis/setting split
+(GLOSSARY.md), and their cache behaviour differs accordingly — the
+heading is *not* "neither is an axis":
+
+- **`dists` is a fit-level *simulation setting*, not an axis.** It is
+  a single character vector applied uniformly to every fit task (one
+  model-averaged `ssd_fit_dists()` call per task); it is absent from
+  `task_axes("fit")`, so it never enters a **primer** or a
+  **partition**. Because a `dists` vector defines *one* model-averaged
+  fit, fanning out per-distribution would change the science, so it is
+  deliberately not an axis. Editing it (e.g. adding `llogis`) changes
+  the content fed to every fit task and re-fits the whole slice — the
+  "rewrite all fit shards" row of §8 — with no way to fit only the
+  added distribution and merge.
+- **`nboot` *is* an hc grid axis** (`task_axes("hc")`): distinct
+  values fan out into separate tasks, identities, and shards, so they
+  are cached independently and `partition_by[["hc"]]` may list
+  `nboot` to shard by it. Raising `nboot` does **not** invalidate the
+  existing branch — the smaller value keeps its own identity and shard
+  (the `nsim`-grow story, §8.1); what is unavailable is *content*
+  reuse **across** nboot values.
+
+**Why `nboot` enters the per-task primer (and `nrow` does not).**
+Bootstrapping is the *only* RNG consumer in hc estimation: `ssd_hc()`
+computes the point estimate `est` analytically from the fit,
+independent of the bootstrap and the RNG (§1.2), so a `ci = FALSE`
+task draws no random numbers at all and an hc task's RNG use is
+entirely the `nboot`-iteration bootstrap. The per-task primer
+(`task_primer()` over `task_axes("hc")`, which includes `nboot`)
+therefore gives **each `nboot` value its own dqrng stream** →
+statistically *independent* bootstrap draws, each fully reproducible
+on its own. The alternative — hashing the hc primer over
+`task_axes("hc")` *minus* `nboot` (decoupling the primer from the
+task identity, exactly as §5 keeps `nrow` out of the *sample* draw's
+primer) — would make every `nboot` value draw from one shared primed
+stream, so `nboot = 100`'s draws would be a **prefix** of
+`nboot = 1000`'s (a subset property), which is the RNG precondition
+that would make any future inner-loop reuse *coherent* (the extra 900
+draws continue the same stream rather than starting an independent
+one). We keep `nboot` **in** the primer because, unlike `nrow` —
+whose `head(sample, nrow)` truncation is *our* deterministic code,
+validated by `scripts/experiment-subset-property.R` — the bootstrap
+loop is *internal to ssdtools* (the opaque-RNG limitation below), so
+the prefix/subset property cannot be guaranteed or easily validated.
+Independent-stream-per-`nboot` is the honest, robust default; the
+shared-stream nesting is revisitable only if ssdtools exposes the
+loop or its prefix-stability is validated and pinned.
 
 ### `ssdtools` RNG flow is opaque
 
@@ -2102,6 +2157,18 @@ public-API or ergonomics gaps.
   constructors (`ssd_data()`, the `ssd_run_*`/`ssd_scenario_*` family) for the
   same ordering. Independent tidy-up with no dependants; not on the dependency
   DAG.
+
+- **`dists-simulation-setting`** — Reconcile `dists`'s classification across the
+  spec, signature, and docs. `dists` is absent from `task_axes("fit")` — a
+  fit-level **simulation setting** (one model-averaged `ssd_fit_dists()` per
+  task, applied uniformly), not a cross-join axis — but the `scenario-definition`
+  role-grouping requirement lists it among the axes and the signature wedges it
+  in the fit-axis block. This change moves `dists` to lead the contiguous
+  simulation-settings block (`… parametric, dists, proportion, ci, samples`),
+  corrects the spec, and sweeps call sites. Behaviour-preserving (no task-graph,
+  primer, or shard change); pairs with the §9 / GLOSSARY corrections that also
+  fixed the stale *"`dists` and `nboot` are not fit/hc grid axes"* heading
+  (`nboot` **is** an hc axis). Independent tidy-up; not on the dependency DAG.
 
 ### Archived
 

--- a/openspec/changes/dists-simulation-setting/.openspec.yaml
+++ b/openspec/changes/dists-simulation-setting/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-05

--- a/openspec/changes/dists-simulation-setting/design.md
+++ b/openspec/changes/dists-simulation-setting/design.md
@@ -1,0 +1,103 @@
+# Design — `dists` is a fit-level simulation setting
+
+## Context
+
+`ssd_define_scenario()` accepts `dists` (default `ssdtools::ssd_dists_bcanz()`),
+validated as a unique character vector and stored at `scenario$fit$dists`. At
+the fit step it is handed *whole* to one `ssd_fit_dists()` call per task
+(`R/task-lists.R:256`), uniformly across every fit task. It is **not** in
+`task_axes("fit")`, so it does not fan out, does not enter the per-task primer,
+and is not partition-eligible.
+
+That makes `dists` a **simulation setting** by the glossary definition. Yet the
+`scenario-definition` spec's `Constructor arguments are grouped by role`
+requirement lists `dists` among the cross-join axes and places it in the
+fit-axis block of the signature. This change reconciles the spec and signature
+with the implementation.
+
+## Two clarifications this change pins down
+
+### 1. "Inner axis" vs "simulation setting" — same cost, different mechanism
+
+These are easy to conflate because *adding a value to either* rewrites all
+shards of the step. They are categorically different:
+
+| | **inner axis** (e.g. `nboot`, `est_method`, bundled `rescale`) | **simulation setting** (e.g. `dists`, `ci`, `samples`, `proportion`) |
+|---|---|---|
+| In `task_axes(step)`? | **yes** | **no** |
+| Multiplies the task graph? | yes — one new **task** per value | no — same task count |
+| Enters the per-task **primer** / identity? | yes | no |
+| On disk | an ordinary Parquet **column** varying row-to-row *inside* a shard (the complement of `partition_by`) | not a column-axis at all; realised in the task body |
+| What "adding a value" does | appends a **row** (a new task) to every shard → atomic rewrite | changes the **content** of every existing row (re-fit / re-estimate) → rewrite |
+| Escape hatch for the rewrite | **move it into `partition_by`** → new shards instead of rewrites | **none** — a setting can't be a partition level; the rewrite is intrinsic |
+
+So an **inner axis** is still a genuine cross-join axis — it has just been left
+out of `partition_by`, so its fan-out lives as columns *within* a shard rather
+than as Hive directories *across* shards (`path ⊎ inner = task_axes(step)`,
+GLOSSARY). A **simulation setting** is not an axis in either position: it never
+multiplies the task graph. `dists` adding a distribution and `nboot` adding a
+value both "rewrite all fit/hc shards", but `nboot`'s rewrite adds a *row per
+shard* (and can be avoided by sharding on `nboot`), whereas `dists`'s rewrite
+changes *existing rows' contents* and cannot be partitioned away.
+
+### 2. Why `nboot` enters the per-task primer (and what dropping it would buy)
+
+**Bootstrapping is the only RNG consumer in hc estimation.** `ssd_hc()`
+computes the point estimate `est` analytically from the fit, independent of the
+bootstrap and the RNG (TARGETS-DESIGN.md §1.2; verified byte-identical across
+`ci`). So a `ci = FALSE` hc task draws *no* random numbers, and the entire RNG
+footprint of an hc task is the `nboot`-iteration bootstrap resampling.
+
+The per-task primer is `task_primer()` over `task_axes("hc")`, which **includes
+`nboot`**. Two consequences and one alternative:
+
+- **Current (in the primer):** each distinct `nboot` value gets its own dqrng
+  stream → statistically **independent** bootstrap draws, each fully
+  reproducible standalone. `nboot = 100` and `nboot = 1000` share nothing.
+- **Alternative (out of the primer):** hash the hc primer over
+  `task_axes("hc")` *minus* `nboot`, decoupling the primer from the task
+  *identity* (which keeps `nboot`, so shards/rows still separate per value).
+  Then every `nboot` value would draw from **one shared primed stream**, so
+  `nboot = 100`'s draws would be a **prefix** of `nboot = 1000`'s — a subset
+  property exactly analogous to how §5 keeps `nrow` out of the *sample* draw's
+  primer (every `nrow` is a `head()` of one shared draw). This nested-draw
+  property is the RNG **precondition** that would make any future inner-loop
+  reuse *coherent*: the extra 900 iterations continue the same stream instead
+  of starting an independent one. It does **not**, by itself, save computation
+  (ssdtools still runs 1000 from scratch — §9).
+
+**Why we keep `nboot` in the primer.** Unlike `nrow` — whose
+`head(sample, nrow)` truncation is *our* deterministic code, validated by
+`scripts/experiment-subset-property.R` — the bootstrap loop is *internal to
+ssdtools* (the opaque-RNG limitation, §9). We cannot guarantee or cheaply
+validate that ssdtools consumes the stream as a stable prefix across `nboot`,
+so the subset property is not assured. Independent-stream-per-`nboot` is the
+honest, robust default: each value is reproducible on its own with no reliance
+on hidden draw order. The shared-stream nesting becomes worth revisiting only
+if ssdtools exposes the bootstrap loop, or its prefix-stability is validated and
+version-pinned the way `sample.int` is for `nrow`.
+
+This change does **not** alter primer behaviour; it records the rationale so the
+decision is explicit. Dropping `nboot` from the primer would be a separate
+change with statistical implications (it sacrifices inter-`nboot` independence)
+and a new fragility (reliance on opaque prefix-stability).
+
+## Signature placement
+
+`dists` is a *fit*-level setting while `proportion`/`ci`/`samples` are *hc*-level.
+To honour "simulation settings are contiguous" we place `dists` **first** in the
+settings block (fit before hc): `… nboot, est_method, ci_method, parametric,`
+**`dists, proportion, ci, samples,`** `partition_by, bundle, upload`. Storage is
+unchanged and step-based: `dists` stays in `scenario$fit`, the hc settings in
+`scenario$hc`. All reordered formals follow `...`, so call sites name them and
+the reorder is behaviour-preserving.
+
+## Alternatives considered
+
+- **Leave `dists` in the fit-axis block, just fix the prose.** Rejected: the
+  chosen resolution is strict contiguity of settings (the role-grouping
+  requirement already mandates it for `proportion`/`ci`/`samples`).
+- **Make `dists` a real fit axis (fan out per dists-set).** Rejected: a single
+  character vector cannot express multiple sets, and per-distribution fan-out
+  would destroy model averaging — it would change the science, not just the
+  plumbing.

--- a/openspec/changes/dists-simulation-setting/proposal.md
+++ b/openspec/changes/dists-simulation-setting/proposal.md
@@ -1,0 +1,76 @@
+## Why
+
+The `scenario-definition` spec (`Constructor arguments are grouped by role`)
+lists `dists` among the **cross-join axes** — "the grid knobs that fan out over
+tasks". The implementation disagrees: `task_axes("fit")` does **not** contain
+`dists` (`R/task-lists.R:363`). `dists` is a single character vector passed
+*whole* and *uniformly* to one `ssdtools::ssd_fit_dists()` call per fit task
+(`R/task-lists.R:256`); it never fans out, enters a per-task **primer**, or
+becomes a **partition** level. Fanning out per-distribution would dissolve the
+model averaging that *defines* one fit, so `dists` is deliberately not an axis.
+
+By the glossary's own definition, `dists` is therefore a **simulation setting**
+(absent from `task_axes(step)`, consumed within each task, applied uniformly —
+the same category as `ci` and `samples`). It is the *fit*-level setting, where
+`proportion`/`ci`/`samples` are hc-level. The spec's role-grouping requirement
+both mis-labels it as an axis and, consequently, positions it in the fit-axis
+block of the signature rather than with the other simulation settings.
+
+This was surfaced while correcting the related TARGETS-DESIGN.md §9 limitation
+(*"`dists` and `nboot` are not fit/hc grid axes"*), whose heading was wrong
+about `nboot`: `nboot` **is** an hc axis (`task_axes("hc")`). The design-doc and
+glossary corrections land directly; this change carries the matching
+`scenario-definition` **spec** correction and the signature move, per the
+OpenSpec workflow.
+
+## What Changes
+
+- **Re-classify `dists` as a fit-level simulation setting** in the
+  `Constructor arguments are grouped by role` requirement: remove it from the
+  cross-join-axes clause (2) and name it in the simulation-settings clause (3),
+  alongside `proportion`/`ci`/`samples`. The taxonomy stays binary: a knob is
+  either an axis (in `task_axes(step)`) or a simulation setting.
+- **Move `dists` in the `ssd_define_scenario()` signature** out of the fit-axis
+  block to the contiguous simulation-settings block, leading it (fit setting
+  before the hc settings): `… parametric, dists, proportion, ci, samples,
+  partition_by, …`. All these formals follow `...` and are name-only at the
+  call site, so the reorder is behaviour-preserving.
+- **Keep storage step-based**: `dists` remains stored at `scenario$fit$dists`
+  (it shapes the fit). `print.ssdsims_scenario()` renders it among the fit
+  knobs but marked as a setting, not an axis.
+- **Sweep call sites** (`canonical-call-sites` convention) so examples,
+  fixtures, tests, scripts, vignettes, and `inst/targets-templates/` pass the
+  constructor arguments in the new signature order.
+
+No change to the task graph, primers, shard layout, or any computed result:
+`dists` was never an axis in code. This change makes the spec, the signature,
+and the docs agree with the implementation.
+
+## Capabilities
+
+### New Capabilities
+<!-- None: this corrects/extends the existing scenario-definition capability. -->
+
+### Modified Capabilities
+- `scenario-definition`: The `Constructor arguments are grouped by role`
+  requirement is corrected so `dists` is a fit-level **simulation setting**
+  (not a cross-join axis) and sits in the contiguous simulation-settings block
+  of the signature, while remaining stored under `scenario$fit`.
+
+## Impact
+
+- **Spec**: `openspec/specs/scenario-definition/spec.md` — the role-grouping
+  requirement and its `Simulation settings are contiguous` / `Print groups the
+  hc knobs by role` scenarios.
+- **Code**: `R/scenario.R` (signature reorder; `print.ssdsims_scenario()` if it
+  positions `dists`). No change to `R/task-lists.R` (`task_axes()` already
+  excludes `dists`).
+- **Call sites**: examples in `@examples`, `tests/`, `scripts/`, `vignettes/`,
+  `inst/targets-templates/` reordered to signature order (name-only args).
+- **Docs**: `man/` regenerated; `GLOSSARY.md` and `TARGETS-DESIGN.md` already
+  corrected ahead of this change (the conceptual classification); the glossary's
+  "moving `dists` … lands via the `dists-simulation-setting` change" note
+  resolves when this change is applied.
+- **Risk**: low — behaviour-preserving signature reorder of name-only formals;
+  no result, primer, or shard changes. Snapshot tests that print a scenario may
+  need re-recording.

--- a/openspec/changes/dists-simulation-setting/specs/scenario-definition/spec.md
+++ b/openspec/changes/dists-simulation-setting/specs/scenario-definition/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Constructor arguments are grouped by role
+`ssd_define_scenario()` SHALL order its arguments by role so that arguments of the same kind are contiguous, in this sequence: (1) the required data/`seed`/`nsim` inputs and the dataset `name`; (2) the **cross-join axes** — the grid knobs that fan out over tasks (`nrow`, `replace`, `rescale`, `computable`, `at_boundary_ok`, `min_pmix`, `range_shape1`, `range_shape2`, `nboot`, `est_method`, `ci_method`, `parametric`); (3) the **simulation settings** — the non-axis knobs consumed within each task (`dists`, `proportion`, `ci`, `samples`); (4) the **partitioning and remaining arguments** (`partition_by`, `bundle`, `upload`). A simulation setting is any knob absent from `task_axes(step)`: it never multiplies tasks, but is consumed inside each task — fanning out within the task's output (`proportion`) or applied uniformly (`dists`, `ci`, `samples`). `dists` is the **fit**-level simulation setting (a single character vector handed whole to every fit task's `ssd_fit_dists()` call, absent from `task_axes("fit")`); `proportion`/`ci`/`samples` are **hc**-level. The simulation settings SHALL be contiguous, with `dists` leading (fit before hc), so `dists`, `proportion`, `ci`, and `samples` sit together after the last axis (`parametric`) rather than `dists` being interleaved among the fit axes as it is today. Storage SHALL remain step-based: `dists` is stored at `scenario$fit$dists` and `proportion`/`ci`/`samples` at `scenario$hc`. The stored `scenario$hc` field and `print.ssdsims_scenario()` SHALL list the hc knobs in role order (hc axes, then the hc simulation settings `proportion`/`ci`/`samples`); `print.ssdsims_scenario()` SHALL render `dists` among the fit knobs, marked as a setting rather than an axis.
+
+#### Scenario: Simulation settings are contiguous and follow the axes
+- **WHEN** the `ssd_define_scenario()` signature is inspected
+- **THEN** `dists`, `proportion`, `ci`, and `samples` SHALL appear adjacent to one another, after the last cross-join axis (`parametric`) and before the partitioning arguments (`partition_by`, `bundle`, `upload`), with `dists` first
+
+#### Scenario: dists is a simulation setting, not an axis
+- **WHEN** the fit-step axis vocabulary (`task_axes("fit")`) is queried
+- **THEN** it SHALL NOT contain `"dists"`, so `dists` is neither a path axis nor an inner axis and does not enter the per-task primer; it is applied uniformly to every fit task and stored at `scenario$fit$dists`
+
+#### Scenario: Print groups the hc knobs by role
+- **WHEN** an `ssdsims_scenario` is printed
+- **THEN** the hc grid SHALL render the axes first (`nboot`, `est_method`, `ci_method`, `parametric`) and the simulation settings (`proportion`, `ci`, `samples`) together after them, and the fit knobs SHALL render `dists` marked as a setting

--- a/openspec/changes/dists-simulation-setting/tasks.md
+++ b/openspec/changes/dists-simulation-setting/tasks.md
@@ -1,0 +1,25 @@
+## 1. Signature and storage
+
+- [ ] 1.1 In `R/scenario.R`, move the `dists` formal out of the fit-axis block of `ssd_define_scenario()` to lead the simulation-settings block: `… parametric, dists, proportion, ci, samples, partition_by, bundle, upload`
+- [ ] 1.2 Confirm storage is unchanged — `dists` still validated as a unique character vector and stored at `scenario$fit$dists`; no change to `scenario$hc`
+- [ ] 1.3 Confirm `task_axes()` is untouched (it already excludes `dists`); no change to `R/task-lists.R`, primers, identities, or shard layout
+
+## 2. Print and docs
+
+- [ ] 2.1 Update `print.ssdsims_scenario()` so `dists` renders among the **fit** knobs marked as a setting (not an axis), the hc knobs keep role order (axes then `proportion`/`ci`/`samples`)
+- [ ] 2.2 Update the `ssd_define_scenario()` roxygen: document `dists` as a fit-level simulation setting; regenerate `man/`
+
+## 3. Call-site sweep (`canonical-call-sites`)
+
+- [ ] 3.1 Reorder `dists` to its new signature position in every `ssd_define_scenario()` call: `@examples`, `tests/`, `tests/testthat/_snaps/`, `scripts/`, `vignettes/`, and `inst/targets-templates/`
+- [ ] 3.2 Re-record any scenario `print()` snapshots affected by the fit/hc knob grouping
+
+## 4. Tests
+
+- [ ] 4.1 Assert `task_axes("fit")` excludes `"dists"` and that two scenarios differing only in `dists` produce identical fit/hc `*_id` keys and primers (behaviour-preserving: `dists` is not part of identity)
+- [ ] 4.2 Assert the signature order: `dists`, `proportion`, `ci`, `samples` are contiguous and follow `parametric`
+- [ ] 4.3 `air format` and `R CMD check` clean; `devtools::test()` green
+
+## 5. Sync
+
+- [ ] 5.1 After implementation, sync the `scenario-definition` delta into `openspec/specs/scenario-definition/spec.md` and resolve the GLOSSARY.md note ("moving `dists` … lands via the `dists-simulation-setting` change")


### PR DESCRIPTION
## Summary

Reconcile the classification of `dists` (and `nboot`) across the design docs, glossary, spec, and implementation.

The trigger was the stale TARGETS-DESIGN.md §9 limitation heading *"`dists` and `nboot` are not fit/hc grid axes"*. The code disagrees (`R/task-lists.R:363`):

- **`nboot` IS an hc grid axis** (`task_axes("hc")`) — it fans out, enters the per-task primer, and is partition-eligible. That is exactly how results are partitioned by `nboot`.
- **`dists` is NOT an axis** — it is a single character vector handed *whole and uniformly* to every fit task's `ssd_fit_dists()` call (`R/task-lists.R:256`), absent from `task_axes("fit")`. By the glossary's own definition it is a fit-level **simulation setting** (like `ci`/`samples`, but at the fit step). It can't be an axis: a `dists` vector defines one model-averaged fit, so per-distribution fan-out would change the science.

## What this branch actually contains (docs + proposal)

Per the agreed split — **design docs corrected now; the spec/signature change routed through OpenSpec** — this branch is doc-and-proposal only, no package code yet:

- **TARGETS-DESIGN.md §9** rewritten around the real limitation (no nested reuse of ssdtools' inner `dists`/`nboot` loops); two §8 cache tables and the "move the axis into `partition_by`" footer corrected (that escape hatch applies to inner *axes*, not to a setting).
- **GLOSSARY.md**: `dists` classified as a fit-level simulation setting; `nboot` documented as an hc axis that enters the primer.
- **New OpenSpec change `dists-simulation-setting`** (`proposal` / `design` / spec delta / `tasks`), validated by `openspec validate`, and registered in the §12 roadmap.

**No behaviour change in this branch** (no R touched). `task_axes()` already excludes `dists`, so primers, identities, shards, and results are unaffected.

## Planned by the OpenSpec change (not yet implemented here)

These are the change's `tasks.md`, to be applied in a follow-up (e.g. `/opsx:apply dists-simulation-setting`):

- Move `dists` in the `ssd_define_scenario()` signature out of the fit-axis block to lead the contiguous simulation-settings block: `… parametric, dists, proportion, ci, samples, partition_by, …` (all name-only formals after `...`, so the reorder is behaviour-preserving). Storage stays step-based (`scenario$fit$dists`).
- Correct the `scenario-definition` spec's role-grouping requirement and update `print.ssdsims_scenario()` to mark `dists` as a setting.
- Sweep call sites (`@examples`, `tests/`, `scripts/`, `vignettes/`, `inst/targets-templates/`) to the new order; re-record any affected print snapshots; regenerate `man/`; add a signature-order assertion.

## Design notes captured in the change

1. **Inner axis vs. simulation setting** — both rewrite all shards when changed, but differently: an *inner axis* (`nboot`, `est_method`) is in `task_axes(step)`, adds a *row* (new task) per shard, and can be moved into `partition_by` to avoid rewrites; a *simulation setting* (`dists`, `ci`, `samples`) is absent from `task_axes(step)`, changes the *content* of existing rows, and cannot be partitioned away (rewrite is intrinsic).
2. **Why `nboot` enters the per-task primer** — bootstrapping is the only RNG consumer in hc estimation (the point estimate is analytic). Each `nboot` value gets its own dqrng stream → independent, reproducible draws. The alternative (shared stream → `nboot=100` draws as a prefix of `nboot=1000`, the §5 `nrow` subset property) would rely on ssdtools' opaque bootstrap loop being prefix-stable, which is not guaranteed; so independent-stream-per-`nboot` is the robust default.

https://claude.ai/code/session_01Dd12PRVxDX9JJe7aQ4yet2