### PR TITLE
feat(task-shards): add optional full summary retaining dists/samples

### DIFF
--- a/R/targets-runner.R
+++ b/R/targets-runner.R
@@ -422,9 +422,9 @@ ssd_run_hc_step <- function(tasks, scenario, fit_dir, out_dir) {
 #'
 #' The compact summary at `path` projects the `dists`/`samples` list-columns out
 #' at the DuckDB level, so the potentially-large retained bootstrap draws are
-#' never pulled into R. Supply `path_full` to **also** write a full summary that
-#' retains those list-columns: that write is kept lazy in DuckDB (read the glob,
-#' write Parquet) so the draws never materialise in R there either. The draws are
+#' never pulled into R. Supply `path_with_samples` to **also** write a full
+#' summary that retains those list-columns: that write reuses the same lazy
+#' DuckDB read, so the draws never materialise in R there either. The draws are
 #' populated only when the scenario set `samples = TRUE`, so the full summary is
 #' the analysis-ready estimates plus the per-row draws.
 #'
@@ -433,11 +433,11 @@ ssd_run_hc_step <- function(tasks, scenario, fit_dir, out_dir) {
 #' @param dir_hc The `hc` results root.
 #' @param path The output Parquet path for the compact summary (`dists`/`samples`
 #'   projected out).
-#' @param path_full Optional output Parquet path for a full summary that retains
-#'   the `dists`/`samples` list-columns. `NULL` (the default) writes only the
-#'   compact summary.
+#' @param path_with_samples Optional output Parquet path for a full summary that
+#'   retains the `dists`/`samples` list-columns. `NULL` (the default) writes only
+#'   the compact summary.
 #' @return The summary Parquet path(s) (the `format = "file"` contract): `path`
-#'   when `path_full` is `NULL`, otherwise `c(path, path_full)`.
+#'   when `path_with_samples` is `NULL`, otherwise `c(path, path_with_samples)`.
 #' @details
 #' In a `targets` pipeline a directory read carries no dependency edge, so
 #' [ssd_scenario_targets()] orders `summary` after the shards by naming every
@@ -464,38 +464,36 @@ ssd_run_hc_step <- function(tasks, scenario, fit_dir, out_dir) {
 #'   file.path(run$dir, "summary.parquet")
 #' )
 #' }
-ssd_summarise <- function(dir_sample, dir_fit, dir_hc, path, path_full = NULL) {
+ssd_summarise <- function(
+  dir_sample,
+  dir_fit,
+  dir_hc,
+  path,
+  path_with_samples = NULL
+) {
   glob <- file.path(dir_hc, "**", "part.parquet")
+  hc_shards <- duckplyr::read_parquet_duckdb(
+    glob,
+    options = list(hive_partitioning = FALSE)
+  )
   # Project out the `dists`/`samples` list-columns at the DuckDB level (so the
   # potentially-large retained `samples` draws are never pulled into R): the
   # compact summary is the analysis-ready estimate table; the draws stay in the
   # hc shards. The select stays lazy and is written straight to Parquet by
   # duckplyr - the read, projection, and write all happen inside DuckDB, never
   # collecting the union into R.
-  hc <- dplyr::select(
-    duckplyr::read_parquet_duckdb(
-      glob,
-      options = list(hive_partitioning = FALSE)
-    ),
-    -dplyr::any_of(c("dists", "samples"))
-  )
+  hc <- dplyr::select(hc_shards, -dplyr::any_of(c("dists", "samples")))
   ssd_write_parquet(hc, path)
-  if (is.null(path_full)) {
+  if (is.null(path_with_samples)) {
     return(path)
   }
   # The full summary retains every hc column (`dists`/`samples` included). The
-  # read stays lazy in DuckDB and is written straight back out, so the
-  # potentially-large draws never materialise in R either - the same no-R
-  # guarantee the compact projection above relies on.
-  dir.create(dirname(path_full), recursive = TRUE, showWarnings = FALSE)
-  duckplyr::compute_parquet(
-    duckplyr::read_parquet_duckdb(
-      glob,
-      options = list(hive_partitioning = FALSE)
-    ),
-    path_full
-  )
-  c(path, path_full)
+  # same lazy read is written straight back out, so the potentially-large draws
+  # never materialise in R either - the same no-R guarantee the compact
+  # projection above relies on.
+  dir.create(dirname(path_with_samples), recursive = TRUE, showWarnings = FALSE)
+  duckplyr::compute_parquet(hc_shards, path_with_samples)
+  c(path, path_with_samples)
 }
 
 # ---- per-child upstream edges (Option 3, TARGETS-DESIGN.md sections 6, 8) ---
@@ -723,7 +721,7 @@ ssd_scenario_targets <- function(
   # a full summary that keeps the `dists`/`samples` list-columns the compact
   # summary projects out; otherwise those draws are empty and the second file
   # would carry nothing extra (TARGETS-DESIGN.md §12 `dual-summary-outputs`).
-  summary_full_path <- if (isTRUE(scenario$hc$samples)) {
+  summary_samples_path <- if (isTRUE(scenario$hc$samples)) {
     file.path(root, "summary-samples.parquet")
   } else {
     NULL
@@ -858,7 +856,7 @@ ssd_scenario_targets <- function(
         !!fit_dir,
         !!hc_dir,
         !!summary_path,
-        path_full = !!summary_full_path
+        path_with_samples = !!summary_samples_path
       )
     }),
     format = "file"

--- a/R/targets-runner.R
+++ b/R/targets-runner.R
@@ -420,11 +420,24 @@ ssd_run_hc_step <- function(tasks, scenario, fit_dir, out_dir) {
 #' three result layers; the `sample` draws and serialised `fit` objects are not
 #' summary material, so the combined summary is the `hc` layer.
 #'
+#' The compact summary at `path` projects the `dists`/`samples` list-columns out
+#' at the DuckDB level, so the potentially-large retained bootstrap draws are
+#' never pulled into R. Supply `path_full` to **also** write a full summary that
+#' retains those list-columns: that write is kept lazy in DuckDB (read the glob,
+#' write Parquet) so the draws never materialise in R there either. The draws are
+#' populated only when the scenario set `samples = TRUE`, so the full summary is
+#' the analysis-ready estimates plus the per-row draws.
+#'
 #' @param dir_sample The `sample` results root.
 #' @param dir_fit The `fit` results root.
 #' @param dir_hc The `hc` results root.
-#' @param path The output Parquet path for the combined summary.
-#' @return The summary Parquet path (the `format = "file"` contract).
+#' @param path The output Parquet path for the compact summary (`dists`/`samples`
+#'   projected out).
+#' @param path_full Optional output Parquet path for a full summary that retains
+#'   the `dists`/`samples` list-columns. `NULL` (the default) writes only the
+#'   compact summary.
+#' @return The summary Parquet path(s) (the `format = "file"` contract): `path`
+#'   when `path_full` is `NULL`, otherwise `c(path, path_full)`.
 #' @details
 #' In a `targets` pipeline a directory read carries no dependency edge, so
 #' [ssd_scenario_targets()] orders `summary` after the shards by naming every
@@ -451,12 +464,12 @@ ssd_run_hc_step <- function(tasks, scenario, fit_dir, out_dir) {
 #'   file.path(run$dir, "summary.parquet")
 #' )
 #' }
-ssd_summarise <- function(dir_sample, dir_fit, dir_hc, path) {
+ssd_summarise <- function(dir_sample, dir_fit, dir_hc, path, path_full = NULL) {
   glob <- file.path(dir_hc, "**", "part.parquet")
   # Project out the `dists`/`samples` list-columns at the DuckDB level (so the
   # potentially-large retained `samples` draws are never pulled into R): the
-  # summary is the analysis-ready estimate table; the draws stay in the hc
-  # shards. The select stays lazy and is written straight to Parquet by
+  # compact summary is the analysis-ready estimate table; the draws stay in the
+  # hc shards. The select stays lazy and is written straight to Parquet by
   # duckplyr - the read, projection, and write all happen inside DuckDB, never
   # collecting the union into R.
   hc <- dplyr::select(
@@ -467,6 +480,22 @@ ssd_summarise <- function(dir_sample, dir_fit, dir_hc, path) {
     -dplyr::any_of(c("dists", "samples"))
   )
   ssd_write_parquet(hc, path)
+  if (is.null(path_full)) {
+    return(path)
+  }
+  # The full summary retains every hc column (`dists`/`samples` included). The
+  # read stays lazy in DuckDB and is written straight back out, so the
+  # potentially-large draws never materialise in R either - the same no-R
+  # guarantee the compact projection above relies on.
+  dir.create(dirname(path_full), recursive = TRUE, showWarnings = FALSE)
+  duckplyr::compute_parquet(
+    duckplyr::read_parquet_duckdb(
+      glob,
+      options = list(hive_partitioning = FALSE)
+    ),
+    path_full
+  )
+  c(path, path_full)
 }
 
 # ---- per-child upstream edges (Option 3, TARGETS-DESIGN.md sections 6, 8) ---
@@ -690,6 +719,15 @@ ssd_scenario_targets <- function(
   fit_dir <- file.path(root, "fit")
   hc_dir <- file.path(root, "hc")
   summary_path <- file.path(root, "summary.parquet")
+  # When the scenario retains the bootstrap draws (`samples = TRUE`), also fan in
+  # a full summary that keeps the `dists`/`samples` list-columns the compact
+  # summary projects out; otherwise those draws are empty and the second file
+  # would carry nothing extra (TARGETS-DESIGN.md §12 `dual-summary-outputs`).
+  summary_full_path <- if (isTRUE(scenario$hc$samples)) {
+    file.path(root, "summary-samples.parquet")
+  } else {
+    NULL
+  }
 
   sample_shards <- ssd_scenario_sample_shards(scenario)
   fit_shards <- ssd_scenario_fit_shards(scenario)
@@ -815,7 +853,13 @@ ssd_scenario_targets <- function(
     "summary",
     rlang::expr({
       !!edge_block(unname(hc_names)) # order/value-depend on every hc shard
-      ssd_summarise(!!sample_dir, !!fit_dir, !!hc_dir, !!summary_path)
+      ssd_summarise(
+        !!sample_dir,
+        !!fit_dir,
+        !!hc_dir,
+        !!summary_path,
+        path_full = !!summary_full_path
+      )
     }),
     format = "file"
   )

--- a/TARGETS-DESIGN.md
+++ b/TARGETS-DESIGN.md
@@ -2305,6 +2305,23 @@ public-API or ergonomics gaps.
   property is preserved. Same "axis/row → setting" family as `scalar-ci-flag` /
   `dists-simulation-setting` / `est-method-setting`. Independent tidy-up; not on
   the dependency DAG.
+
+- **`dual-summary-outputs`** — Give the §6 fan-in a second, optional output.
+  `ssd_summarise()` keeps writing the compact `summary.parquet` (the
+  analysis-ready estimate table, `dists`/`samples` projected out at the DuckDB
+  level and never pulled into R) and gains a trailing `path_full = NULL`: when
+  supplied it **also** writes a *full* hc union that **retains** the
+  `dists`/`samples` list-columns, via the same directory read kept lazy in DuckDB
+  (read glob → write Parquet) so the draws never materialise in R either.
+  `ssd_scenario_targets()` passes `path_full = <root>/summary-samples.parquet`
+  **iff** `scenario$hc$samples` is `TRUE` (the case where the retained draws carry
+  information the compact summary cannot) and the `summary` target returns the
+  path vector so `targets` tracks both files; with `samples = FALSE` the pipeline
+  is unchanged. Additive and backward-compatible (`path_full` defaults to `NULL`);
+  `task-shards` delta. Pairs with the cloud-upload `ssd_summarise_uploaded(...,
+  drop_samples =)` knob (the uploaded-read analogue). Independent tidy-up; not on
+  the dependency DAG.
+
 ### Archived
 
 Completed steps that have landed and been archived (full artifacts under `openspec/changes/archive/`; their requirements are synced into `openspec/specs/`). Listed in the dependency order they were implemented; the Mermaid graph below colours these nodes green inside `archived_box`.

--- a/TARGETS-DESIGN.md
+++ b/TARGETS-DESIGN.md
@@ -2309,15 +2309,15 @@ public-API or ergonomics gaps.
 - **`dual-summary-outputs`** — Give the §6 fan-in a second, optional output.
   `ssd_summarise()` keeps writing the compact `summary.parquet` (the
   analysis-ready estimate table, `dists`/`samples` projected out at the DuckDB
-  level and never pulled into R) and gains a trailing `path_full = NULL`: when
+  level and never pulled into R) and gains a trailing `path_with_samples = NULL`: when
   supplied it **also** writes a *full* hc union that **retains** the
   `dists`/`samples` list-columns, via the same directory read kept lazy in DuckDB
   (read glob → write Parquet) so the draws never materialise in R either.
-  `ssd_scenario_targets()` passes `path_full = <root>/summary-samples.parquet`
+  `ssd_scenario_targets()` passes `path_with_samples = <root>/summary-samples.parquet`
   **iff** `scenario$hc$samples` is `TRUE` (the case where the retained draws carry
   information the compact summary cannot) and the `summary` target returns the
   path vector so `targets` tracks both files; with `samples = FALSE` the pipeline
-  is unchanged. Additive and backward-compatible (`path_full` defaults to `NULL`);
+  is unchanged. Additive and backward-compatible (`path_with_samples` defaults to `NULL`);
   `task-shards` delta. Pairs with the cloud-upload `ssd_summarise_uploaded(...,
   drop_samples =)` knob (the uploaded-read analogue). Independent tidy-up; not on
   the dependency DAG.

--- a/inst/targets-templates/cluster/run.R
+++ b/inst/targets-templates/cluster/run.R
@@ -65,9 +65,11 @@ source("preflight.R")
 tar_make()
 
 # The `summary` target is `format = "file"`, so its value is the path to the
-# combined Parquet (the union of the hc shards).
-summary_path <- tar_read(summary)
-cat("Summary written to:", summary_path, "\n")
+# compact `summary.parquet` (the union of the hc shards). If the scenario sets
+# `samples = TRUE`, the target also tracks a full `summary-samples.parquet`, so
+# the value is a length-2 vector; peek at the compact estimate table.
+summary_paths <- tar_read(summary)
+cat("Summary written to:", summary_paths, sep = "\n")
 
 # Peek at the combined estimates (duckplyr is an ssdsims dependency).
-print(duckplyr::read_parquet_duckdb(summary_path))
+print(duckplyr::read_parquet_duckdb(summary_paths[[1L]]))

--- a/inst/targets-templates/large/run.R
+++ b/inst/targets-templates/large/run.R
@@ -10,7 +10,9 @@
 # It builds one target per shard (writing
 # `results/layout=<hash>/<step>/<axis=value>/.../part.parquet`) and the combined
 # `results/layout=<hash>/summary.parquet`, then reports the summary path and a peek at the
-# hazard-concentration estimates.
+# hazard-concentration estimates. This scenario sets `samples = TRUE`, so the
+# `summary` target also writes a full `summary-samples.parquet` retaining the
+# per-row bootstrap draws (the compact `summary.parquet` projects them out).
 
 library(targets)
 
@@ -29,10 +31,11 @@ if (dir.exists("inst/targets-templates/large")) {
 # Needs the `crew` package installed.
 tar_make()
 
-# The `summary` target is `format = "file"`, so its value is the path to the
-# combined Parquet (the union of the hc shards).
-summary_path <- tar_read(summary)
-cat("Summary written to:", summary_path, "\n")
+# The `summary` target is `format = "file"`. With `samples = TRUE` it tracks two
+# files: the compact `summary.parquet` (first) and the full
+# `summary-samples.parquet` (second). Peek at the compact estimate table.
+summary_paths <- tar_read(summary)
+cat("Summaries written to:", summary_paths, sep = "\n")
 
 # Peek at the combined estimates (duckplyr is an ssdsims dependency).
-print(duckplyr::read_parquet_duckdb(summary_path))
+print(duckplyr::read_parquet_duckdb(summary_paths[[1L]]))

--- a/inst/targets-templates/small/run.R
+++ b/inst/targets-templates/small/run.R
@@ -30,9 +30,11 @@ if (dir.exists("inst/targets-templates/small")) {
 tar_make()
 
 # The `summary` target is `format = "file"`, so its value is the path to the
-# combined Parquet (the union of the hc shards).
-summary_path <- tar_read(summary)
-cat("Summary written to:", summary_path, "\n")
+# compact `summary.parquet` (the union of the hc shards). If the scenario sets
+# `samples = TRUE`, the target also tracks a full `summary-samples.parquet`, so
+# the value is a length-2 vector; peek at the compact estimate table.
+summary_paths <- tar_read(summary)
+cat("Summary written to:", summary_paths, sep = "\n")
 
 # Peek at the combined estimates (duckplyr is an ssdsims dependency).
-print(duckplyr::read_parquet_duckdb(summary_path))
+print(duckplyr::read_parquet_duckdb(summary_paths[[1L]]))

--- a/man/ssd_summarise.Rd
+++ b/man/ssd_summarise.Rd
@@ -4,7 +4,7 @@
 \alias{ssd_summarise}
 \title{Summarise a Run's hc Estimates Across Shards}
 \usage{
-ssd_summarise(dir_sample, dir_fit, dir_hc, path, path_full = NULL)
+ssd_summarise(dir_sample, dir_fit, dir_hc, path, path_with_samples = NULL)
 }
 \arguments{
 \item{dir_sample}{The \code{sample} results root.}
@@ -16,13 +16,13 @@ ssd_summarise(dir_sample, dir_fit, dir_hc, path, path_full = NULL)
 \item{path}{The output Parquet path for the compact summary (\code{dists}/\code{samples}
 projected out).}
 
-\item{path_full}{Optional output Parquet path for a full summary that retains
-the \code{dists}/\code{samples} list-columns. \code{NULL} (the default) writes only the
-compact summary.}
+\item{path_with_samples}{Optional output Parquet path for a full summary that
+retains the \code{dists}/\code{samples} list-columns. \code{NULL} (the default) writes only
+the compact summary.}
 }
 \value{
 The summary Parquet path(s) (the \code{format = "file"} contract): \code{path}
-when \code{path_full} is \code{NULL}, otherwise \code{c(path, path_full)}.
+when \code{path_with_samples} is \code{NULL}, otherwise \code{c(path, path_with_samples)}.
 }
 \description{
 Fans in the run's results without pulling shard target values back into R or
@@ -38,9 +38,9 @@ summary material, so the combined summary is the \code{hc} layer.
 \details{
 The compact summary at \code{path} projects the \code{dists}/\code{samples} list-columns out
 at the DuckDB level, so the potentially-large retained bootstrap draws are
-never pulled into R. Supply \code{path_full} to \strong{also} write a full summary that
-retains those list-columns: that write is kept lazy in DuckDB (read the glob,
-write Parquet) so the draws never materialise in R there either. The draws are
+never pulled into R. Supply \code{path_with_samples} to \strong{also} write a full
+summary that retains those list-columns: that write reuses the same lazy
+DuckDB read, so the draws never materialise in R there either. The draws are
 populated only when the scenario set \code{samples = TRUE}, so the full summary is
 the analysis-ready estimates plus the per-row draws.
 

--- a/man/ssd_summarise.Rd
+++ b/man/ssd_summarise.Rd
@@ -4,7 +4,7 @@
 \alias{ssd_summarise}
 \title{Summarise a Run's hc Estimates Across Shards}
 \usage{
-ssd_summarise(dir_sample, dir_fit, dir_hc, path)
+ssd_summarise(dir_sample, dir_fit, dir_hc, path, path_full = NULL)
 }
 \arguments{
 \item{dir_sample}{The \code{sample} results root.}
@@ -13,10 +13,16 @@ ssd_summarise(dir_sample, dir_fit, dir_hc, path)
 
 \item{dir_hc}{The \code{hc} results root.}
 
-\item{path}{The output Parquet path for the combined summary.}
+\item{path}{The output Parquet path for the compact summary (\code{dists}/\code{samples}
+projected out).}
+
+\item{path_full}{Optional output Parquet path for a full summary that retains
+the \code{dists}/\code{samples} list-columns. \code{NULL} (the default) writes only the
+compact summary.}
 }
 \value{
-The summary Parquet path (the \code{format = "file"} contract).
+The summary Parquet path(s) (the \code{format = "file"} contract): \code{path}
+when \code{path_full} is \code{NULL}, otherwise \code{c(path, path_full)}.
 }
 \description{
 Fans in the run's results without pulling shard target values back into R or
@@ -30,6 +36,14 @@ three result layers; the \code{sample} draws and serialised \code{fit} objects a
 summary material, so the combined summary is the \code{hc} layer.
 }
 \details{
+The compact summary at \code{path} projects the \code{dists}/\code{samples} list-columns out
+at the DuckDB level, so the potentially-large retained bootstrap draws are
+never pulled into R. Supply \code{path_full} to \strong{also} write a full summary that
+retains those list-columns: that write is kept lazy in DuckDB (read the glob,
+write Parquet) so the draws never materialise in R there either. The draws are
+populated only when the scenario set \code{samples = TRUE}, so the full summary is
+the analysis-ready estimates plus the per-row draws.
+
 In a \code{targets} pipeline a directory read carries no dependency edge, so
 \code{\link[=ssd_scenario_targets]{ssd_scenario_targets()}} orders \code{summary} after the shards by naming every
 \code{hc} shard target in its command (it re-runs when any \code{hc} shard's bytes

--- a/openspec/changes/dual-summary-outputs/.openspec.yaml
+++ b/openspec/changes/dual-summary-outputs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/dual-summary-outputs/design.md
+++ b/openspec/changes/dual-summary-outputs/design.md
@@ -45,9 +45,9 @@ failure) and returns `summary_path`.
 
 ## Decisions
 
-### Decision: an optional `path_full = NULL` argument, not a new function or a flag
+### Decision: an optional `path_with_samples = NULL` argument, not a new function or a flag
 
-`ssd_summarise()` grows a trailing `path_full = NULL`. `NULL` ⇒ today's
+`ssd_summarise()` grows a trailing `path_with_samples = NULL`. `NULL` ⇒ today's
 behaviour, so the four-positional call sites
 (`inst/targets-templates/`, the vignette) are untouched. A non-`NULL` value adds
 the second write.
@@ -70,7 +70,7 @@ glob and writes Parquet entirely at the DuckDB level:
 ```r
 duckplyr::compute_parquet(
   duckplyr::read_parquet_duckdb(glob, options = list(hive_partitioning = FALSE)),
-  path_full
+  path_with_samples
 )
 ```
 
@@ -84,7 +84,7 @@ carried by the engine, not by R.
 ### Decision: the factory gates the full summary on `scenario$hc$samples`
 
 `scenario$hc$samples` is known at sourcing time, so `ssd_scenario_targets()`
-decides **statically** whether to pass `path_full`. When `TRUE` it passes
+decides **statically** whether to pass `path_with_samples`. When `TRUE` it passes
 `file.path(root, "summary-samples.parquet")` and the `summary` target returns
 `c(summary_path, summary_full_path)`; a `format = "file"` target accepts a path
 vector, so `targets` tracks both files. When `FALSE` the command and return arity

--- a/openspec/changes/dual-summary-outputs/design.md
+++ b/openspec/changes/dual-summary-outputs/design.md
@@ -1,0 +1,118 @@
+## Context
+
+`ssd_summarize(dir_sample, dir_fit, dir_hc, path)` (`R/targets-runner.R:457-472`)
+is the §6 fan-in: it reads the `hc` shard glob with duckplyr, projects out the
+`dists`/`samples` list-columns with `select(-any_of(c("dists", "samples")))`
+**before** collecting into R, and writes the compact estimate table to `path`.
+The projection is load-bearing — the `samples` draws (populated when the scenario
+sets `samples = TRUE`, `scenario-definition/spec.md:198`) can be large, and the
+`shard-runner` spec pins the rule that a reader that does not need a heavy column
+drops it by column projection alone so no bytes cross into R
+(`shard-runner/spec.md:83-85`).
+
+The draws are not lost — they remain in the `hc` shards on disk — but the single
+fan-in artifact does not carry them, so a `samples = TRUE` user must re-glob the
+shards to recover what they explicitly asked the run to retain. Dropping columns
+from Parquet is cheap, so writing a second, wider projection alongside the
+compact one is near-free.
+
+The pipeline call site (`ssd_scenario_targets()`, `R/targets-runner.R:742-749`)
+wraps `ssd_summarize()` in a single `format = "file"` `summary` target that names
+every `hc` shard (so it re-runs on any shard change and survives a partial
+failure) and returns `summary_path`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a second, *optional* full summary that retains `dists`/`samples`, written by
+  the same fan-in read.
+- Preserve the no-R-materialise guarantee for **both** outputs — the full write
+  must not pull the draws into R either.
+- Keep the compact output (bytes and path) and every existing call site unchanged
+  when the new output is not requested.
+- Emit the full summary from the pipeline exactly when it carries information —
+  i.e. when `scenario$hc$samples` is `TRUE`.
+
+**Non-Goals:**
+
+- Changing the compact summary's columns or projection.
+- Recomputing or re-seeding anything — this is a wider read of the same shards.
+- A full summary for `samples = FALSE` runs in the pipeline (no extra information;
+  the function still allows it, but the factory does not request it).
+- Uploading/serving the second file (`cloud-upload` already offers a path to the
+  summary; extending it to the full summary is out of scope here).
+
+## Decisions
+
+### Decision: an optional `path_full = NULL` argument, not a new function or a flag
+
+`ssd_summarize()` grows a trailing `path_full = NULL`. `NULL` ⇒ today's
+behaviour, so the four-positional call sites
+(`inst/targets-templates/`, the vignette) are untouched. A non-`NULL` value adds
+the second write.
+
+- *Why not a separate `ssd_summarize_full()`?* It would duplicate the glob read
+  and the partial-failure-survival wording for one differing line (the
+  projection). One function reading the directory once and emitting one or two
+  projections is the smaller surface.
+- *Why not a `samples = TRUE/FALSE` flag selecting which single file to write?*
+  The value is having **both** — a compact table for analysis and a complete
+  artifact — so the API writes the compact one always and the full one on demand,
+  rather than forcing a choice.
+
+### Decision: the full write stays lazy in DuckDB (never collects the draws into R)
+
+The compact path collects into R *after* projecting the heavy columns out. The
+full path must keep the draws, so it must **not** collect — instead it reads the
+glob and writes Parquet entirely at the DuckDB level:
+
+```r
+duckplyr::compute_parquet(
+  duckplyr::read_parquet_duckdb(glob, options = list(hive_partitioning = FALSE)),
+  path_full
+)
+```
+
+This is the same DuckDB read→write `ssd_write_parquet()` already uses, and the
+`samples` list-column round-trips as a DuckDB `LIST` (it was written from a
+tibble list-column the same way, `R/targets-runner.R:408-411`), so the draws move
+shard→summary without ever materialising in R. This honours the
+`shard-runner/spec.md:83-85` spirit for the full output too: the heavy column is
+carried by the engine, not by R.
+
+### Decision: the factory gates the full summary on `scenario$hc$samples`
+
+`scenario$hc$samples` is known at sourcing time, so `ssd_scenario_targets()`
+decides **statically** whether to pass `path_full`. When `TRUE` it passes
+`file.path(root, "summary-samples.parquet")` and the `summary` target returns
+`c(summary_path, summary_full_path)`; a `format = "file"` target accepts a path
+vector, so `targets` tracks both files. When `FALSE` the command and return arity
+are exactly as today.
+
+- *Naming:* `summary-samples.parquet` names the distinguishing feature (the
+  retained draws). It sits beside `summary.parquet` under the same layout-keyed
+  root, so a changed `partition_by` still isolates it
+  (`task-shards/spec.md:78`).
+- *Why gate on `samples`?* With `samples = FALSE` the `samples` column is empty,
+  so the full file would differ from the compact only by an empty list-column and
+  the small `dists` column — not worth a second tracked artifact in the
+  happy-path pipeline. The function still permits it (callers outside the factory
+  may want the `dists` column); the factory just does not request it.
+
+## Risks / Trade-offs
+
+- **DuckDB cannot write the `samples` `LIST` column** → Mitigation: the column is
+  *read back* from Parquet that duckplyr itself wrote from a list-column, so the
+  round-trip is already exercised by the hc step; a test asserts the full file's
+  `samples` is non-empty and matches the shard draws.
+- **A `format = "file"` target returning a vector behaves differently** →
+  Mitigation: `targets` supports multi-file `format = "file"` (the return is a
+  character vector of paths); the arity is fixed per pipeline because it is chosen
+  statically from `scenario$hc$samples`, not at runtime.
+- **Double scan of the `hc` glob (compact + full reads)** → Mitigation: the scan
+  is negligible against the simulation cost the summary fans in, and only the
+  `samples = TRUE` path pays for the second read.
+- **Two artifacts can drift in consumers' minds** → Mitigation: doc the contract
+  (`?ssd_summarize`, the vignette) — same rows/estimates, the full one adds the
+  retained list-columns; `tar_read("summary")` returns the vector when both exist.

--- a/openspec/changes/dual-summary-outputs/design.md
+++ b/openspec/changes/dual-summary-outputs/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-`ssd_summarize(dir_sample, dir_fit, dir_hc, path)` (`R/targets-runner.R:457-472`)
+`ssd_summarise(dir_sample, dir_fit, dir_hc, path)` (`R/targets-runner.R:457-472`)
 is the §6 fan-in: it reads the `hc` shard glob with duckplyr, projects out the
 `dists`/`samples` list-columns with `select(-any_of(c("dists", "samples")))`
 **before** collecting into R, and writes the compact estimate table to `path`.
@@ -17,7 +17,7 @@ from Parquet is cheap, so writing a second, wider projection alongside the
 compact one is near-free.
 
 The pipeline call site (`ssd_scenario_targets()`, `R/targets-runner.R:742-749`)
-wraps `ssd_summarize()` in a single `format = "file"` `summary` target that names
+wraps `ssd_summarise()` in a single `format = "file"` `summary` target that names
 every `hc` shard (so it re-runs on any shard change and survives a partial
 failure) and returns `summary_path`.
 
@@ -47,12 +47,12 @@ failure) and returns `summary_path`.
 
 ### Decision: an optional `path_full = NULL` argument, not a new function or a flag
 
-`ssd_summarize()` grows a trailing `path_full = NULL`. `NULL` ⇒ today's
+`ssd_summarise()` grows a trailing `path_full = NULL`. `NULL` ⇒ today's
 behaviour, so the four-positional call sites
 (`inst/targets-templates/`, the vignette) are untouched. A non-`NULL` value adds
 the second write.
 
-- *Why not a separate `ssd_summarize_full()`?* It would duplicate the glob read
+- *Why not a separate `ssd_summarise_full()`?* It would duplicate the glob read
   and the partial-failure-survival wording for one differing line (the
   projection). One function reading the directory once and emitting one or two
   projections is the smaller surface.
@@ -114,5 +114,5 @@ are exactly as today.
   is negligible against the simulation cost the summary fans in, and only the
   `samples = TRUE` path pays for the second read.
 - **Two artifacts can drift in consumers' minds** → Mitigation: doc the contract
-  (`?ssd_summarize`, the vignette) — same rows/estimates, the full one adds the
+  (`?ssd_summarise`, the vignette) — same rows/estimates, the full one adds the
   retained list-columns; `tar_read("summary")` returns the vector when both exist.

--- a/openspec/changes/dual-summary-outputs/proposal.md
+++ b/openspec/changes/dual-summary-outputs/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-`ssd_summarize()` writes a single `summary.parquet` that **projects out** the
+`ssd_summarise()` writes a single `summary.parquet` that **projects out** the
 `dists` and `samples` list-columns at the DuckDB level
 (`R/targets-runner.R:457-472`): the potentially-large per-row bootstrap draws are
 never pulled into R, and the summary is the compact, analysis-ready estimate
@@ -12,7 +12,7 @@ from Parquet is cheap, so there is no reason to make the run choose: it can writ
 
 ## What Changes
 
-- **`ssd_summarize()` gains an optional second output.** A new trailing
+- **`ssd_summarise()` gains an optional second output.** A new trailing
   `path_full = NULL` argument: when supplied, the function **also** writes a
   *full* hc union to `path_full` that **retains** the `dists`/`samples`
   list-columns, in addition to the compact `path` (whose projection is
@@ -33,7 +33,7 @@ from Parquet is cheap, so there is no reason to make the run choose: it can writ
   `hc` glob and `hive_partitioning = FALSE` read as the compact one, so it
   inherits the partial-failure-survival property (`error = "null"`, §6.2) — it is
   the same fan-in with a wider projection.
-- **Sweep docs and templates** (`?ssd_summarize`, the sharded-pipeline vignette,
+- **Sweep docs and templates** (`?ssd_summarise`, the sharded-pipeline vignette,
   `inst/targets-templates/`) to describe the two outputs and the
   `samples = TRUE` trigger.
 
@@ -52,12 +52,12 @@ from Parquet is cheap, so there is no reason to make the run choose: it can writ
 ## Impact
 
 - **Specs**: `task-shards` delta.
-- **Code**: `R/targets-runner.R` — `ssd_summarize()` (`path_full` argument and the
+- **Code**: `R/targets-runner.R` — `ssd_summarise()` (`path_full` argument and the
   lazy full write); `ssd_scenario_targets()` (conditional `path_full`, the
   `summary` target returning a path vector).
 - **API**: additive, backward-compatible (`path_full` defaults to `NULL`); no
   change to the compact `summary.parquet` bytes or path.
-- **Docs/templates**: `man/ssd_summarize.Rd` (roxygen), `vignettes/sharded-pipeline.qmd`,
+- **Docs/templates**: `man/ssd_summarise.Rd` (roxygen), `vignettes/sharded-pipeline.qmd`,
   `inst/targets-templates/` run scripts/READMEs, `GLOSSARY.md`/`TARGETS-DESIGN.md`
   as needed.
 - **Tests**: a scenario with `samples = TRUE` yields both files (full retains a

--- a/openspec/changes/dual-summary-outputs/proposal.md
+++ b/openspec/changes/dual-summary-outputs/proposal.md
@@ -1,0 +1,65 @@
+## Why
+
+`ssd_summarize()` writes a single `summary.parquet` that **projects out** the
+`dists` and `samples` list-columns at the DuckDB level
+(`R/targets-runner.R:457-472`): the potentially-large per-row bootstrap draws are
+never pulled into R, and the summary is the compact, analysis-ready estimate
+table. But a user who set `samples = TRUE` on the scenario specifically to
+**retain** those draws then finds them absent from the only fan-in artifact — to
+get them back they must re-read the `hc` shard glob themselves. Dropping columns
+from Parquet is cheap, so there is no reason to make the run choose: it can write
+**both** a compact estimate table and a complete artifact that keeps the draws.
+
+## What Changes
+
+- **`ssd_summarize()` gains an optional second output.** A new trailing
+  `path_full = NULL` argument: when supplied, the function **also** writes a
+  *full* hc union to `path_full` that **retains** the `dists`/`samples`
+  list-columns, in addition to the compact `path` (whose projection is
+  unchanged). The full write stays at the DuckDB level (read the Hive glob → write
+  Parquet) so the draws are **never collected into R** — the same no-R-materialise
+  guarantee the compact path already has. With `path_full = NULL` the behaviour is
+  exactly as today (single compact summary), so existing call sites are
+  unaffected.
+- **The targets pipeline writes the full summary when, and only when, the
+  scenario retains draws.** `ssd_scenario_targets()` passes
+  `path_full = <root>/summary-samples.parquet` to the `summary` target **iff**
+  `scenario$hc$samples` is `TRUE` (the case where the draws carry information the
+  compact summary cannot). The target returns the path **vector** so `targets`
+  tracks both files under its `format = "file"` contract. When
+  `samples = FALSE`, the pipeline is byte-for-byte unchanged (one
+  `summary.parquet`, no extra file).
+- **Both summaries union the same landed shards.** The full read uses the same
+  `hc` glob and `hive_partitioning = FALSE` read as the compact one, so it
+  inherits the partial-failure-survival property (`error = "null"`, §6.2) — it is
+  the same fan-in with a wider projection.
+- **Sweep docs and templates** (`?ssd_summarize`, the sharded-pipeline vignette,
+  `inst/targets-templates/`) to describe the two outputs and the
+  `samples = TRUE` trigger.
+
+## Capabilities
+
+### New Capabilities
+<!-- None: this extends an existing capability. -->
+
+### Modified Capabilities
+- `task-shards`: the summary-fan-in requirement gains a second, optional output —
+  a *full* summary that retains the `dists`/`samples` list-columns, written by the
+  same directory read without pulling the draws into R, and emitted by the
+  pipeline exactly when `scenario$hc$samples` is `TRUE`. The existing compact
+  summary and its no-R-materialise projection are unchanged.
+
+## Impact
+
+- **Specs**: `task-shards` delta.
+- **Code**: `R/targets-runner.R` — `ssd_summarize()` (`path_full` argument and the
+  lazy full write); `ssd_scenario_targets()` (conditional `path_full`, the
+  `summary` target returning a path vector).
+- **API**: additive, backward-compatible (`path_full` defaults to `NULL`); no
+  change to the compact `summary.parquet` bytes or path.
+- **Docs/templates**: `man/ssd_summarize.Rd` (roxygen), `vignettes/sharded-pipeline.qmd`,
+  `inst/targets-templates/` run scripts/READMEs, `GLOSSARY.md`/`TARGETS-DESIGN.md`
+  as needed.
+- **Tests**: a scenario with `samples = TRUE` yields both files (full retains a
+  non-empty `samples` column, compact omits it, estimate columns identical); with
+  `samples = FALSE` only the compact file is written.

--- a/openspec/changes/dual-summary-outputs/proposal.md
+++ b/openspec/changes/dual-summary-outputs/proposal.md
@@ -13,17 +13,17 @@ from Parquet is cheap, so there is no reason to make the run choose: it can writ
 ## What Changes
 
 - **`ssd_summarise()` gains an optional second output.** A new trailing
-  `path_full = NULL` argument: when supplied, the function **also** writes a
-  *full* hc union to `path_full` that **retains** the `dists`/`samples`
+  `path_with_samples = NULL` argument: when supplied, the function **also** writes a
+  *full* hc union to `path_with_samples` that **retains** the `dists`/`samples`
   list-columns, in addition to the compact `path` (whose projection is
   unchanged). The full write stays at the DuckDB level (read the Hive glob → write
   Parquet) so the draws are **never collected into R** — the same no-R-materialise
-  guarantee the compact path already has. With `path_full = NULL` the behaviour is
+  guarantee the compact path already has. With `path_with_samples = NULL` the behaviour is
   exactly as today (single compact summary), so existing call sites are
   unaffected.
 - **The targets pipeline writes the full summary when, and only when, the
   scenario retains draws.** `ssd_scenario_targets()` passes
-  `path_full = <root>/summary-samples.parquet` to the `summary` target **iff**
+  `path_with_samples = <root>/summary-samples.parquet` to the `summary` target **iff**
   `scenario$hc$samples` is `TRUE` (the case where the draws carry information the
   compact summary cannot). The target returns the path **vector** so `targets`
   tracks both files under its `format = "file"` contract. When
@@ -52,10 +52,10 @@ from Parquet is cheap, so there is no reason to make the run choose: it can writ
 ## Impact
 
 - **Specs**: `task-shards` delta.
-- **Code**: `R/targets-runner.R` — `ssd_summarise()` (`path_full` argument and the
-  lazy full write); `ssd_scenario_targets()` (conditional `path_full`, the
+- **Code**: `R/targets-runner.R` — `ssd_summarise()` (`path_with_samples` argument and the
+  lazy full write); `ssd_scenario_targets()` (conditional `path_with_samples`, the
   `summary` target returning a path vector).
-- **API**: additive, backward-compatible (`path_full` defaults to `NULL`); no
+- **API**: additive, backward-compatible (`path_with_samples` defaults to `NULL`); no
   change to the compact `summary.parquet` bytes or path.
 - **Docs/templates**: `man/ssd_summarise.Rd` (roxygen), `vignettes/sharded-pipeline.qmd`,
   `inst/targets-templates/` run scripts/READMEs, `GLOSSARY.md`/`TARGETS-DESIGN.md`

--- a/openspec/changes/dual-summary-outputs/specs/task-shards/spec.md
+++ b/openspec/changes/dual-summary-outputs/specs/task-shards/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: An optional full summary retains the dists/samples list-columns
+
+`ssd_summarize()` SHALL accept an optional trailing `path_full` argument
+(default `NULL`). The compact summary written to `path` SHALL be unchanged — it
+SHALL continue to project the `dists` and `samples` list-columns out at the
+DuckDB level so the potentially-large per-row bootstrap draws are never pulled
+into R. When `path_full` is non-`NULL`, the function SHALL **additionally** write
+a *full* summary to `path_full` that unions the same `hc` shard glob but
+**retains** the `dists`/`samples` list-columns. The full write SHALL be performed
+at the DuckDB level (read the Hive glob, write Parquet) so the retained draws are
+**never collected into R** — the same no-R-materialise guarantee as the compact
+path. Both summaries SHALL read the result directory (`hive_partitioning =
+FALSE`) rather than the shard target values, so the full summary inherits the
+partial-failure-survival property and unions whatever shards landed
+(`TARGETS-DESIGN.md` §6.2). When `path_full` is `NULL`, `ssd_summarize()` SHALL
+behave exactly as before (a single compact summary, no extra file).
+
+#### Scenario: Full summary retains the draws the compact summary drops
+- **WHEN** `ssd_summarize()` is run with a non-`NULL` `path_full` over `hc` shards
+  produced with `samples = TRUE`
+- **THEN** the compact `path` SHALL omit the `dists`/`samples` columns, the full
+  `path_full` SHALL contain a populated `samples` list-column (and `dists`), and
+  the estimate columns (`est`/`lcl`/`ucl`) SHALL be identical across the two files
+
+#### Scenario: Without path_full the behaviour is unchanged
+- **WHEN** `ssd_summarize()` is run with `path_full = NULL` (the default)
+- **THEN** it SHALL write only the compact summary at `path`, projecting out
+  `dists`/`samples` as before, and SHALL NOT write any second file
+
+### Requirement: The pipeline emits the full summary only when the scenario retains draws
+
+`ssd_scenario_targets()` SHALL pass `path_full = <root>/summary-samples.parquet`
+to the `summary` target's `ssd_summarize()` call **if and only if**
+`scenario$hc$samples` is `TRUE` — the case where the retained draws carry
+information the compact summary cannot. In that case the `summary` target SHALL
+return the **vector** of both file paths so `targets` tracks both under its
+`format = "file"` contract. When `scenario$hc$samples` is `FALSE`, the pipeline
+SHALL be unchanged: the `summary` target writes the single compact
+`summary.parquet` and returns its path.
+
+#### Scenario: samples = TRUE yields two tracked summary files
+- **WHEN** a scenario defined with `samples = TRUE` is run through the targets
+  pipeline
+- **THEN** the `summary` target SHALL write both `summary.parquet` and
+  `summary-samples.parquet` and SHALL return both paths so `targets` tracks each
+  as a `format = "file"` output
+
+#### Scenario: samples = FALSE leaves the pipeline unchanged
+- **WHEN** a scenario defined with `samples = FALSE` is run through the targets
+  pipeline
+- **THEN** the `summary` target SHALL write only `summary.parquet` and SHALL NOT
+  write `summary-samples.parquet`

--- a/openspec/changes/dual-summary-outputs/specs/task-shards/spec.md
+++ b/openspec/changes/dual-summary-outputs/specs/task-shards/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: An optional full summary retains the dists/samples list-columns
 
-`ssd_summarize()` SHALL accept an optional trailing `path_full` argument
+`ssd_summarise()` SHALL accept an optional trailing `path_full` argument
 (default `NULL`). The compact summary written to `path` SHALL be unchanged — it
 SHALL continue to project the `dists` and `samples` list-columns out at the
 DuckDB level so the potentially-large per-row bootstrap draws are never pulled
@@ -14,25 +14,25 @@ at the DuckDB level (read the Hive glob, write Parquet) so the retained draws ar
 path. Both summaries SHALL read the result directory (`hive_partitioning =
 FALSE`) rather than the shard target values, so the full summary inherits the
 partial-failure-survival property and unions whatever shards landed
-(`TARGETS-DESIGN.md` §6.2). When `path_full` is `NULL`, `ssd_summarize()` SHALL
+(`TARGETS-DESIGN.md` §6.2). When `path_full` is `NULL`, `ssd_summarise()` SHALL
 behave exactly as before (a single compact summary, no extra file).
 
 #### Scenario: Full summary retains the draws the compact summary drops
-- **WHEN** `ssd_summarize()` is run with a non-`NULL` `path_full` over `hc` shards
+- **WHEN** `ssd_summarise()` is run with a non-`NULL` `path_full` over `hc` shards
   produced with `samples = TRUE`
 - **THEN** the compact `path` SHALL omit the `dists`/`samples` columns, the full
   `path_full` SHALL contain a populated `samples` list-column (and `dists`), and
   the estimate columns (`est`/`lcl`/`ucl`) SHALL be identical across the two files
 
 #### Scenario: Without path_full the behaviour is unchanged
-- **WHEN** `ssd_summarize()` is run with `path_full = NULL` (the default)
+- **WHEN** `ssd_summarise()` is run with `path_full = NULL` (the default)
 - **THEN** it SHALL write only the compact summary at `path`, projecting out
   `dists`/`samples` as before, and SHALL NOT write any second file
 
 ### Requirement: The pipeline emits the full summary only when the scenario retains draws
 
 `ssd_scenario_targets()` SHALL pass `path_full = <root>/summary-samples.parquet`
-to the `summary` target's `ssd_summarize()` call **if and only if**
+to the `summary` target's `ssd_summarise()` call **if and only if**
 `scenario$hc$samples` is `TRUE` — the case where the retained draws carry
 information the compact summary cannot. In that case the `summary` target SHALL
 return the **vector** of both file paths so `targets` tracks both under its

--- a/openspec/changes/dual-summary-outputs/specs/task-shards/spec.md
+++ b/openspec/changes/dual-summary-outputs/specs/task-shards/spec.md
@@ -2,36 +2,36 @@
 
 ### Requirement: An optional full summary retains the dists/samples list-columns
 
-`ssd_summarise()` SHALL accept an optional trailing `path_full` argument
+`ssd_summarise()` SHALL accept an optional trailing `path_with_samples` argument
 (default `NULL`). The compact summary written to `path` SHALL be unchanged — it
 SHALL continue to project the `dists` and `samples` list-columns out at the
 DuckDB level so the potentially-large per-row bootstrap draws are never pulled
-into R. When `path_full` is non-`NULL`, the function SHALL **additionally** write
-a *full* summary to `path_full` that unions the same `hc` shard glob but
+into R. When `path_with_samples` is non-`NULL`, the function SHALL **additionally** write
+a *full* summary to `path_with_samples` that unions the same `hc` shard glob but
 **retains** the `dists`/`samples` list-columns. The full write SHALL be performed
 at the DuckDB level (read the Hive glob, write Parquet) so the retained draws are
 **never collected into R** — the same no-R-materialise guarantee as the compact
 path. Both summaries SHALL read the result directory (`hive_partitioning =
 FALSE`) rather than the shard target values, so the full summary inherits the
 partial-failure-survival property and unions whatever shards landed
-(`TARGETS-DESIGN.md` §6.2). When `path_full` is `NULL`, `ssd_summarise()` SHALL
+(`TARGETS-DESIGN.md` §6.2). When `path_with_samples` is `NULL`, `ssd_summarise()` SHALL
 behave exactly as before (a single compact summary, no extra file).
 
 #### Scenario: Full summary retains the draws the compact summary drops
-- **WHEN** `ssd_summarise()` is run with a non-`NULL` `path_full` over `hc` shards
+- **WHEN** `ssd_summarise()` is run with a non-`NULL` `path_with_samples` over `hc` shards
   produced with `samples = TRUE`
 - **THEN** the compact `path` SHALL omit the `dists`/`samples` columns, the full
-  `path_full` SHALL contain a populated `samples` list-column (and `dists`), and
+  `path_with_samples` SHALL contain a populated `samples` list-column (and `dists`), and
   the estimate columns (`est`/`lcl`/`ucl`) SHALL be identical across the two files
 
-#### Scenario: Without path_full the behaviour is unchanged
-- **WHEN** `ssd_summarise()` is run with `path_full = NULL` (the default)
+#### Scenario: Without path_with_samples the behaviour is unchanged
+- **WHEN** `ssd_summarise()` is run with `path_with_samples = NULL` (the default)
 - **THEN** it SHALL write only the compact summary at `path`, projecting out
   `dists`/`samples` as before, and SHALL NOT write any second file
 
 ### Requirement: The pipeline emits the full summary only when the scenario retains draws
 
-`ssd_scenario_targets()` SHALL pass `path_full = <root>/summary-samples.parquet`
+`ssd_scenario_targets()` SHALL pass `path_with_samples = <root>/summary-samples.parquet`
 to the `summary` target's `ssd_summarise()` call **if and only if**
 `scenario$hc$samples` is `TRUE` — the case where the retained draws carry
 information the compact summary cannot. In that case the `summary` target SHALL

--- a/openspec/changes/dual-summary-outputs/tasks.md
+++ b/openspec/changes/dual-summary-outputs/tasks.md
@@ -1,15 +1,15 @@
 ## 1. `ssd_summarise()` second output
 
-- [x] 1.1 Add a trailing `path_full = NULL` argument to `ssd_summarise()`
+- [x] 1.1 Add a trailing `path_with_samples = NULL` argument to `ssd_summarise()`
   (`R/targets-runner.R`); keep the compact `path` write (the
   `select(-any_of(c("dists", "samples")))` projection collected into R) unchanged.
-- [x] 1.2 When `path_full` is non-`NULL`, also write the full hc union to
-  `path_full` via a lazy DuckDB read→write
-  (`compute_parquet(read_parquet_duckdb(glob, hive_partitioning = FALSE), path_full)`),
+- [x] 1.2 When `path_with_samples` is non-`NULL`, also write the full hc union to
+  `path_with_samples` via a lazy DuckDB read→write
+  (`compute_parquet(read_parquet_duckdb(glob, hive_partitioning = FALSE), path_with_samples)`),
   retaining `dists`/`samples` and never collecting the draws into R.
-- [x] 1.3 Return `path` when `path_full` is `NULL`, else the vector
-  `c(path, path_full)` (the `format = "file"` contract).
-- [x] 1.4 Update the roxygen for `ssd_summarise()` (`@param path_full`, `@return`,
+- [x] 1.3 Return `path` when `path_with_samples` is `NULL`, else the vector
+  `c(path, path_with_samples)` (the `format = "file"` contract).
+- [x] 1.4 Update the roxygen for `ssd_summarise()` (`@param path_with_samples`, `@return`,
   and a `@details`/`@examples` note describing the two outputs and the
   no-R-materialise guarantee for both).
 
@@ -17,7 +17,7 @@
 
 - [x] 2.1 In `ssd_scenario_targets()`, compute
   `summary_full_path <- file.path(root, "summary-samples.parquet")` and pass
-  `path_full` to the `summary` target's `ssd_summarise()` call **iff**
+  `path_with_samples` to the `summary` target's `ssd_summarise()` call **iff**
   `scenario$hc$samples` is `TRUE`.
 - [x] 2.2 Ensure the `summary` target returns the path vector when both files are
   written (verify `format = "file"` tracks both), and is byte-for-byte unchanged
@@ -34,11 +34,11 @@
 
 ## 4. Tests
 
-- [x] 4.1 `samples = TRUE`: `ssd_summarise(..., path_full = ...)` writes both
+- [x] 4.1 `samples = TRUE`: `ssd_summarise(..., path_with_samples = ...)` writes both
   files; assert the full file's `samples` column is populated (and `dists`
   present), the compact omits both, and `est`/`lcl`/`ucl` are identical across
   the two files.
-- [x] 4.2 `path_full = NULL`: only the compact file is written (no second file),
+- [x] 4.2 `path_with_samples = NULL`: only the compact file is written (no second file),
   and the return value is the single path.
 - [x] 4.3 Pipeline: a `samples = TRUE` scenario's `summary` target tracks both
   paths; a `samples = FALSE` scenario tracks only `summary.parquet`.

--- a/openspec/changes/dual-summary-outputs/tasks.md
+++ b/openspec/changes/dual-summary-outputs/tasks.md
@@ -1,50 +1,50 @@
-## 1. `ssd_summarize()` second output
+## 1. `ssd_summarise()` second output
 
-- [ ] 1.1 Add a trailing `path_full = NULL` argument to `ssd_summarize()`
+- [x] 1.1 Add a trailing `path_full = NULL` argument to `ssd_summarise()`
   (`R/targets-runner.R`); keep the compact `path` write (the
   `select(-any_of(c("dists", "samples")))` projection collected into R) unchanged.
-- [ ] 1.2 When `path_full` is non-`NULL`, also write the full hc union to
+- [x] 1.2 When `path_full` is non-`NULL`, also write the full hc union to
   `path_full` via a lazy DuckDB read→write
   (`compute_parquet(read_parquet_duckdb(glob, hive_partitioning = FALSE), path_full)`),
   retaining `dists`/`samples` and never collecting the draws into R.
-- [ ] 1.3 Return `path` when `path_full` is `NULL`, else the vector
+- [x] 1.3 Return `path` when `path_full` is `NULL`, else the vector
   `c(path, path_full)` (the `format = "file"` contract).
-- [ ] 1.4 Update the roxygen for `ssd_summarize()` (`@param path_full`, `@return`,
+- [x] 1.4 Update the roxygen for `ssd_summarise()` (`@param path_full`, `@return`,
   and a `@details`/`@examples` note describing the two outputs and the
   no-R-materialise guarantee for both).
 
 ## 2. Pipeline wiring
 
-- [ ] 2.1 In `ssd_scenario_targets()`, compute
+- [x] 2.1 In `ssd_scenario_targets()`, compute
   `summary_full_path <- file.path(root, "summary-samples.parquet")` and pass
-  `path_full` to the `summary` target's `ssd_summarize()` call **iff**
+  `path_full` to the `summary` target's `ssd_summarise()` call **iff**
   `scenario$hc$samples` is `TRUE`.
-- [ ] 2.2 Ensure the `summary` target returns the path vector when both files are
+- [x] 2.2 Ensure the `summary` target returns the path vector when both files are
   written (verify `format = "file"` tracks both), and is byte-for-byte unchanged
   when `samples = FALSE`.
 
 ## 3. Docs and templates
 
-- [ ] 3.1 Update `vignettes/sharded-pipeline.qmd` to describe the compact vs. full
+- [x] 3.1 Update `vignettes/sharded-pipeline.qmd` to describe the compact vs. full
   summary and the `samples = TRUE` trigger.
-- [ ] 3.2 Update `inst/targets-templates/` run scripts/READMEs that read or report
+- [x] 3.2 Update `inst/targets-templates/` run scripts/READMEs that read or report
   the summary (note the second file appears under `samples = TRUE`).
-- [ ] 3.3 Reflect the two-output contract in `GLOSSARY.md`/`TARGETS-DESIGN.md`
+- [x] 3.3 Reflect the two-output contract in `GLOSSARY.md`/`TARGETS-DESIGN.md`
   where the summary is described, if needed.
 
 ## 4. Tests
 
-- [ ] 4.1 `samples = TRUE`: `ssd_summarize(..., path_full = ...)` writes both
+- [x] 4.1 `samples = TRUE`: `ssd_summarise(..., path_full = ...)` writes both
   files; assert the full file's `samples` column is populated (and `dists`
   present), the compact omits both, and `est`/`lcl`/`ucl` are identical across
   the two files.
-- [ ] 4.2 `path_full = NULL`: only the compact file is written (no second file),
+- [x] 4.2 `path_full = NULL`: only the compact file is written (no second file),
   and the return value is the single path.
-- [ ] 4.3 Pipeline: a `samples = TRUE` scenario's `summary` target tracks both
+- [x] 4.3 Pipeline: a `samples = TRUE` scenario's `summary` target tracks both
   paths; a `samples = FALSE` scenario tracks only `summary.parquet`.
 
 ## 5. Validation
 
-- [ ] 5.1 Format with `air` and run `openspec validate dual-summary-outputs --strict`.
-- [ ] 5.2 Run `R CMD check`/`devtools::test()` for the touched runner and confirm
+- [x] 5.1 Format with `air` and run `openspec validate dual-summary-outputs --strict`.
+- [x] 5.2 Run `R CMD check`/`devtools::test()` for the touched runner and confirm
   the roadmap (§12) bullet matches the shipped behaviour before archiving.

--- a/openspec/changes/dual-summary-outputs/tasks.md
+++ b/openspec/changes/dual-summary-outputs/tasks.md
@@ -1,0 +1,50 @@
+## 1. `ssd_summarize()` second output
+
+- [ ] 1.1 Add a trailing `path_full = NULL` argument to `ssd_summarize()`
+  (`R/targets-runner.R`); keep the compact `path` write (the
+  `select(-any_of(c("dists", "samples")))` projection collected into R) unchanged.
+- [ ] 1.2 When `path_full` is non-`NULL`, also write the full hc union to
+  `path_full` via a lazy DuckDB read→write
+  (`compute_parquet(read_parquet_duckdb(glob, hive_partitioning = FALSE), path_full)`),
+  retaining `dists`/`samples` and never collecting the draws into R.
+- [ ] 1.3 Return `path` when `path_full` is `NULL`, else the vector
+  `c(path, path_full)` (the `format = "file"` contract).
+- [ ] 1.4 Update the roxygen for `ssd_summarize()` (`@param path_full`, `@return`,
+  and a `@details`/`@examples` note describing the two outputs and the
+  no-R-materialise guarantee for both).
+
+## 2. Pipeline wiring
+
+- [ ] 2.1 In `ssd_scenario_targets()`, compute
+  `summary_full_path <- file.path(root, "summary-samples.parquet")` and pass
+  `path_full` to the `summary` target's `ssd_summarize()` call **iff**
+  `scenario$hc$samples` is `TRUE`.
+- [ ] 2.2 Ensure the `summary` target returns the path vector when both files are
+  written (verify `format = "file"` tracks both), and is byte-for-byte unchanged
+  when `samples = FALSE`.
+
+## 3. Docs and templates
+
+- [ ] 3.1 Update `vignettes/sharded-pipeline.qmd` to describe the compact vs. full
+  summary and the `samples = TRUE` trigger.
+- [ ] 3.2 Update `inst/targets-templates/` run scripts/READMEs that read or report
+  the summary (note the second file appears under `samples = TRUE`).
+- [ ] 3.3 Reflect the two-output contract in `GLOSSARY.md`/`TARGETS-DESIGN.md`
+  where the summary is described, if needed.
+
+## 4. Tests
+
+- [ ] 4.1 `samples = TRUE`: `ssd_summarize(..., path_full = ...)` writes both
+  files; assert the full file's `samples` column is populated (and `dists`
+  present), the compact omits both, and `est`/`lcl`/`ucl` are identical across
+  the two files.
+- [ ] 4.2 `path_full = NULL`: only the compact file is written (no second file),
+  and the return value is the single path.
+- [ ] 4.3 Pipeline: a `samples = TRUE` scenario's `summary` target tracks both
+  paths; a `samples = FALSE` scenario tracks only `summary.parquet`.
+
+## 5. Validation
+
+- [ ] 5.1 Format with `air` and run `openspec validate dual-summary-outputs --strict`.
+- [ ] 5.2 Run `R CMD check`/`devtools::test()` for the touched runner and confirm
+  the roadmap (§12) bullet matches the shipped behaviour before archiving.

--- a/tests/testthat/test-task-shards.R
+++ b/tests/testthat/test-task-shards.R
@@ -243,7 +243,7 @@ materialise_shards <- function(scenario, dir) {
   }
 }
 
-test_that("dual-summary-outputs: path_full writes a full summary retaining samples", {
+test_that("dual-summary-outputs: path_with_samples writes a full summary retaining samples", {
   dir <- withr::local_tempdir()
   scenario <- ssd_define_scenario(
     ssd_data(d = numeric_dataset()),
@@ -263,7 +263,7 @@ test_that("dual-summary-outputs: path_full writes a full summary retaining sampl
     file.path(dir, "fit"),
     file.path(dir, "hc"),
     compact_path,
-    path_full = full_path
+    path_with_samples = full_path
   )
   # both paths returned and written
   expect_identical(out, c(compact_path, full_path))
@@ -284,7 +284,7 @@ test_that("dual-summary-outputs: path_full writes a full summary retaining sampl
   expect_equal(sort(compact$ucl), sort(full$ucl))
 })
 
-test_that("dual-summary-outputs: path_full = NULL writes only the compact summary", {
+test_that("dual-summary-outputs: path_with_samples = NULL writes only the compact summary", {
   dir <- withr::local_tempdir()
   scenario <- ssd_define_scenario(
     ssd_data(d = numeric_dataset()),
@@ -335,14 +335,18 @@ test_that("dual-summary-outputs: the pipeline gates the full summary on samples"
     "summary-samples.parquet",
     fixed = TRUE
   )
-  expect_match(summary_cmd(with_samples), "path_full = ", fixed = TRUE)
-  # samples = FALSE injects `path_full = NULL` and no second file path
+  expect_match(summary_cmd(with_samples), "path_with_samples = ", fixed = TRUE)
+  # samples = FALSE injects `path_with_samples = NULL` and no second file path
   expect_no_match(
     summary_cmd(without_samples),
     "summary-samples.parquet",
     fixed = TRUE
   )
-  expect_match(summary_cmd(without_samples), "path_full = NULL", fixed = TRUE)
+  expect_match(
+    summary_cmd(without_samples),
+    "path_with_samples = NULL",
+    fixed = TRUE
+  )
 })
 
 # ---- targets pipeline integration (task 7.4) -------------------------------

--- a/tests/testthat/test-task-shards.R
+++ b/tests/testthat/test-task-shards.R
@@ -215,6 +215,136 @@ test_that("task-shards: ssd_summarise unions landed hc shards without recomputat
   expect_gt(nrow(summary), 0L)
 })
 
+# ---- dual summary outputs (dual-summary-outputs change) --------------------
+
+# Materialise every sample/fit/hc shard for `scenario` under `dir`.
+materialise_shards <- function(scenario, dir) {
+  ss <- ssd_scenario_sample_shards(scenario)
+  fs <- ssd_scenario_fit_shards(scenario)
+  hs <- ssd_scenario_hc_shards(scenario)
+  for (i in seq_len(nrow(ss))) {
+    ssd_run_sample_step(ss$tasks[[i]], scenario, file.path(dir, "sample"))
+  }
+  for (i in seq_len(nrow(fs))) {
+    ssd_run_fit_step(
+      fs$tasks[[i]],
+      scenario,
+      file.path(dir, "sample"),
+      file.path(dir, "fit")
+    )
+  }
+  for (i in seq_len(nrow(hs))) {
+    ssd_run_hc_step(
+      hs$tasks[[i]],
+      scenario,
+      file.path(dir, "fit"),
+      file.path(dir, "hc")
+    )
+  }
+}
+
+test_that("dual-summary-outputs: path_full writes a full summary retaining samples", {
+  dir <- withr::local_tempdir()
+  scenario <- ssd_define_scenario(
+    ssd_data(d = numeric_dataset()),
+    nsim = 1L,
+    seed = 42L,
+    nrow = 6L,
+    dists = "lnorm",
+    ci = TRUE,
+    nboot = 10L,
+    samples = TRUE
+  )
+  materialise_shards(scenario, dir)
+  compact_path <- file.path(dir, "summary.parquet")
+  full_path <- file.path(dir, "summary-samples.parquet")
+  out <- ssd_summarise(
+    file.path(dir, "sample"),
+    file.path(dir, "fit"),
+    file.path(dir, "hc"),
+    compact_path,
+    path_full = full_path
+  )
+  # both paths returned and written
+  expect_identical(out, c(compact_path, full_path))
+  expect_true(all(file.exists(out)))
+
+  compact <- ssd_read_parquet(compact_path)
+  full <- ssd_read_parquet(full_path)
+  # compact projects the heavy list-columns out; full retains them
+  expect_false(any(c("dists", "samples") %in% names(compact)))
+  expect_true(all(c("dists", "samples") %in% names(full)))
+  # the full summary's draws are populated (samples = TRUE)
+  expect_true(any(lengths(full$samples) > 0L))
+  # same rows and identical estimates across the two files (the union read is
+  # unordered, so compare sorted)
+  expect_identical(nrow(compact), nrow(full))
+  expect_equal(sort(compact$est), sort(full$est))
+  expect_equal(sort(compact$lcl), sort(full$lcl))
+  expect_equal(sort(compact$ucl), sort(full$ucl))
+})
+
+test_that("dual-summary-outputs: path_full = NULL writes only the compact summary", {
+  dir <- withr::local_tempdir()
+  scenario <- ssd_define_scenario(
+    ssd_data(d = numeric_dataset()),
+    nsim = 1L,
+    seed = 42L,
+    nrow = 6L,
+    dists = "lnorm"
+  )
+  materialise_shards(scenario, dir)
+  out <- ssd_summarise(
+    file.path(dir, "sample"),
+    file.path(dir, "fit"),
+    file.path(dir, "hc"),
+    file.path(dir, "summary.parquet")
+  )
+  expect_identical(out, file.path(dir, "summary.parquet"))
+  expect_true(file.exists(out))
+  expect_false(file.exists(file.path(dir, "summary-samples.parquet")))
+})
+
+test_that("dual-summary-outputs: the pipeline gates the full summary on samples", {
+  skip_targets()
+  root <- withr::local_tempdir()
+  with_samples <- ssd_define_scenario(
+    ssd_data(d = numeric_dataset()),
+    nsim = 1L,
+    seed = 42L,
+    nrow = 6L,
+    dists = "lnorm",
+    ci = TRUE,
+    nboot = 10L,
+    samples = TRUE
+  )
+  without_samples <- ssd_define_scenario(
+    ssd_data(d = numeric_dataset()),
+    nsim = 1L,
+    seed = 42L,
+    nrow = 6L,
+    dists = "lnorm"
+  )
+  # the summary target is the last element of the factory's list
+  summary_cmd <- function(scenario) {
+    tgts <- ssd_scenario_targets(scenario, root = root)
+    tgts[[length(tgts)]]$command$string
+  }
+  expect_match(
+    summary_cmd(with_samples),
+    "summary-samples.parquet",
+    fixed = TRUE
+  )
+  expect_match(summary_cmd(with_samples), "path_full = ", fixed = TRUE)
+  # samples = FALSE injects `path_full = NULL` and no second file path
+  expect_no_match(
+    summary_cmd(without_samples),
+    "summary-samples.parquet",
+    fixed = TRUE
+  )
+  expect_match(summary_cmd(without_samples), "path_full = NULL", fixed = TRUE)
+})
+
 # ---- targets pipeline integration (task 7.4) -------------------------------
 
 test_that("task-shards: the shipped template tar_make()s every shard", {

--- a/vignettes/sharded-pipeline.qmd
+++ b/vignettes/sharded-pipeline.qmd
@@ -138,7 +138,13 @@ all.equal(base_est, shard_est)
 
 `ssd_summarise()` fans the `hc` layer in across shards (via duckplyr) into a
 single `summary.parquet` --- the analysis-ready table --- without recomputing
-anything.
+anything. It projects the `dists`/`samples` list-columns out at the DuckDB level,
+so the (potentially large) retained bootstrap draws are never pulled into R. Pass
+`path_full =` to **also** write a full summary that keeps those columns; that
+write stays lazy in DuckDB, so the draws never materialise in R there either. In
+the `targets` pipeline the full `summary-samples.parquet` is written
+automatically when the scenario set `samples = TRUE` (the case where the retained
+draws carry information the compact summary cannot).
 
 ## Scaling up: the `targets` pipeline
 

--- a/vignettes/sharded-pipeline.qmd
+++ b/vignettes/sharded-pipeline.qmd
@@ -140,7 +140,7 @@ all.equal(base_est, shard_est)
 single `summary.parquet` --- the analysis-ready table --- without recomputing
 anything. It projects the `dists`/`samples` list-columns out at the DuckDB level,
 so the (potentially large) retained bootstrap draws are never pulled into R. Pass
-`path_full =` to **also** write a full summary that keeps those columns; that
+`path_with_samples =` to **also** write a full summary that keeps those columns; that
 write stays lazy in DuckDB, so the draws never materialise in R there either. In
 the `targets` pipeline the full `summary-samples.parquet` is written
 automatically when the scenario set `samples = TRUE` (the case where the retained


### PR DESCRIPTION
## Summary

Gives the §6 fan-in a second, optional output. `ssd_summarise()` gains a trailing
`path_with_samples = NULL` argument: when supplied it writes **both** the compact
`summary.parquet` (existing behaviour — `dists`/`samples` projected out at the
DuckDB level, never collected into R) and a full `summary-samples.parquet` that
**retains** those list-columns. A single lazy DuckDB read of the `hc` glob feeds
both writes, so the draws never materialise in R.

The targets pipeline requests the full summary **iff** `scenario$hc$samples` is
`TRUE` — the case where the retained draws carry information the compact summary
cannot — and the `summary` target returns the path vector so `targets` tracks
both files under `format = "file"`. With `samples = FALSE` the pipeline is
unchanged (single `summary.parquet`).

Motivation: a user who sets `samples = TRUE` to retain the bootstrap draws
currently finds them absent from the only fan-in artifact and must re-glob the
`hc` shards. Dropping columns from Parquet is cheap, so the run writes both a
compact estimate table and a complete artifact.

## Changes

- **`ssd_summarise()` (`R/targets-runner.R`)** — add `path_with_samples = NULL`.
  One lazy `read_parquet_duckdb(glob, hive_partitioning = FALSE)` (`hc_shards`)
  feeds the compact projection and, when `path_with_samples` is non-`NULL`, a full
  `compute_parquet(hc_shards, path_with_samples)` that retains `dists`/`samples`
  without collecting into R. Returns `path` when `path_with_samples = NULL`, else
  `c(path, path_with_samples)`.
- **`ssd_scenario_targets()` (`R/targets-runner.R`)** — pass
  `path_with_samples = file.path(root, "summary-samples.parquet")` to the
  `summary` target iff `scenario$hc$samples` is `TRUE`; the target returns the
  path vector when both files are written.
- **Docs/templates** — `man/ssd_summarise.Rd` (roxygen), the sharded-pipeline
  vignette, and the `small`/`large`/`cluster` template `run.R` peeks (handle the
  length-2 `tar_read("summary")` value).
- **Tests** (`tests/testthat/test-task-shards.R`) — `samples = TRUE` writes both
  files (full retains a populated `samples`, compact omits it, estimates
  identical); `path_with_samples = NULL` writes only the compact file; the factory
  gates the full path on `samples`.
- **OpenSpec** — `dual-summary-outputs` change (proposal, design, `task-shards`
  delta, tasks) and the `TARGETS-DESIGN.md` §12 roadmap bullet.

## Relationship to `ssd_summarise_uploaded()`

The cloud-upload work (#129) added `ssd_summarise_uploaded(upload, step,
drop_samples = TRUE)`, the **uploaded-read** analogue — a single *lazy* table
whose `samples` projection the caller toggles. This PR is the **local-pipeline**
side: it writes **two files** (the `format = "file"` targets contract). The
asymmetry is intentional — *always write both* locally vs. *pick one* on read —
so the argument is named `path_with_samples`, not `drop_samples`.

## Backward compatibility

Additive: `path_with_samples` defaults to `NULL`, so all existing call sites and
the compact `summary.parquet` (bytes and path) are unchanged.

## Notes

Rebased onto current `main` (`85c77a7`): adapted to the `ssd_summarize` →
`ssd_summarise` rename and its now-lazy compact body, and merged the §12 roadmap
(kept the new `nrow-max-setting` bullet) and the vignette. All OpenSpec tasks are
complete; the change still needs `/opsx:archive` after merge.

https://claude.ai/code/session_01WMHRV8R5sBa2M4ywTQuYcd