### PR TITLE
docs: Add/correct author ORCID(s) in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,8 @@ Version: 0.0.0.9013
 Authors@R: c(
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7683-4592")),
-    person("Rebecca", "Fisher", , "R.Fisher@aims.gov.au", role = "aut")
+    person("Rebecca", "Fisher", , "R.Fisher@aims.gov.au", role = "aut",
+           comment = c(ORCID = "0000-0001-5148-6731"))
   )
 Description: Runs reproducible simulation studies for species sensitivity
     distribution (SSD) models built on the 'ssdtools' package. Expands a

--- a/man/ssdsims-package.Rd
+++ b/man/ssdsims-package.Rd
@@ -22,7 +22,7 @@ Useful links:
 Authors:
 \itemize{
   \item Joe Thorley \email{joe@poissonconsulting.ca} (\href{https://orcid.org/0000-0002-7683-4592}{ORCID})
-  \item Rebecca Fisher \email{R.Fisher@aims.gov.au}
+  \item Rebecca Fisher \email{R.Fisher@aims.gov.au} (\href{https://orcid.org/0000-0001-5148-6731}{ORCID})
 }
 
 }


### PR DESCRIPTION
Add Rebecca Fisher's ORCID (0000-0001-5148-6731).

Reviewed across all non-archived, non-forked poissonconsulting R packages to ensure co-authors and contributors carry their correct ORCID iDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)