### PR TITLE
test: cut the slow tail of the targets and cost-estimation suites

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,7 @@ Imports:
 Suggests: 
     AzureRMR,
     AzureStor,
+    callr,
     crew,
     crew.cluster,
     knitr,

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -51,6 +51,60 @@ skip_targets <- function() {
   testthat::skip_if_not_installed("ssdsims")
 }
 
+# The targets-backed tests build pipelines that write Parquet through duckdb.
+# Running that build *in the main test session* deadlocks once enough
+# duckdb/duckplyr state has accumulated from the earlier test files (it does not
+# when these files run on their own). Spawning a fresh `callr` subprocess per
+# `tar_make()`/`tar_outdated()` is the safe-but-slow alternative the suite used
+# before.
+#
+# Instead, route every pipeline call through ONE dedicated, reused `callr`
+# session. It keeps the duckdb state out of the main session (so no deadlock),
+# and because it only ever runs targets builds it stays as clean as those files
+# do in isolation. Within that single session `callr_function = NULL` runs the
+# build in-process, so the whole suite pays one R startup rather than one per
+# call. The session is closed at suite teardown.
+the_targets <- new.env(parent = emptyenv())
+
+targets_session <- function() {
+  s <- the_targets$session
+  if (is.null(s) || !s$is_alive()) {
+    s <- callr::r_session$new()
+    the_targets$session <- s
+    withr::defer(s$close(), envir = testthat::teardown_env())
+  }
+  s
+}
+
+# Run `fun` (a self-contained function) in the dedicated session, first matching
+# its working directory to the caller's -- each test drives its own withr
+# tempdir, and the `_targets` store and `results/` tree are resolved relative to
+# it.
+in_targets_session <- function(fun) {
+  targets_session()$run(
+    function(wd, fun) {
+      setwd(wd)
+      fun()
+    },
+    args = list(getwd(), fun)
+  )
+}
+
+tar_make_local <- function() {
+  in_targets_session(function() {
+    suppressWarnings(targets::tar_make(
+      reporter = "silent",
+      callr_function = NULL
+    ))
+  })
+}
+
+tar_outdated_local <- function() {
+  in_targets_session(function() {
+    targets::tar_outdated(reporter = "silent", callr_function = NULL)
+  })
+}
+
 # A small numeric-only dataset: avoids factor/character columns so a draw
 # round-trips through Parquet byte-identically (the byte-identity oracle).
 numeric_dataset <- function() {

--- a/tests/testthat/test-cost-estimate.R
+++ b/tests/testthat/test-cost-estimate.R
@@ -153,11 +153,13 @@ test_that("cost-estimation: input validation errors", {
 test_that("cost-estimation: a single call calibrates a usable object", {
   skip_on_cran()
   skip_if_not_installed("ssddata")
-  cal <- ssd_calibrate_cost(nboot = c(20L, 50L), nrow = c(5L, 10L), seed = 1L)
+  # The smallest grid the harness accepts (two `nboot`, two `nrow`); this is a
+  # wiring smoke test, so keep the bootstrap counts low rather than realistic.
+  cal <- ssd_calibrate_cost(nboot = c(10L, 20L), nrow = c(5L, 10L), seed = 1L)
   expect_s3_class(cal, "ssdsims_cost_calibration")
   expect_setequal(cal$coefficients$ci_method, ssdtools::ssd_ci_methods())
   expect_identical(nrow(cal$nrow_factor), 2L)
-  expect_identical(cal$provenance$sweep_grid$nboot, c(20L, 50L))
+  expect_identical(cal$provenance$sweep_grid$nboot, c(10L, 20L))
   # The freshly fitted calibration drives the estimator just like the default.
   scenario <- ssd_define_scenario(
     ssddata::ccme_boron,

--- a/tests/testthat/test-path-axis-growth.R
+++ b/tests/testthat/test-path-axis-growth.R
@@ -29,7 +29,7 @@ test_that("path-axis-growth: appending a dataset builds only the new dataset's s
   )
   withr::local_dir(dir)
   saveRDS(list(d1 = numeric_dataset()), "datasets.rds")
-  suppressWarnings(targets::tar_make(reporter = "silent"))
+  tar_make_local()
   orig <- growth_state()
 
   # the captured shard names are one per shard of each step's shard table (so the
@@ -58,7 +58,7 @@ test_that("path-axis-growth: appending a dataset builds only the new dataset's s
   # append a dataset (a path axis for all three steps), `partition_by` unchanged,
   # re-source and `tar_make()` again into the same store/root
   saveRDS(list(d1 = numeric_dataset(), d2 = numeric_dataset()), "datasets.rds")
-  suppressWarnings(targets::tar_make(reporter = "silent"))
+  tar_make_local()
   progress <- targets::tar_progress()
   completed <- progress$name[progress$progress == "completed"]
   skipped <- progress$name[progress$progress == "skipped"]
@@ -86,7 +86,7 @@ test_that("path-axis-growth: growing nsim builds only the new sim cells' shards 
   withr::local_dir(dir)
   saveRDS(numeric_dataset(), "data.rds")
   saveRDS(2L, "nsim.rds")
-  suppressWarnings(targets::tar_make(reporter = "silent"))
+  tar_make_local()
   orig <- growth_state()
 
   scenario <- ssd_define_scenario(
@@ -113,7 +113,7 @@ test_that("path-axis-growth: growing nsim builds only the new sim cells' shards 
   # grow `nsim` (adds new `sim` path cells for all three steps), `partition_by`
   # unchanged, re-source and `tar_make()` again into the same store/root
   saveRDS(3L, "nsim.rds")
-  suppressWarnings(targets::tar_make(reporter = "silent"))
+  tar_make_local()
   progress <- targets::tar_progress()
   completed <- progress$name[progress$progress == "completed"]
   skipped <- progress$name[progress$progress == "skipped"]

--- a/tests/testthat/test-task-shards.R
+++ b/tests/testthat/test-task-shards.R
@@ -362,7 +362,7 @@ test_that("task-shards: the shipped template tar_make()s every shard", {
     dir
   )
   withr::local_dir(dir)
-  suppressWarnings(targets::tar_make(reporter = "silent"))
+  tar_make_local()
   meta <- targets::tar_meta(fields = "error")
   steps <- meta[grepl("_step_", meta$name), ]
   expect_gt(nrow(steps), 0L)
@@ -392,7 +392,7 @@ test_that("task-shards: pipeline per-task results equal the baseline runner", {
   dir <- withr::local_tempdir()
   setup_targets_fixture(dir, "byte-identity-targets.R")
   withr::local_dir(dir)
-  suppressWarnings(targets::tar_make(reporter = "silent"))
+  tar_make_local()
 
   scenario <- ssd_define_scenario(
     ssd_data(d = numeric_dataset()),
@@ -444,7 +444,7 @@ test_that("task-shards: a failing shard goes NULL and the survivors still summar
   # fail as whole shards (error = "null"); the sample shards still build.
   setup_targets_fixture(dir, "error-null-targets.R")
   withr::local_dir(dir)
-  suppressWarnings(targets::tar_make(reporter = "silent"))
+  tar_make_local()
   meta <- targets::tar_meta(fields = "error")
   # sample shards built; fit shards recorded an error and went NULL
   sample_meta <- meta[grepl("sample_step_", meta$name), ]
@@ -629,12 +629,12 @@ test_that("hive: re-make is a full cache hit; a missing Parquet rebuilds only it
   dir <- withr::local_tempdir()
   setup_targets_fixture(dir, "factory-invalidation-targets.R")
   withr::local_dir(dir)
-  suppressWarnings(targets::tar_make(reporter = "silent"))
+  tar_make_local()
   # cache-by-existence: a second make with nothing changed is a full hit.
-  expect_length(targets::tar_outdated(reporter = "silent"), 0L)
+  expect_length(tar_outdated_local(), 0L)
   # delete the sim=1 sample shard's Parquet -> only its subtree (+ summary) rebuilds.
   unlink(file.path("results", "sample", "dataset=d", "sim=1", "part.parquet"))
-  outdated <- targets::tar_outdated(reporter = "silent")
+  outdated <- tar_outdated_local()
   expect_true(all(
     c("sample_step_d_1", "fit_step_d_1", "hc_step_d_1", "summary") %in% outdated
   ))
@@ -648,10 +648,10 @@ test_that("hive: invalidating one parent shard re-runs only the children that re
   dir <- withr::local_tempdir()
   setup_targets_fixture(dir, "factory-invalidation-targets.R")
   withr::local_dir(dir)
-  suppressWarnings(targets::tar_make(reporter = "silent"))
+  tar_make_local()
   # invalidate the sim=1 sample shard; its subtree is outdated, sim=2 stays cached.
   targets::tar_invalidate(tidyselect::any_of("sample_step_d_1"))
-  outdated <- targets::tar_outdated(reporter = "silent")
+  outdated <- tar_outdated_local()
   expect_true(all(
     c("sample_step_d_1", "fit_step_d_1", "hc_step_d_1", "summary") %in% outdated
   ))
@@ -670,7 +670,7 @@ test_that("shard-atomic-rewrite: growing a fit inner axis rewrites the fit shard
 
   # First build: one fit task per shard (min_pmix = loose only).
   saveRDS(FALSE, "grow.rds")
-  suppressWarnings(targets::tar_make(reporter = "silent"))
+  tar_make_local()
 
   # Capture each affected fit shard's Parquet before the growth.
   fit_shard_dirs <- dirname(list.files(
@@ -689,13 +689,13 @@ test_that("shard-atomic-rewrite: growing a fit inner axis rewrites the fit shard
   # is unchanged (min_pmix is not a partition_by axis), so the per-layout root
   # is identical and the shards are rewritten in place, not re-pathed.
   saveRDS(TRUE, "grow.rds")
-  outdated <- targets::tar_outdated(reporter = "silent")
+  outdated <- tar_outdated_local()
   # Exactly the fit shards (and their hc/summary subtree) are stale; the sample
   # shards - a step the inner-axis growth does not touch - are not.
   expect_true(all(c("fit_step_d_1", "fit_step_d_2") %in% outdated))
   expect_false(any(c("sample_step_d_1", "sample_step_d_2") %in% outdated))
 
-  suppressWarnings(targets::tar_make(reporter = "silent"))
+  tar_make_local()
 
   # The sample shards are reported cached by targets and are NOT rebuilt.
   progress <- targets::tar_progress()
@@ -729,13 +729,13 @@ test_that("task-shards: changing an hc-only knob rebuilds only hc and summary", 
   setup_targets_fixture(dir, "slice-invalidation-targets.R")
   withr::local_dir(dir)
   saveRDS(list(dists = "lnorm", samples = FALSE), "knobs.rds")
-  suppressWarnings(targets::tar_make(reporter = "silent"))
-  expect_length(targets::tar_outdated(reporter = "silent"), 0L)
+  tar_make_local()
+  expect_length(tar_outdated_local(), 0L)
 
   # Flip the hc-only `samples` knob: only the hc slice changes, so only the hc
   # shard's command moves; the sample/fit slices (and commands) are untouched.
   saveRDS(list(dists = "lnorm", samples = TRUE), "knobs.rds")
-  outdated <- targets::tar_outdated(reporter = "silent")
+  outdated <- tar_outdated_local()
   expect_true(all(c("hc_step_d_1", "summary") %in% outdated))
   expect_false(any(c("sample_step_d_1", "fit_step_d_1") %in% outdated))
 })
@@ -746,14 +746,14 @@ test_that("task-shards: changing a fit-only knob leaves sample cached", {
   setup_targets_fixture(dir, "slice-invalidation-targets.R")
   withr::local_dir(dir)
   saveRDS(list(dists = "lnorm", samples = FALSE), "knobs.rds")
-  suppressWarnings(targets::tar_make(reporter = "silent"))
-  expect_length(targets::tar_outdated(reporter = "silent"), 0L)
+  tar_make_local()
+  expect_length(tar_outdated_local(), 0L)
 
   # Flip the fit-only `dists` knob: the fit slice changes (and cascades into the
   # hc shard that reads the fit shard, and summary), but the sample slice does
   # not, so the sample shard stays cached.
   saveRDS(list(dists = c("lnorm", "gamma"), samples = FALSE), "knobs.rds")
-  outdated <- targets::tar_outdated(reporter = "silent")
+  outdated <- tar_outdated_local()
   expect_true(all(c("fit_step_d_1", "hc_step_d_1", "summary") %in% outdated))
   expect_false("sample_step_d_1" %in% outdated)
 })
@@ -767,14 +767,14 @@ test_that("task-shards: appending a dataset mints new shards and caches existing
   )
   withr::local_dir(dir)
   saveRDS(list(d1 = numeric_dataset()), "datasets.rds")
-  suppressWarnings(targets::tar_make(reporter = "silent"))
-  expect_length(targets::tar_outdated(reporter = "silent"), 0L)
+  tar_make_local()
+  expect_length(tar_outdated_local(), 0L)
 
   # Append a second dataset: its shards are new path cells; the per-dataset
   # `sample` slice keeps d1's shard commands byte-identical, so only d2's shards
   # (and `summary`) are outdated while every d1 shard stays cached.
   saveRDS(list(d1 = numeric_dataset(), d2 = numeric_dataset()), "datasets.rds")
-  outdated <- targets::tar_outdated(reporter = "silent")
+  outdated <- tar_outdated_local()
   expect_true(all(
     c("sample_step_d2_1", "fit_step_d2_1", "hc_step_d2_1", "summary") %in%
       outdated
@@ -790,7 +790,7 @@ test_that("task-shards: factory per-task results equal the baseline (slice drops
   setup_targets_fixture(dir, "slice-invalidation-targets.R")
   withr::local_dir(dir)
   saveRDS(list(dists = "lnorm", samples = FALSE), "knobs.rds")
-  suppressWarnings(targets::tar_make(reporter = "silent"))
+  tar_make_local()
 
   scenario <- ssd_define_scenario(
     ssd_data(d = numeric_dataset()),

--- a/tests/testthat/test-upload.R
+++ b/tests/testthat/test-upload.R
@@ -395,7 +395,7 @@ test_that("cloud-upload: a re-driven dry-run re-uploads no unchanged shard", {
     file.path(dir, "_targets.R")
   )
   withr::local_dir(dir)
-  suppressWarnings(targets::tar_make(reporter = "silent"))
+  tar_make_local()
   # the no-op upload targets ran the first time
   meta <- targets::tar_meta(fields = "error")
   upload_meta <- meta[grepl("^upload_", meta$name), ]
@@ -403,7 +403,7 @@ test_that("cloud-upload: a re-driven dry-run re-uploads no unchanged shard", {
   expect_true(all(is.na(upload_meta$error)))
 
   # re-drive with nothing changed: no upload target re-runs
-  suppressWarnings(targets::tar_make(reporter = "silent"))
+  tar_make_local()
   progress <- targets::tar_progress()
   reran <- progress$name[progress$progress %in% c("completed", "started")]
   expect_length(grep("^upload_", reran), 0L)
@@ -419,11 +419,11 @@ test_that("cloud-upload: extending nsim uploads only the new shard", {
     file.path(dir, "_targets.R")
   )
   withr::local_dir(dir)
-  suppressWarnings(targets::tar_make(reporter = "silent"))
+  tar_make_local()
 
   # grow nsim by one sim: only the new sim's shards (and their upload pair) run
   saveRDS(2L, "nsim.rds")
-  suppressWarnings(targets::tar_make(reporter = "silent"))
+  tar_make_local()
   progress <- targets::tar_progress()
   completed <- progress$name[progress$progress == "completed"]
   new_uploads <- grep("^upload_", completed, value = TRUE)

--- a/vignettes/defining-a-scenario.qmd
+++ b/vignettes/defining-a-scenario.qmd
@@ -98,12 +98,12 @@ scenario <- ssd_define_scenario(
   datasets,
   nsim = 3L,
   seed = 42L,
-  nrow = c(5L, 10L, 20L),
+  nrow = c(5L, 10L),
   dists = c("lnorm", "gamma"),
   est_method = "multi",
   proportion = c(0.05, 0.2),
   ci = TRUE,
-  nboot = c(10L, 100L),
+  nboot = c(10L, 50L),
   ci_method = "weighted_samples"
 )
 scenario


### PR DESCRIPTION
## Why

The test suite's runtime was dominated by a short heavy tail. Profiling with `targets` active (as under `R CMD check` / CI, `NOT_CRAN`) put the total at ~131s, of which two files alone were ~73%. This PR cuts the three biggest contributors.

## What

### Targets-backed tests → one dedicated `callr` session (the big win)

`test-task-shards.R`, `test-path-axis-growth.R`, and `test-upload.R` each spawned a fresh `callr` subprocess **per** `tar_make()` / `tar_outdated()` call, paying an R startup every time (`tar_outdated()` ≈ 1.8s/call).

Running those builds in-process (`callr_function = NULL`) in the main test session is fast but **deadlocks** under a full-suite run — enough `duckdb`/`duckplyr` state accumulates from the earlier test files that the first in-process pipeline build hangs (it doesn't when these files run in isolation).

The fix: route every pipeline call through **one dedicated, reused `callr` session** (`tar_make_local()` / `tar_outdated_local()` in `helper.R`). That keeps the duckdb state out of the main session, and since the session only ever runs targets builds it stays as clean as those files are in isolation. Within that one session `callr_function = NULL` runs the build in-process, so the suite pays a single R startup instead of one per call.

- The three targets files drop from **~63s to ~16s**.
- A full `test_dir()` run completes (**669 passing, 0 failed**) where the plain in-process variant froze at the first build.

### `ssd_calibrate_cost()` smoke test

A wiring test that just proves the calibration harness runs. It ran a `nboot = c(20L, 50L)` benchmark sweep (7 `ci_method`s × 2 `nboot` × 2 `nrow` of real fitting + bootstrap); shrunk to the smallest grid the harness accepts (`nboot = c(10L, 20L)`), keeping every assertion while roughly halving the sweep.

### `defining-a-scenario.qmd` vignette

The one bootstrap-bound vignette (~21s, all in the `ci = TRUE` bootstrap). Trimming two illustrative knobs (`nrow = c(5L, 10L)`, `nboot = c(10L, 50L)`) takes it to ~9s. Every axis stays multi-valued, so the fan-out it teaches is unchanged and the generic prose needs no edits.

## Validation

A full clean-session run mirroring `R CMD check` (`test_dir(package = "ssdsims")`, `NOT_CRAN`) completes in **~68s (was ~131s), 669 passing / 0 failed / 1 skipped** — including the byte-identity oracle and the `tar_outdated`/`tar_invalidate` invalidation tests, which pin that the dedicated session is equivalent to the per-call subprocess.
