### PR TITLE
docs: Document keep-going error mode and pre-flight checks

### DIFF
--- a/R/targets-runner.R
+++ b/R/targets-runner.R
@@ -549,6 +549,16 @@ edge_block <- function(names) {
 #' ssd_scenario_targets(scenario)
 #' ```
 #'
+#' The shard and summary targets carry `error = "null"` so a shard whose body
+#' fails entirely goes `NULL` (its error readable via `tar_meta()`) without
+#' aborting the run, and `ssd_summarize()` unions whatever landed
+#' (TARGETS-DESIGN.md section 6.2). The shipped `_targets.R` templates pair this
+#' with a pipeline-wide **keep-going** default (`tar_option_set(error =
+#' "continue")`, the `make -k` analogue) so an errored target skips only its
+#' dependents while the rest of the shards still build; fail-fast pre-flight
+#' checks (upload/cluster connectivity) belong in a separate script run *before*
+#' `tar_make()`, not in this DAG.
+#'
 #' For each step it `tarchetypes::tar_map()`s one named, `format = "file"`,
 #' `error = "null"` target per `partition_by` path cell (the `names` are the
 #' step's path axes), and writes every shard and the summary under the

--- a/R/targets-runner.R
+++ b/R/targets-runner.R
@@ -556,8 +556,8 @@ edge_block <- function(names) {
 #' with a pipeline-wide **keep-going** default (`tar_option_set(error =
 #' "continue")`, the `make -k` analogue) so an errored target skips only its
 #' dependents while the rest of the shards still build; fail-fast pre-flight
-#' checks (upload/cluster connectivity) belong in a separate script run *before*
-#' `tar_make()`, not in this DAG.
+#' checks (upload/cluster connectivity) belong in a separate script the user
+#' runs *before* `tar_make()`, not in this DAG.
 #'
 #' For each step it `tarchetypes::tar_map()`s one named, `format = "file"`,
 #' `error = "null"` target per `partition_by` path cell (the `names` are the

--- a/TARGETS-DESIGN.md
+++ b/TARGETS-DESIGN.md
@@ -103,10 +103,16 @@ The most consequential design choices, with section refs:
   target, content-hashing skips re-uploading shards that did not
   change; `ssd_test_upload()` probes the backend at pipeline init,
   and the graph still builds and dry-runs with no credentials.
-- **Partial failures survive and stay visible (§6.2).** A shard body
+- **Partial failures survive and stay visible (§6.2).** The pipeline
+  runs **keep-going by default** — the shipped `_targets.R` templates set
+  `tar_option_set(error = "continue")`, the `make -k` analogue, so one
+  errored target skips only its dependents while every other reachable
+  shard still builds (a long parallel run is never lost to one bad
+  branch). On top of that, a shard body
   writes as many rows as ran successfully, so a bad task yields a
   *shorter* shard, not an abort; the step target errors (and carries
-  `error = "null"`) only in exceptional cases. A downstream
+  `error = "null"`, stronger still — its NULL flows downstream) only in
+  exceptional cases. A downstream
   `assert_<step>` target — sibling to `upload_<step>` — compares the
   shard's row count to the expected count and goes red on any
   shortfall, making incompleteness a first-class DAG node and the
@@ -1270,16 +1276,26 @@ combo). The scenario object does **not** carry secrets — it carries
 only the destination URL and container name. Their absence is what
 flips `ssd_upload_shard()` into its dry-run no-op.
 
-**Connectivity probe up front.** `ssd_test_upload(scenario)` performs
-a minimal round-trip (list the container, write and delete a small
-marker blob) and either returns silently or errors with the
-backend's diagnostic. The pipeline calls it once at the start of
-`tar_make()` so an auth or network failure aborts before any
-compute starts. Easy to run interactively too:
+**Connectivity probe up front, in a separate pre-flight script.**
+`ssd_test_upload(scenario)` performs a minimal round-trip (list the
+container, write and delete a small marker blob) and either returns
+silently or errors with the backend's diagnostic. It is a **fail-fast
+guard run *before* `tar_make()`, not a target inside the DAG** — the
+driver script (`run.R`) sources a standalone `preflight.R` first, so an
+auth or network failure aborts before any compute starts, *independent of
+the pipeline's keep-going error mode* (§6.2). Keeping it outside the DAG
+is deliberate and now the established pattern: the `cluster/` template
+does exactly this for its SLURM connectivity + worker-prerequisite probe
+(a standalone `preflight.R` sourced by `run.R`, kept out of `_targets.R`
+so that stays a clean scenario-and-factory definition), and the upload
+probe follows the same shape. A credentials check is a pre-condition for
+the *whole* run, not a per-shard concern, so it must not live in a target
+that `error = "continue"`/`"null"` would let slide past. The same call
+works interactively:
 
 ```r
 scenario <- ssd_scenario(..., upload = list(backend = "azure_blob", ...))
-ssd_test_upload(scenario)   # silent on success, throws on failure
+ssd_test_upload(scenario)   # silent on success, throws on failure — run before tar_make()
 tar_make()
 ```
 
@@ -1323,6 +1339,33 @@ So "see partial shard failures clearly" is the assert layer's job;
 (the exceptional case) is always out of date, so a re-driven
 `tar_make()` after a fix retries it (§8.4); a short shard is found by
 its red `assert_<step>` (also §8.4).
+
+**Keep-going is the pipeline default (`make -k`), and it is layered.**
+The shipped `_targets.R` templates set `tar_option_set(error =
+"continue")` — the `make -k` analogue — so a target that errors skips
+only its own dependents while every other reachable shard still builds;
+one bad branch never tears down a long parallel run. (It is a
+pipeline-wide *option*, so it sits in `_targets.R` next to the controller
+block, not in the `ssd_scenario_targets()` factory — which owns the
+*per-target* settings instead.) The shard, `assert_<step>`, and
+`upload_<step>` targets carry the stronger per-target `error = "null"`,
+which is *more* permissive than `make -k`: the errored target's value
+becomes `NULL` and its downstream still runs (a short/`NULL` shard flows
+on and is reported, above), where plain `make -k` would skip it. The two
+settings compose cleanly — a per-target `error` overrides the global
+default — so the global `continue` only governs the targets that carry no
+explicit override (e.g. an unexpected error in `summary` or a
+user-added target skips its dependents instead of aborting the run).
+Guards that *should* abort the whole run — the upload/cluster pre-flight
+(§6.1, §4) — deliberately live **outside** the DAG, in a separate
+pre-flight script run before `tar_make()`, so the keep-going default
+never swallows them. The trade we accept: under keep-going a *systemic*
+failure (every shard red because a package won't load) does not stop the
+pipeline on its own — but the operator watches the first few minutes,
+where a wall of red surfaces immediately, so optimising for *not losing a
+long run to one bad branch* beats stop-on-first-error. Override with an
+explicit `tar_option_set(error = "stop")` in `_targets.R` if a hard stop
+is ever wanted.
 
 Two constraints, both confirmed by the targets lab's failure spike:
 

--- a/TARGETS-DESIGN.md
+++ b/TARGETS-DESIGN.md
@@ -1280,22 +1280,26 @@ flips `ssd_upload_shard()` into its dry-run no-op.
 `ssd_test_upload(scenario)` performs a minimal round-trip (list the
 container, write and delete a small marker blob) and either returns
 silently or errors with the backend's diagnostic. It is a **fail-fast
-guard run *before* `tar_make()`, not a target inside the DAG** — the
-driver script (`run.R`) sources a standalone `preflight.R` first, so an
-auth or network failure aborts before any compute starts, *independent of
-the pipeline's keep-going error mode* (§6.2). Keeping it outside the DAG
-is deliberate and now the established pattern: the `cluster/` template
-does exactly this for its SLURM connectivity + worker-prerequisite probe
-(a standalone `preflight.R` sourced by `run.R`, kept out of `_targets.R`
-so that stays a clean scenario-and-factory definition), and the upload
-probe follows the same shape. A credentials check is a pre-condition for
-the *whole* run, not a per-shard concern, so it must not live in a target
-that `error = "continue"`/`"null"` would let slide past. The same call
-works interactively:
+guard the user runs *before* `tar_make()`, not a target inside the
+DAG** — running it is the **user's responsibility**, a documented
+pre-condition the pipeline neither contains nor can enforce. The
+standalone `preflight.R` carries the probe; the `run.R` driver runs it
+ahead of `tar_make()` as a convenience, but a bare `tar_make()` (or an
+interactive re-run) does not, so the user must ensure the pre-flight has
+run. Either way the check happens *independent of the pipeline's
+keep-going error mode* (§6.2). Keeping it outside the DAG is deliberate
+and now the established pattern: the `cluster/` template does exactly
+this for its SLURM connectivity + worker-prerequisite probe (a standalone
+`preflight.R` the user runs — `run.R` sources it as a convenience — kept
+out of `_targets.R` so that stays a clean scenario-and-factory
+definition), and the upload probe follows the same shape. A credentials
+check is a pre-condition for the *whole* run, not a per-shard concern, so
+it must not live in a target that `error = "continue"`/`"null"` would let
+slide past. The same call works interactively:
 
 ```r
 scenario <- ssd_scenario(..., upload = list(backend = "azure_blob", ...))
-ssd_test_upload(scenario)   # silent on success, throws on failure — run before tar_make()
+ssd_test_upload(scenario)   # silent on success, throws on failure — the user runs this before tar_make()
 tar_make()
 ```
 
@@ -1358,8 +1362,9 @@ explicit override (e.g. an unexpected error in `summary` or a
 user-added target skips its dependents instead of aborting the run).
 Guards that *should* abort the whole run — the upload/cluster pre-flight
 (§6.1, §4) — deliberately live **outside** the DAG, in a separate
-pre-flight script run before `tar_make()`, so the keep-going default
-never swallows them. The trade we accept: under keep-going a *systemic*
+pre-flight script the **user runs** before `tar_make()` (a documented
+pre-condition, not a target the pipeline enforces), so the keep-going
+default never swallows them. The trade we accept: under keep-going a *systemic*
 failure (every shard red because a package won't load) does not stop the
 pipeline on its own — but the operator watches the first few minutes,
 where a wall of red surfaces immediately, so optimising for *not losing a

--- a/inst/targets-templates/cluster/_targets.R
+++ b/inst/targets-templates/cluster/_targets.R
@@ -25,8 +25,13 @@ library(tarchetypes)
 library(ssdsims)
 
 # Ingredient B — the SLURM controller (the one editable block; see controller.R).
+# `error = "continue"` is the cluster-independent keep-going (`make -k`) default:
+# one failed shard/job skips only its dependents while the rest of the sweep
+# still runs (TARGETS-DESIGN.md §6.2). The connectivity/prerequisite fail-fast
+# guard is the separate `preflight.R` that `run.R` sources before `tar_make()`,
+# NOT a target here.
 source("controller.R")
-tar_option_set(controller = controller)
+tar_option_set(controller = controller, error = "continue")
 
 # Ingredient C — THE SCENARIO. Edit to taste. The same shape as
 # `large/scenario.R`: a wider study sweeping sample sizes, hazard proportions,

--- a/inst/targets-templates/cluster/_targets.R
+++ b/inst/targets-templates/cluster/_targets.R
@@ -28,8 +28,8 @@ library(ssdsims)
 # `error = "continue"` is the cluster-independent keep-going (`make -k`) default:
 # one failed shard/job skips only its dependents while the rest of the sweep
 # still runs (TARGETS-DESIGN.md §6.2). The connectivity/prerequisite fail-fast
-# guard is the separate `preflight.R` that `run.R` sources before `tar_make()`,
-# NOT a target here.
+# guard is the separate `preflight.R` the user runs before `tar_make()` (the
+# `run.R` driver runs it for you), NOT a target here.
 source("controller.R")
 tar_option_set(controller = controller, error = "continue")
 

--- a/inst/targets-templates/large/_targets.R
+++ b/inst/targets-templates/large/_targets.R
@@ -23,8 +23,8 @@ library(tarchetypes)
 #     its dependents while every other reachable shard still builds, so one bad
 #     branch never aborts the parallel run — it just leaves a gap the summary
 #     unions over. The factory's shard targets carry the stronger `error =
-#     "null"` on top; fail-fast pre-flight checks belong in a separate script run
-#     before `tar_make()`, not here (TARGETS-DESIGN.md §6.2).
+#     "null"` on top; fail-fast pre-flight checks belong in a separate script the
+#     user runs before `tar_make()`, not here (TARGETS-DESIGN.md §6.2).
 tar_option_set(
   controller = crew::crew_controller_local(workers = 8L),
   error = "continue"

--- a/inst/targets-templates/large/_targets.R
+++ b/inst/targets-templates/large/_targets.R
@@ -12,13 +12,22 @@
 library(targets)
 library(tarchetypes)
 
-# Parallelise the (independent) shard targets across local workers with a
-# mirai-backed `crew` controller. `targets` dispatches each ready shard target
-# to a worker, so the fit/hc shards of this wider study run concurrently. Tune
-# `workers` to your machine; swap in `crew.cluster` controllers for SLURM/PBS
-# etc. (`cluster-pipeline`, section 11). Needs the `crew` package installed.
+# Two pipeline-wide options:
+#   * controller — parallelise the (independent) shard targets across local
+#     workers with a mirai-backed `crew` controller. `targets` dispatches each
+#     ready shard target to a worker, so the fit/hc shards of this wider study
+#     run concurrently. Tune `workers` to your machine; swap in `crew.cluster`
+#     controllers for SLURM/PBS etc. (`cluster-pipeline`, section 11). Needs the
+#     `crew` package installed.
+#   * error = "continue" — keep-going (`make -k`): an errored target skips only
+#     its dependents while every other reachable shard still builds, so one bad
+#     branch never aborts the parallel run — it just leaves a gap the summary
+#     unions over. The factory's shard targets carry the stronger `error =
+#     "null"` on top; fail-fast pre-flight checks belong in a separate script run
+#     before `tar_make()`, not here (TARGETS-DESIGN.md §6.2).
 tar_option_set(
-  controller = crew::crew_controller_local(workers = 8L)
+  controller = crew::crew_controller_local(workers = 8L),
+  error = "continue"
 )
 
 # `scenario` is defined in scenario.R — shared with run-serial.R so both drivers

--- a/inst/targets-templates/small/_targets.R
+++ b/inst/targets-templates/small/_targets.R
@@ -17,7 +17,7 @@ library(tarchetypes)
 # its dependents while every other reachable shard still builds, so one bad
 # branch never aborts the run — it just leaves a gap the summary unions over.
 # The factory's shard targets carry the stronger `error = "null"` on top.
-# Fail-fast pre-flight checks belong in a separate script run before
+# Fail-fast pre-flight checks belong in a separate script the user runs before
 # `tar_make()`, not here (TARGETS-DESIGN.md §6.2).
 tar_option_set(error = "continue")
 

--- a/inst/targets-templates/small/_targets.R
+++ b/inst/targets-templates/small/_targets.R
@@ -13,6 +13,14 @@
 library(targets)
 library(tarchetypes)
 
+# Keep-going (`make -k`) is the pipeline default: an errored target skips only
+# its dependents while every other reachable shard still builds, so one bad
+# branch never aborts the run — it just leaves a gap the summary unions over.
+# The factory's shard targets carry the stronger `error = "null"` on top.
+# Fail-fast pre-flight checks belong in a separate script run before
+# `tar_make()`, not here (TARGETS-DESIGN.md §6.2).
+tar_option_set(error = "continue")
+
 # `scenario` is defined in scenario.R — shared with run-serial.R so both drivers
 # run the same study.
 source("scenario.R")

--- a/man/ssd_scenario_targets.Rd
+++ b/man/ssd_scenario_targets.Rd
@@ -37,6 +37,15 @@ scenario <- ssd_define_scenario(ssddata::ccme_boron, nsim = 2L, seed = 42L)
 ssd_scenario_targets(scenario)
 }\if{html}{\out{</div>}}
 
+The shard and summary targets carry \code{error = "null"} so a shard whose body
+fails entirely goes \code{NULL} (its error readable via \code{tar_meta()}) without
+aborting the run, and \code{ssd_summarize()} unions whatever landed
+(TARGETS-DESIGN.md section 6.2). The shipped \verb{_targets.R} templates pair this
+with a pipeline-wide \strong{keep-going} default (\code{tar_option_set(error = "continue")}, the \code{make -k} analogue) so an errored target skips only its
+dependents while the rest of the shards still build; fail-fast pre-flight
+checks (upload/cluster connectivity) belong in a separate script run \emph{before}
+\code{tar_make()}, not in this DAG.
+
 For each step it \code{tarchetypes::tar_map()}s one named, \code{format = "file"},
 \code{error = "null"} target per \code{partition_by} path cell (the \code{names} are the
 step's path axes), and writes every shard and the summary under the

--- a/man/ssd_scenario_targets.Rd
+++ b/man/ssd_scenario_targets.Rd
@@ -43,8 +43,8 @@ aborting the run, and \code{ssd_summarize()} unions whatever landed
 (TARGETS-DESIGN.md section 6.2). The shipped \verb{_targets.R} templates pair this
 with a pipeline-wide \strong{keep-going} default (\code{tar_option_set(error = "continue")}, the \code{make -k} analogue) so an errored target skips only its
 dependents while the rest of the shards still build; fail-fast pre-flight
-checks (upload/cluster connectivity) belong in a separate script run \emph{before}
-\code{tar_make()}, not in this DAG.
+checks (upload/cluster connectivity) belong in a separate script the user
+runs \emph{before} \code{tar_make()}, not in this DAG.
 
 For each step it \code{tarchetypes::tar_map()}s one named, \code{format = "file"},
 \code{error = "null"} target per \code{partition_by} path cell (the \code{names} are the


### PR DESCRIPTION
This PR documents the pipeline's error-handling strategy and makes the **keep-going (`make -k`) default** explicit in the shipped examples, aligning with the separate-script pre-flight pattern that landed in #115.

## Summary of Changes

- **`_targets.R` templates** (small, large, cluster): set `tar_option_set(error = "continue")` — the `make -k` analogue — so one errored target skips only its dependents while every other reachable shard still builds; a long parallel run is never lost to one bad branch. In `large`/`cluster` this merges into the existing `tar_option_set(controller = …)` block. Comments explain the rationale and that pre-flight checks belong in a separate script, not the DAG.

- **TARGETS-DESIGN.md**: §0 bullet states the keep-going default; §6.2 adds the **layered error model** (global `continue` for unguarded targets, the stronger per-shard `error = "null"` on top, fail-fast guards outside the DAG) plus the "operator watches the first few minutes" rationale; §6.1 reframes the upload pre-flight (`ssd_test_upload()`) as a standalone script the **user runs** before `tar_make()` — a documented pre-condition the pipeline does not contain or enforce (`run.R` runs it as a convenience, but a bare `tar_make()` does not), mirroring the cluster template's `preflight.R`, independent of the pipeline's error mode.

- **R/targets-runner.R** + **man/ssd_scenario_targets.Rd**: factory roxygen documents the per-target `error = "null"` and how the templates pair it with the pipeline-wide keep-going default.

## Pre-flight is the user's responsibility

Running the pre-flight check is the **user's responsibility** — a documented pre-condition, not a target the pipeline enforces. The `run.R` driver runs it before `tar_make()` as a convenience, but a bare `tar_make()` (or an interactive re-run) does not, so the user must ensure it has run. This is captured in the design, the factory roxygen, and the template comments.

## Placement decision

The global keep-going lives in `_targets.R` (next to the controller block), **not** in the `ssd_scenario_targets()` factory. Per-target `error = "null"` is intrinsic to *building each target* (the factory's job); the global `error = "continue"` is a *pipeline-wide option* that belongs in `_targets.R` where it's visible and editable. This also keeps the factory's contract (documented in the `task-shards` spec) unchanged.

## Rationale

The codebase already implemented the per-shard `error = "null"` survival path, but the global keep-going behavior was neither set nor documented (the default was an implicit `error = "stop"`). This PR makes it the explicit default and documents:
1. Why the pipeline doesn't stop on first error (one bad shard ≠ lost run)
2. Why pre-flight checks are separate scripts the user runs, not targets (they must abort the whole run, independent of the error mode)
3. How the two error modes (`error = "continue"` global + `error = "null"` per-target) compose

## Test Plan

Installed package deps (plus the `libglpk` system lib `targets` requires) and ran the affected suites with `devtools::test()`:
- `test-task-shards` — pass (includes the "shipped template `tar_make()`s every shard" test, which now exercises the `error = "continue"` line)
- `test-cluster-pipeline` — pass (the "no probe target / clean graph" assertion validates the edited cluster `_targets.R`)
- `test-run-scenario` — pass

Re-documented with `devtools::document()` and formatted with `air`.

## Follow-up note

The `task-shards` capability spec (`openspec/specs/task-shards/spec.md`) documents per-target `error = "null"` but not the global keep-going default. It was left untouched here (synced specs change via an OpenSpec change, and this PR is scoped to design + examples). Capturing the global default in that spec is a small optional follow-up.

https://claude.ai/code/session_01UNCv4s2KBrtkdx6xA3xFVb