### PR TITLE
chore: bump codecov-action to v7 and sharpen PR-title convention

### DIFF
--- a/.github/workflows/covr/action.yml
+++ b/.github/workflows/covr/action.yml
@@ -22,7 +22,7 @@ runs:
         }
       shell: Rscript {0}
 
-    - uses: codecov/codecov-action@v5
+    - uses: codecov/codecov-action@v7
       with:
         # Fail if token is given
         fail_ci_if_error: ${{ inputs.token != '' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,13 @@ See **`tests/testthat/AGENTS.md`** for the full test-suite conventions
 
 ## Pull Requests
 
+> **The PR title MUST be a Conventional Commit** — `<type>(<scope>): <summary>`
+> — because the squash-merge makes it the lone commit on `main` that `fledge`
+> turns into the `NEWS.md` entry. Write e.g. `ci(covr): bump codecov-action to
+> v7`, **not** a bare sentence like `Update codecov-action to v7`. This holds
+> even when an external tool (e.g. the PR-creation UI) drafts a title for you:
+> rewrite it to match before merge.
+
 - **Always update PR title and description** when opening the PR and after committing.
   The description must capture the
 change's *current* state, not a revision/process log.


### PR DESCRIPTION
## Description

Two related fixes:

1. **`covr` job failure** — the `codecov/codecov-action@v5` uploader failed at its GPG signature-verification step (`gpg: no valid OpenPGP data found` → `Can't check signature: No public key`), reddening the covr job even though the tests passed (`507 PASS`). Bumping to `@v7` resolves the binary-verification failure ([codecov/codecov-action#1956](https://github.com/codecov/codecov-action/issues/1956)).
2. **Conventional Commit PR-title rule** — this PR was originally opened with a non-conventional title (`Update codecov-action to v7`). The rule in `AGENTS.md` was buried and example-light, so title generators (including the PR-creation UI) miss it. Lead the *Pull Requests* section with the requirement plus a negative example, and note that externally-drafted titles must be rewritten to match.

## Changes

- `.github/workflows/covr/action.yml`: `codecov/codecov-action` `@v5` → `@v7`.
- `AGENTS.md`: promote the Conventional Commit PR-title rule to the top of the *Pull Requests* section with a good-vs-bad example.

## Test Plan

CI runs the `covr` job; the codecov upload step should now succeed past GPG verification. The `AGENTS.md` change is documentation only.

https://claude.ai/code/session_01APC2ufnTyyKWHoQhPuTYgp