### PR TITLE
docs(openspec): propose cost-analysis-targets change

### DIFF
--- a/openspec/changes/cost-analysis-targets/.openspec.yaml
+++ b/openspec/changes/cost-analysis-targets/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-10

--- a/openspec/changes/cost-analysis-targets/design.md
+++ b/openspec/changes/cost-analysis-targets/design.md
@@ -2,130 +2,167 @@
 
 The `cost-estimation` capability (`R/cost-estimate.R`) predicts a scenario's
 compute cost from a per-`ci_method` model `time = (base + slope × max(nboot, n0))
-× nrow_factor(nrow) + fixed_addend`. Its coefficients come from
-`ssd_calibrate_cost()`, a synthetic micro-benchmark that resamples a reference
-dataset and times tiny `ssd_hc()` calls — it never touches the real `targets`
-pipeline. A real run, meanwhile, leaves a complete record of ground-truth
-durations: `targets` writes a `seconds` field per target into its meta store,
-readable read-only with `targets::tar_meta()`.
+× nrow_factor(nrow) + fixed_addend`, calibrated by a synthetic micro-benchmark
+(`ssd_calibrate_cost()`) that never touches the real pipeline. A real run leaves
+ground truth behind at two granularities:
 
-The pipeline (`ssd_scenario_targets()`, `R/targets-runner.R`) fans a scenario out
-into one named, `format = "file"` shard target per `partition_by` path cell, via
-`tarchetypes::tar_map(values = <step>_shards, names = <path axes>)`. The minted
-names are `<step>_step_<pathcell>` (e.g. `hc_step_boron_1`). The shard layout —
-which axes a step partitions on and which task rows fall in each cell — is a pure
-function of the scenario (`ssd_scenario_<step>_shards()`,
-`scenario_partition_axes()`, `path_key()`), so a target name can be mapped back
-to its shard, and a shard's `tasks` list-column carries every axis value
-(`ci_method`, `nboot`, `nrow`, `dataset`, `sim`, …) the cost model keys on.
+- the `targets` meta store records wall `seconds` per *target* — i.e. per
+  **shard**, since `ssd_scenario_targets()` mints one named `format = "file"`
+  target per `partition_by` path cell (`<step>_step_<pathcell>`);
+- the *task* granularity does not exist anywhere today — an `hc` shard bundles
+  tasks with different `nboot`/`ci_method`, so shard seconds alone cannot be
+  attributed to the model's axes without inference.
 
-This change reads that store, attributes each shard target's `seconds` to the
-scenario shard (and its task axes) that produced it, and uses the result to
-validate and recalibrate the estimator.
+This change instruments the `fit`/`hc` runners with per-task timings carried
+**in the shard Parquets themselves**, and builds the analysis on top: measured
+per-task durations as the primary source, the targets store as the per-shard
+envelope and as the fallback for pre-timing runs.
+
+Constraints that shaped the design: deliverable-scale scenarios run to the order
+of ~450k shard files, so the shard-file count is the object budget; the
+shard-runner spec pins per-task results byte-identical to the in-memory baseline
+oracle; the invalidation and upload models content-hash the `format = "file"`
+Parquets; the per-scenario manifest is parked (no sidecar provenance mechanism
+exists or should be revived here).
 
 ## Goals / Non-Goals
 
 **Goals:**
-- Read a completed run's per-target durations from the `targets` store and
-  attribute them to scenario shards/axes (`ssd_analyse_cost()`).
-- Recalibrate the existing `ssdsims_cost_calibration` model from an observed run's
-  `hc`-shard durations (`ssd_calibrate_cost_from_run()`), reusing the
-  `cost-estimation` fitting helpers so the object shape is identical.
-- Compare predicted vs observed in one object (`ssd_compare_cost()`).
-- Be strictly read-only: no pipeline execution, no RNG, no writes.
+- Measure per-task cost in-band: `.start`/`.end`/`.host` columns on the `fit`
+  and `hc` shard rows, captured by the step runners and the baseline runner.
+- Read a run's observed cost back and attribute it to scenario axes
+  (`ssd_analyse_cost()`); compare against the prediction (`ssd_compare_cost()`);
+  recalibrate the model from measured durations (`ssd_calibrate_cost_from_run()`).
+- Use the targets store for what only it can say: the per-shard envelope
+  (`target seconds − Σ task durations` = read/write/dispatch overhead, the
+  `partition_by`-tuning number) and the fallback for pre-timing runs.
+- Keep the analysis functions strictly read-only (no pipeline, no RNG, no writes).
 
 **Non-Goals:**
-- Changing the cost model's *form* or any `cost-estimation` requirement (reused
-  as-is).
-- Profiling within a shard (per-task timing inside one target) — `targets` times
-  at the target granularity, so the shard is the finest observable unit; per-task
-  attribution is by even division within a shard where needed, not measured.
-- Live progress monitoring of a running pipeline (this reads a *finished* store).
-- Any new on-disk artifact or manifest.
+- Changing the cost model's *form* or any `cost-estimation` requirement.
+- Sidecar files or any per-shard provenance artifact (no manifest revival): the
+  timing data rides inside `part.parquet`, adding zero files.
+- Timing the `sample` step (cheap; stays inside the model's `fixed_addend` —
+  and keeps the sample layer file-level deterministic).
+- Instrumenting the legacy `ssd_*_sims` family (waits for `migrate-public-api`).
+- Live progress monitoring of a running pipeline.
 
 ## Decisions
 
-### Attribute at the shard (target) granularity, divide to tasks only for hc fits
-`targets` records one `seconds` per target, and a target is a shard (many tasks),
-so the shard is the finest *measured* unit. For the totals (`total`, `longest`)
-this is exact: sum and max over shard `seconds`. For the per-axis breakdown and
-recalibration, an `hc` shard may bundle several tasks (different `nboot` /
-`ci_method`); the cost model attributes per task by the model's own predicted
-share, i.e. split a shard's observed `seconds` across its tasks in proportion to
-the *predicted* per-task seconds, then aggregate by axis. This keeps the
-breakdown keyed identically to `ssd_estimate_cost()` while staying honest that
-the measurement is per shard. *Alternative considered:* divide equally across a
-shard's tasks — rejected because `nboot` varies within a shard and equal division
-would mis-rank the costly cells; proportional-to-prediction is the least-biased
-split given only the shard total.
+### Timing columns in-band, not sidecars
+A per-shard `timings.parquet` sidecar would keep `part.parquet` byte-stable but
+**doubles the object count** (~450k → ~900k files at deliverable scale): inode
+pressure, blob-store object counts, and every glob/listing operation pay for a
+few bytes of timing per task. In-band columns add zero files, survive
+`shard-failure-survival`'s future shorter-shard semantics for free (survivors'
+timings are just surviving rows), and travel with uploads. *Rejected
+alternatives:* sidecar files (file count); the targets store alone (shard
+granularity only, targets-only, prunable, doesn't travel).
 
-### Resolve target → shard via the scenario, not by re-parsing Hive paths
-The target name suffix is produced by `tar_map`'s `names` from the path-axis
-columns; the cleanest inverse is to *regenerate* the expected names from the
-scenario (reuse `shard_cell_names()` / `scenario_partition_axes()` logic) and
-join the store's `name` column to them, rather than string-splitting
-`<step>_step_<...>` heuristically (axis values can themselves contain
-separators). The scenario is the source of truth for the layout; the store
-supplies only `name` and `seconds`. *Alternative considered:* parse the name with
-a regex — rejected as brittle against dataset names with underscores and against
-`partition_by` changes.
+### Byte-identity narrows to result columns — fit/hc only
+The shard-runner contract ("per-task results byte-identical to the baseline
+oracle") is restated over **result columns** joined on `<step>_id`, with
+`.start`/`.end`/`.host` enumerated out (a delta on the `shard-runner` spec).
+`sample` is not timed, so sample shards keep full file-level determinism. The
+real cost is that a `fit`/`hc` shard's **file hash is no longer deterministic
+across recomputes**: a forced recompute with identical results now re-runs
+dependents and re-uploads (see Risks). Traced against the §8 extension stories
+this loss is narrow — inner-axis growth changes result bytes anyway, and the
+code-edit-without-result-change case is what the §8.3 pin
+(`tar_cue(depend = FALSE)`) is designed for.
 
-### Recalibration reuses `calibrate_coefficients()` / `calibrate_nrow_factor()`
-`R/cost-estimate.R` already fits `time ~ pmax(nboot, n0)` per `ci_method` and the
-bounded `nrow_factor` from a `sweep` data frame with columns `nrow`, `ci_method`,
-`nboot`, `time`. `ssd_calibrate_cost_from_run()` builds that same `sweep` frame
-from observed `hc`-shard per-task seconds and calls the existing (unexported)
-helpers, so the run-derived `ssdsims_cost_calibration` is byte-shape-identical to
-a sweep-derived one and drops straight into `ssd_estimate_cost()`. Only the
-provenance differs (a `source = "run"` marker plus the store path and the
-observed run date). *Alternative considered:* a separate fitter — rejected as
-duplication; the model form is shared by contract.
+### `.start`/`.end` as UTC timestamps, `.host` as the CPU description
+Start+end (not duration-only) costs the same storage and is strictly richer: it
+reconstructs the run's actual concurrency (per-worker Gantt, straggler
+detection, whether the longest task gated wall time). Stored as Parquet
+TIMESTAMP (UTC) via duckplyr; duration is derived. `.host` carries the existing
+`cost_cpu_info()` description — the grain the architecture-specific calibration
+pools on (identical cluster nodes pool together; a nodename would fragment
+them). On the `hc` layer the values repeat across a task's `proportion` rows and
+RLE-compress to ~nothing.
 
-### `targets` becomes a hard requirement for these functions, via `check_installed`
-`targets` is in `Suggests`. The new functions `rlang::check_installed("targets")`
-at entry and call `targets::tar_meta()` / `targets::tar_config_get()`; the package
-still installs without `targets`, matching how `ssd_scenario_targets()` already
-guards `targets`/`tarchetypes`. *Alternative considered:* promote `targets` to
-`Imports` — rejected; the rest of the package (scenario, task tables, single-core
-runner) needs no `targets`, and the existing factory already uses the
-`check_installed` pattern.
+### Capture in the runners, not the task primitives
+The `*_data_task_primer()` primitives return domain objects (a `fitdists`, an hc
+tibble); bracketing each task in the step-runner loops (`ssd_run_fit_step()`,
+`ssd_run_hc_step()`, and the baseline's fit/hc loops) keeps the primitives pure
+and the capture in one obvious place per runner. `Sys.time()` is RNG-neutral and
+its microsecond resolution is ample against `fixed_addend`-scale (~0.05 s) tasks.
+
+### Summaries keep the timing columns
+`ssd_summarise()` continues to project out `dists`/`samples` but retains
+`.start`/`.end`/`.host`: tiny scalar columns that make observed hc cost
+queryable from `summary.parquet` alone — no 450k-file glob, and it works after
+upload when shards are remote. `ssd_analyse_cost()` itself reads the shard glob
+(it needs the `fit` layer too, and projects only id + timing columns at the
+DuckDB level, never decoding blobs); the summary is the convenient ad-hoc query
+surface, not the function's input.
+
+### Targets store: envelope and fallback, resolved via the scenario
+With measured task durations in-band, `tar_meta()$seconds` is demoted to what
+only it can say: the per-shard envelope (`target seconds − Σ task durations`),
+and the fallback for runs predating the timing columns (attribution proportional
+to the *predicted* per-task cost, marked as inferred). Target names resolve back
+to shards by **regenerating** the expected `<step>_step_<pathcell>` names from
+the scenario (reusing the `shard_cell_names()`/`scenario_partition_axes()`
+logic) and joining on the store's `name` column — never by string-parsing the
+name (axis values can contain separators). Unmatched targets are reported, not
+silently dropped; `NA`-seconds (errored/unbuilt) targets are excluded from
+totals with the contributing count surfaced.
+
+### Recalibration reuses the existing fitters, host-aware
+`ssd_calibrate_cost_from_run()` builds the same sweep frame
+(`nrow`, `ci_method`, `nboot`, `time`) `ssd_calibrate_cost()` fits — now from
+measured hc task durations — and calls the existing unexported
+`calibrate_coefficients()`/`calibrate_nrow_factor()`, so the run-derived
+`ssdsims_cost_calibration` is shape-identical and drops straight into
+`ssd_estimate_cost()`. The fixed addend comes from measured fit durations (the
+sample remainder stays assumed-negligible). Because the calibration is
+architecture-specific, mixed `.host` values are never pooled silently: the
+caller picks a host or the function aborts listing them. Provenance records the
+run-derived source and date.
 
 ### S3 objects mirror the cost-estimation pattern
 `ssdsims_cost_analysis` and `ssdsims_cost_comparison` follow the existing
-`ssdsims_cost_estimate` shape: a list with `difftime` totals, a `breakdown`
-tibble, and provenance, plus `format`/`print` methods reusing `format_duration()`.
-This keeps the three cost objects visually and structurally consistent.
+`ssdsims_cost_estimate` shape (difftime totals, `breakdown` tibble, provenance)
+with `format`/`print` methods reusing `format_duration()`.
 
 ## Risks / Trade-offs
 
-- [Per-task attribution within a multi-task `hc` shard is inferred, not measured]
-  → Document it: totals/longest are exact at shard granularity; the per-axis
-  split is proportional-to-prediction. A user wanting per-task ground truth can
-  push more axes into `partition_by` so each task is its own shard.
-- [A target name regenerated from the scenario may not match the store if the
-  scenario or `partition_by` changed since the run] → Join on name and report
-  unmatched targets rather than silently dropping or aborting; surface the matched
-  count so a mismatch is visible.
-- [Store schema / `tar_meta()` columns could shift across `targets` versions] →
-  Depend only on the long-stable `name` and `seconds` columns; guard the
-  `check_installed` minimum if a floor is needed.
-- [Errored shards carry `NA` seconds] → Exclude from totals (spec requirement),
-  count contributors, so a partially-failed run still analyses cleanly.
+- [Forced recompute of a fit/hc shard with identical results now cascades:
+  dependents re-run and `upload_<step>` re-ships, because the file hash includes
+  volatile timing columns] → Scoped to fit/hc (sample unaffected); inner-axis
+  growth changed bytes anyway; the §8.3 pin covers code-edit recomputes;
+  documented in the factory's invalidation-model docs. Watch the re-upload arm
+  at scale — egress on a forced refresh is the practical cost.
+- [Schema change on fit/hc shards and summaries breaks existing readers/tests]
+  → Pre-release package (0.0.0.9015, breaking allowed); oracle and
+  atomic-rewrite tests move to result-column comparisons; snapshots update once.
+- [Mixed-host results trees (cluster + local debugging shards) would corrupt a
+  pooled calibration] → `.host` in-band; recalibration refuses silent pooling.
+- [Regenerated target names may not match the store if the scenario or
+  `partition_by` changed since the run] → Join-and-report: unmatched targets are
+  surfaced with counts, never silently dropped, never fatal.
+- [`tar_meta()` schema drift across targets versions] → Depend only on the
+  long-stable `name`/`seconds` columns.
+- [Clock skew across cluster nodes makes cross-node `.start` ordering
+  approximate] → Durations are within-node differences (unaffected); document
+  that cross-node Gantt reconstruction is approximate.
 
 ## Migration Plan
 
-Purely additive: new file `R/cost-analysis.R`, new exports, new vignette, new
-`_pkgdown.yml` entries. No existing function, object, or output changes, so no
-rollback beyond reverting the new file and its exports. `targets` stays a
-`Suggests`; only the new functions require it at call time.
+Additive API plus an output-schema change on the fit/hc layers. Order of
+landing inside the change: (1) runner instrumentation + shard-runner spec delta
++ test migration to result-column identity; (2) analysis functions consuming the
+columns; (3) docs/vignette. Pre-release, no compatibility shim: old results
+trees simply lack the columns and route to the tar_meta fallback. Rollback is
+reverting the runner edits and the new file; no on-disk migration exists either
+way.
 
 ## Open Questions
 
-- Should `ssd_compare_cost()` also emit a per-`ci_method` predicted/observed slope
-  ratio (a finer recalibration diagnostic) or is the total/longest ratio enough
-  for the first cut? Leaning to start with totals/longest and add the per-cell
-  diagnostic if the worked vignette shows it is needed.
-- Where the observed run used real parallelism, the store's `seconds` is per-target
-  wall time; summing gives serial-equivalent total (consistent with
-  `ssd_estimate_cost()`'s serial total). Confirm the vignette frames "total" as
-  serial-equivalent to avoid confusion with elapsed wall time under workers.
+- The hc longest-*task* is now measured, but the longest-*shard* (the actual
+  dispatch unit under crew) comes from the envelope; the analysis print method
+  should probably show both. Decide the exact print layout during implementation.
+- Whether `ssd_compare_cost()` should also emit per-`ci_method` predicted/observed
+  slope ratios (a finer diagnostic) — start with totals/longest and let the
+  vignette's worked example decide.

--- a/openspec/changes/cost-analysis-targets/design.md
+++ b/openspec/changes/cost-analysis-targets/design.md
@@ -1,0 +1,131 @@
+## Context
+
+The `cost-estimation` capability (`R/cost-estimate.R`) predicts a scenario's
+compute cost from a per-`ci_method` model `time = (base + slope × max(nboot, n0))
+× nrow_factor(nrow) + fixed_addend`. Its coefficients come from
+`ssd_calibrate_cost()`, a synthetic micro-benchmark that resamples a reference
+dataset and times tiny `ssd_hc()` calls — it never touches the real `targets`
+pipeline. A real run, meanwhile, leaves a complete record of ground-truth
+durations: `targets` writes a `seconds` field per target into its meta store,
+readable read-only with `targets::tar_meta()`.
+
+The pipeline (`ssd_scenario_targets()`, `R/targets-runner.R`) fans a scenario out
+into one named, `format = "file"` shard target per `partition_by` path cell, via
+`tarchetypes::tar_map(values = <step>_shards, names = <path axes>)`. The minted
+names are `<step>_step_<pathcell>` (e.g. `hc_step_boron_1`). The shard layout —
+which axes a step partitions on and which task rows fall in each cell — is a pure
+function of the scenario (`ssd_scenario_<step>_shards()`,
+`scenario_partition_axes()`, `path_key()`), so a target name can be mapped back
+to its shard, and a shard's `tasks` list-column carries every axis value
+(`ci_method`, `nboot`, `nrow`, `dataset`, `sim`, …) the cost model keys on.
+
+This change reads that store, attributes each shard target's `seconds` to the
+scenario shard (and its task axes) that produced it, and uses the result to
+validate and recalibrate the estimator.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Read a completed run's per-target durations from the `targets` store and
+  attribute them to scenario shards/axes (`ssd_analyse_cost()`).
+- Recalibrate the existing `ssdsims_cost_calibration` model from an observed run's
+  `hc`-shard durations (`ssd_calibrate_cost_from_run()`), reusing the
+  `cost-estimation` fitting helpers so the object shape is identical.
+- Compare predicted vs observed in one object (`ssd_compare_cost()`).
+- Be strictly read-only: no pipeline execution, no RNG, no writes.
+
+**Non-Goals:**
+- Changing the cost model's *form* or any `cost-estimation` requirement (reused
+  as-is).
+- Profiling within a shard (per-task timing inside one target) — `targets` times
+  at the target granularity, so the shard is the finest observable unit; per-task
+  attribution is by even division within a shard where needed, not measured.
+- Live progress monitoring of a running pipeline (this reads a *finished* store).
+- Any new on-disk artifact or manifest.
+
+## Decisions
+
+### Attribute at the shard (target) granularity, divide to tasks only for hc fits
+`targets` records one `seconds` per target, and a target is a shard (many tasks),
+so the shard is the finest *measured* unit. For the totals (`total`, `longest`)
+this is exact: sum and max over shard `seconds`. For the per-axis breakdown and
+recalibration, an `hc` shard may bundle several tasks (different `nboot` /
+`ci_method`); the cost model attributes per task by the model's own predicted
+share, i.e. split a shard's observed `seconds` across its tasks in proportion to
+the *predicted* per-task seconds, then aggregate by axis. This keeps the
+breakdown keyed identically to `ssd_estimate_cost()` while staying honest that
+the measurement is per shard. *Alternative considered:* divide equally across a
+shard's tasks — rejected because `nboot` varies within a shard and equal division
+would mis-rank the costly cells; proportional-to-prediction is the least-biased
+split given only the shard total.
+
+### Resolve target → shard via the scenario, not by re-parsing Hive paths
+The target name suffix is produced by `tar_map`'s `names` from the path-axis
+columns; the cleanest inverse is to *regenerate* the expected names from the
+scenario (reuse `shard_cell_names()` / `scenario_partition_axes()` logic) and
+join the store's `name` column to them, rather than string-splitting
+`<step>_step_<...>` heuristically (axis values can themselves contain
+separators). The scenario is the source of truth for the layout; the store
+supplies only `name` and `seconds`. *Alternative considered:* parse the name with
+a regex — rejected as brittle against dataset names with underscores and against
+`partition_by` changes.
+
+### Recalibration reuses `calibrate_coefficients()` / `calibrate_nrow_factor()`
+`R/cost-estimate.R` already fits `time ~ pmax(nboot, n0)` per `ci_method` and the
+bounded `nrow_factor` from a `sweep` data frame with columns `nrow`, `ci_method`,
+`nboot`, `time`. `ssd_calibrate_cost_from_run()` builds that same `sweep` frame
+from observed `hc`-shard per-task seconds and calls the existing (unexported)
+helpers, so the run-derived `ssdsims_cost_calibration` is byte-shape-identical to
+a sweep-derived one and drops straight into `ssd_estimate_cost()`. Only the
+provenance differs (a `source = "run"` marker plus the store path and the
+observed run date). *Alternative considered:* a separate fitter — rejected as
+duplication; the model form is shared by contract.
+
+### `targets` becomes a hard requirement for these functions, via `check_installed`
+`targets` is in `Suggests`. The new functions `rlang::check_installed("targets")`
+at entry and call `targets::tar_meta()` / `targets::tar_config_get()`; the package
+still installs without `targets`, matching how `ssd_scenario_targets()` already
+guards `targets`/`tarchetypes`. *Alternative considered:* promote `targets` to
+`Imports` — rejected; the rest of the package (scenario, task tables, single-core
+runner) needs no `targets`, and the existing factory already uses the
+`check_installed` pattern.
+
+### S3 objects mirror the cost-estimation pattern
+`ssdsims_cost_analysis` and `ssdsims_cost_comparison` follow the existing
+`ssdsims_cost_estimate` shape: a list with `difftime` totals, a `breakdown`
+tibble, and provenance, plus `format`/`print` methods reusing `format_duration()`.
+This keeps the three cost objects visually and structurally consistent.
+
+## Risks / Trade-offs
+
+- [Per-task attribution within a multi-task `hc` shard is inferred, not measured]
+  → Document it: totals/longest are exact at shard granularity; the per-axis
+  split is proportional-to-prediction. A user wanting per-task ground truth can
+  push more axes into `partition_by` so each task is its own shard.
+- [A target name regenerated from the scenario may not match the store if the
+  scenario or `partition_by` changed since the run] → Join on name and report
+  unmatched targets rather than silently dropping or aborting; surface the matched
+  count so a mismatch is visible.
+- [Store schema / `tar_meta()` columns could shift across `targets` versions] →
+  Depend only on the long-stable `name` and `seconds` columns; guard the
+  `check_installed` minimum if a floor is needed.
+- [Errored shards carry `NA` seconds] → Exclude from totals (spec requirement),
+  count contributors, so a partially-failed run still analyses cleanly.
+
+## Migration Plan
+
+Purely additive: new file `R/cost-analysis.R`, new exports, new vignette, new
+`_pkgdown.yml` entries. No existing function, object, or output changes, so no
+rollback beyond reverting the new file and its exports. `targets` stays a
+`Suggests`; only the new functions require it at call time.
+
+## Open Questions
+
+- Should `ssd_compare_cost()` also emit a per-`ci_method` predicted/observed slope
+  ratio (a finer recalibration diagnostic) or is the total/longest ratio enough
+  for the first cut? Leaning to start with totals/longest and add the per-cell
+  diagnostic if the worked vignette shows it is needed.
+- Where the observed run used real parallelism, the store's `seconds` is per-target
+  wall time; summing gives serial-equivalent total (consistent with
+  `ssd_estimate_cost()`'s serial total). Confirm the vignette frames "total" as
+  serial-equivalent to avoid confusion with elapsed wall time under workers.

--- a/openspec/changes/cost-analysis-targets/proposal.md
+++ b/openspec/changes/cost-analysis-targets/proposal.md
@@ -2,65 +2,96 @@
 
 The `cost-estimation` capability predicts a scenario's compute cost *before* a
 run, but its per-task model is fitted from a tiny synthetic `ssd_calibrate_cost()`
-sweep — never from a real scenario executed through the `targets` pipeline. A
-completed run already records the ground truth (`targets` stores a `seconds`
-field per target in its meta store), yet the project has no way to read those
-durations back, attribute them to the scenario axes that drove them, or check
-the prediction against what actually happened. This change closes that loop:
-it turns a finished run into observed per-axis cost data, both to validate (and
-recalibrate) the estimator and to size the *next, larger* scenario from real
-measurements rather than a synthetic micro-benchmark.
+sweep — never from a real scenario. A completed run leaves ground truth behind in
+two places: the `targets` meta store records wall seconds per *target* (shard),
+and — once the runners capture them — the shard Parquets themselves can carry
+per-*task* start/end times. Today neither is read back, attributed to the
+scenario axes that drove it, or checked against the prediction. This change
+instruments the runners with per-task timings and closes the loop: a finished
+run becomes observed per-axis cost data, both to validate (and recalibrate) the
+estimator and to size the next, larger scenario from real measurements rather
+than a synthetic micro-benchmark.
 
 ## What Changes
 
-- Add `ssd_analyse_cost(scenario, store = targets::tar_config_get("store"))`:
-  reads the run's `targets` meta store, pulls the per-target `seconds`, and maps
-  each shard target back to the scenario shard (and its tasks) that produced it,
-  returning an `ssdsims_cost_analysis` object — observed total compute, observed
-  longest task/shard, and a per-axis breakdown (`ci_method` × `nboot`, plus
-  `dataset`/`sim`/`nrow`) keyed the same way `ssd_estimate_cost()`'s breakdown is.
-- Add an internal target-name → shard resolver that parses a `tar_map`-minted
-  shard target name (`<step>_step_<pathcell>`) back to its `partition_by` path
-  cell, so observed durations attribute to the right step and axes without
-  re-running anything. Read-only over the store; the scenario supplies the shard
-  layout.
-- Add `ssd_calibrate_cost_from_run(scenario, store = ...)`: re-fit the per-task
-  cost model from an observed run's hc-shard durations, returning the same
-  `ssdsims_cost_calibration` object `ssd_calibrate_cost()` produces (provenance
-  marked as run-derived), so a real scenario — not the synthetic sweep — can
-  become the estimator's coefficients.
-- Add `ssd_compare_cost(scenario, store = ...)`: place the predicted estimate
-  (`ssd_estimate_cost()`) beside the observed analysis (`ssd_analyse_cost()`) in
-  one object, reporting the ratio of predicted to observed total and longest, for
-  validating and tuning the model.
+- **In-band per-task timing columns on the `fit` and `hc` shards.** Each task's
+  body is bracketed in the step runners (`ssd_run_fit_step()` /
+  `ssd_run_hc_step()`) and the resulting `.start` / `.end` (UTC timestamps) and
+  `.host` (CPU description, the grain the architecture-specific calibration
+  pools on) ride as columns of `part.parquet` — no sidecar files (a sidecar
+  would double the shard-file count; at deliverable scale that is ~450k → ~900k
+  objects). The `sample` step is not timed (its cost stays inside the model's
+  `fixed_addend`), so sample shards keep full file-level byte-determinism.
+- **`ssd_run_scenario_baseline()` carries the same columns** on its in-memory
+  `fit`/`hc` tibbles, so timing capture and cost analysis work on any run —
+  serial baseline, single-core `ssd_run_scenario_shards()`, or the `targets`
+  pipeline. The legacy `ssd_*_sims` family is untouched (waits for
+  `migrate-public-api`).
+- **The byte-identity contract narrows to result columns for `fit`/`hc`.**
+  Per-task *result* columns (joined on `<step>_id`) remain byte-identical to the
+  baseline oracle and across re-layouts; the timing columns are run-specific by
+  design and excluded. **Consequence:** a `fit`/`hc` shard's *file* hash is no
+  longer deterministic across recomputes, so a forced recompute with identical
+  results now re-runs its dependents and re-uploads (see design Risks; the §8.3
+  pin covers the code-edit case).
+- **`ssd_summarise()` keeps the hc timing columns** in both summary outputs
+  (they are tiny scalars), so observed cost is queryable from `summary.parquet`
+  alone — including after upload, when shards may be remote.
+- Add `ssd_analyse_cost(scenario, ...)`: reads the in-band per-task timings off
+  a run's `fit`/`hc` shards (or the baseline result), returning an
+  `ssdsims_cost_analysis` — observed total compute, observed longest task, and
+  a per-axis breakdown (`ci_method` × `nboot`) keyed like `ssd_estimate_cost()`'s.
+  Given a `targets` store it additionally reads `tar_meta()` per-target seconds
+  as the *shard envelope*: `target seconds − Σ task durations` = per-shard
+  overhead (parent read + Parquet write + dispatch), the `partition_by`-tuning
+  number. For pre-timing stores the tar_meta path is the fallback, attributing
+  shard seconds to tasks proportional to the predicted per-task cost.
+- Add `ssd_calibrate_cost_from_run(scenario, ...)`: re-fits the per-task cost
+  model from a run's *measured* hc task durations (and a measured fit addend),
+  host-aware (it does not silently pool timings from different architectures),
+  returning the same `ssdsims_cost_calibration` object `ssd_calibrate_cost()`
+  produces, with run-derived provenance.
+- Add `ssd_compare_cost(scenario, ...)`: predicted estimate beside observed
+  analysis in one object, with predicted/observed ratios for total and longest.
 - Add a cost-analysis vignette demonstrating the analyse → compare → recalibrate
   loop on a small worked run.
 
 ## Capabilities
 
 ### New Capabilities
-- `cost-analysis`: read a completed `targets` run's per-target durations from the
-  store, attribute them back to the scenario's shards and axes, compare observed
-  against predicted cost, and recalibrate the per-task cost model from a real run.
+- `cost-analysis`: capture per-task start/end/host timings in the `fit`/`hc`
+  shard Parquets (and the baseline runner's tibbles), read them back from a
+  completed run, attribute observed cost to the scenario's axes, compare
+  observed against predicted cost, and recalibrate the per-task cost model from
+  a real run; the `targets` meta store supplies the per-shard envelope and the
+  fallback for pre-timing runs.
 
 ### Modified Capabilities
-<!-- The `cost-estimation` predictor and its calibration object are reused, not
-     respecified: cost-analysis produces an `ssdsims_cost_calibration` of the same
-     shape and reads `ssd_estimate_cost()` for comparison, but no cost-estimation
-     requirement changes. Left empty intentionally. -->
+- `shard-runner`: the byte-identity requirement ("partition_by is a free
+  re-layout — per-task results are byte-identical to the in-memory baseline")
+  narrows from whole-row to **result-column** identity for the `fit`/`hc` steps:
+  the new `.start`/`.end`/`.host` timing columns are run-specific and excluded
+  from the oracle and re-layout comparisons. `sample` shards carry no timing
+  columns and keep file-level determinism.
 
 ## Impact
 
-- New code: `R/cost-analysis.R` (the analyse/compare/recalibrate functions, the
-  `ssdsims_cost_analysis`/`ssdsims_cost_comparison` S3 objects and their
-  `format`/`print` methods, the target-name resolver). Reuses
-  `R/cost-estimate.R`'s `calibrate_coefficients()`/`calibrate_nrow_factor()` and
-  `new_ssdsims_cost_calibration()`, and the shard machinery in `R/task-shards.R` /
-  `R/targets-runner.R` (`scenario_partition_axes()`, `shard_cell_names()` naming).
-- Dependencies: `targets` moves to a hard requirement for these functions
-  (already a `Suggests`); the functions `rlang::check_installed("targets")` and
-  read the store via `targets::tar_meta()`, performing no pipeline execution.
-- Docs: new `cost-analysis` vignette; `_pkgdown.yml` reference index; `NAMESPACE`
-  exports for the new functions and S3 methods.
-- No change to the scenario object, the task tables, the shard runners, or any
-  run output — the capability is strictly read-only over an existing store.
+- New code: `R/cost-analysis.R` (analyse/compare/recalibrate, the
+  `ssdsims_cost_analysis`/`ssdsims_cost_comparison` S3 objects and
+  `format`/`print` methods, the tar_meta target-name resolver). Reuses
+  `R/cost-estimate.R`'s `calibrate_coefficients()`/`calibrate_nrow_factor()`,
+  `new_ssdsims_cost_calibration()`, and `cost_cpu_info()` (the `.host` value).
+- Changed code: `R/targets-runner.R` (`ssd_run_fit_step()`/`ssd_run_hc_step()`
+  bracket each task and write the timing columns; `ssd_summarise()` retains
+  them), `R/run-scenario.R` (baseline runner gains the same columns on its
+  `fit`/`hc` tibbles). **Run output schema changes** for `fit`/`hc` shards and
+  the summaries; `sample` output is unchanged.
+- Tests: the byte-identity oracle and re-layout/atomic-rewrite assertions move
+  to result-column comparisons (timing columns excluded); existing snapshots of
+  `fit`/`hc` shard schemas update.
+- Dependencies: none added. `targets` stays in `Suggests`; only the store-reading
+  paths `rlang::check_installed("targets")` at call time.
+- Docs: new `cost-analysis` vignette; `_pkgdown.yml` reference entries;
+  `NAMESPACE` exports for the new functions and S3 methods.
+- No change to the scenario object, the task tables, task identity/primers, or
+  the `sample` layer.

--- a/openspec/changes/cost-analysis-targets/proposal.md
+++ b/openspec/changes/cost-analysis-targets/proposal.md
@@ -1,0 +1,66 @@
+## Why
+
+The `cost-estimation` capability predicts a scenario's compute cost *before* a
+run, but its per-task model is fitted from a tiny synthetic `ssd_calibrate_cost()`
+sweep — never from a real scenario executed through the `targets` pipeline. A
+completed run already records the ground truth (`targets` stores a `seconds`
+field per target in its meta store), yet the project has no way to read those
+durations back, attribute them to the scenario axes that drove them, or check
+the prediction against what actually happened. This change closes that loop:
+it turns a finished run into observed per-axis cost data, both to validate (and
+recalibrate) the estimator and to size the *next, larger* scenario from real
+measurements rather than a synthetic micro-benchmark.
+
+## What Changes
+
+- Add `ssd_analyse_cost(scenario, store = targets::tar_config_get("store"))`:
+  reads the run's `targets` meta store, pulls the per-target `seconds`, and maps
+  each shard target back to the scenario shard (and its tasks) that produced it,
+  returning an `ssdsims_cost_analysis` object — observed total compute, observed
+  longest task/shard, and a per-axis breakdown (`ci_method` × `nboot`, plus
+  `dataset`/`sim`/`nrow`) keyed the same way `ssd_estimate_cost()`'s breakdown is.
+- Add an internal target-name → shard resolver that parses a `tar_map`-minted
+  shard target name (`<step>_step_<pathcell>`) back to its `partition_by` path
+  cell, so observed durations attribute to the right step and axes without
+  re-running anything. Read-only over the store; the scenario supplies the shard
+  layout.
+- Add `ssd_calibrate_cost_from_run(scenario, store = ...)`: re-fit the per-task
+  cost model from an observed run's hc-shard durations, returning the same
+  `ssdsims_cost_calibration` object `ssd_calibrate_cost()` produces (provenance
+  marked as run-derived), so a real scenario — not the synthetic sweep — can
+  become the estimator's coefficients.
+- Add `ssd_compare_cost(scenario, store = ...)`: place the predicted estimate
+  (`ssd_estimate_cost()`) beside the observed analysis (`ssd_analyse_cost()`) in
+  one object, reporting the ratio of predicted to observed total and longest, for
+  validating and tuning the model.
+- Add a cost-analysis vignette demonstrating the analyse → compare → recalibrate
+  loop on a small worked run.
+
+## Capabilities
+
+### New Capabilities
+- `cost-analysis`: read a completed `targets` run's per-target durations from the
+  store, attribute them back to the scenario's shards and axes, compare observed
+  against predicted cost, and recalibrate the per-task cost model from a real run.
+
+### Modified Capabilities
+<!-- The `cost-estimation` predictor and its calibration object are reused, not
+     respecified: cost-analysis produces an `ssdsims_cost_calibration` of the same
+     shape and reads `ssd_estimate_cost()` for comparison, but no cost-estimation
+     requirement changes. Left empty intentionally. -->
+
+## Impact
+
+- New code: `R/cost-analysis.R` (the analyse/compare/recalibrate functions, the
+  `ssdsims_cost_analysis`/`ssdsims_cost_comparison` S3 objects and their
+  `format`/`print` methods, the target-name resolver). Reuses
+  `R/cost-estimate.R`'s `calibrate_coefficients()`/`calibrate_nrow_factor()` and
+  `new_ssdsims_cost_calibration()`, and the shard machinery in `R/task-shards.R` /
+  `R/targets-runner.R` (`scenario_partition_axes()`, `shard_cell_names()` naming).
+- Dependencies: `targets` moves to a hard requirement for these functions
+  (already a `Suggests`); the functions `rlang::check_installed("targets")` and
+  read the store via `targets::tar_meta()`, performing no pipeline execution.
+- Docs: new `cost-analysis` vignette; `_pkgdown.yml` reference index; `NAMESPACE`
+  exports for the new functions and S3 methods.
+- No change to the scenario object, the task tables, the shard runners, or any
+  run output — the capability is strictly read-only over an existing store.

--- a/openspec/changes/cost-analysis-targets/specs/cost-analysis/spec.md
+++ b/openspec/changes/cost-analysis-targets/specs/cost-analysis/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: Observed cost analysis from a targets store
+The package SHALL expose `ssd_analyse_cost(scenario, store)` that reads a
+completed `targets` run's meta store (via `targets::tar_meta()`), extracts the
+per-target `seconds`, attributes each shard target's duration to the
+`ssdsims_scenario` shard that produced it, and returns an `ssdsims_cost_analysis`
+object. The object SHALL carry the observed total compute (summed serial target
+seconds), the observed longest single shard duration, and a per-axis breakdown
+keyed the same way `ssd_estimate_cost()`'s breakdown is (`ci_method` × `nboot`).
+The function SHALL be read-only: it SHALL NOT run the pipeline, fit any
+distribution, draw random numbers, or write any file. It SHALL default `store`
+to `targets::tar_config_get("store")`.
+
+#### Scenario: Returns observed total and longest from the store
+- **WHEN** `ssd_analyse_cost()` is called on a scenario whose run was recorded in `store`
+- **THEN** the result SHALL report the observed total compute duration and the observed longest single shard duration, both as time quantities, computed from the store's `seconds` field
+
+#### Scenario: Analysis does not execute the scenario
+- **WHEN** `ssd_analyse_cost()` is called
+- **THEN** no distributions SHALL be fitted, no bootstrap SHALL run, `.Random.seed` SHALL be unchanged, and no files SHALL be written
+
+#### Scenario: Errored or skipped targets do not break the analysis
+- **WHEN** the store contains a target with a missing or `NA` `seconds` value (an errored or not-yet-built shard)
+- **THEN** `ssd_analyse_cost()` SHALL exclude that target from the totals rather than abort, and SHALL report how many shard targets contributed observed durations
+
+### Requirement: Shard target names resolve back to scenario shards
+The package SHALL map a `tar_map`-minted shard target name of the form
+`<step>_step_<pathcell>` back to its step and its `partition_by` path-cell axis
+values, using the scenario's shard layout as the source of truth, so observed
+durations attribute to the correct step (`sample`/`fit`/`hc`) and partition cell
+without re-running anything. The resolver SHALL match the target names the
+pipeline actually mints (the same names `ssd_scenario_targets()` produces), and
+SHALL ignore non-shard targets (e.g. `summary`, `upload_<step>`) for the per-task
+cost attribution.
+
+#### Scenario: A shard target attributes to its step and path cell
+- **WHEN** the store contains a shard target named for a known `partition_by` path cell of a step
+- **THEN** the resolver SHALL identify that target's step and the axis values of its shard, matching the shard `ssd_scenario_<step>_shards()` produced for that scenario
+
+#### Scenario: Non-shard targets are excluded from per-task attribution
+- **WHEN** the store contains `summary` and `upload_<step>` targets alongside the shard targets
+- **THEN** those targets SHALL NOT be attributed to scenario shards in the per-axis cost breakdown
+
+### Requirement: Recalibrate the cost model from an observed run
+The package SHALL expose `ssd_calibrate_cost_from_run(scenario, store)` that
+re-fits the per-task cost model from an observed run's `hc`-shard durations and
+returns an `ssdsims_cost_calibration` object of the same shape
+`ssd_calibrate_cost()` returns (per-`ci_method` `base`/`slope`/`n0`, a bounded
+`nrow_factor`, a `fixed_addend`, and provenance). The provenance SHALL record
+that the calibration was derived from a run (including the store path and the
+observed-run date) rather than from the synthetic `ssd_calibrate_cost()` sweep,
+so a consumer can tell a run-derived calibration from a sweep-derived one. The
+result SHALL be usable directly by `ssd_estimate_cost()`.
+
+#### Scenario: Run-derived calibration is usable by the estimator
+- **WHEN** `ssd_calibrate_cost_from_run()` returns a calibration and it is passed to `ssd_estimate_cost()`
+- **THEN** the estimate SHALL use that run's fitted coefficients rather than the shipped default
+
+#### Scenario: Provenance marks the calibration as run-derived
+- **WHEN** `ssd_calibrate_cost_from_run()` completes
+- **THEN** the returned object's provenance SHALL identify it as derived from a targets run (carrying the store path), distinguishing it from a `ssd_calibrate_cost()` sweep result
+
+### Requirement: Compare predicted against observed cost
+The package SHALL expose `ssd_compare_cost(scenario, store, calibration)` that
+places the predicted estimate (`ssd_estimate_cost(scenario, calibration)`) beside
+the observed analysis (`ssd_analyse_cost(scenario, store)`) and returns an
+`ssdsims_cost_comparison` object reporting, at minimum, the predicted and observed
+total compute, the predicted and observed longest task/shard, and the ratio of
+predicted to observed for each. The comparison SHALL be read-only.
+
+#### Scenario: Comparison reports predicted, observed, and their ratio
+- **WHEN** `ssd_compare_cost()` is called on a scenario with a recorded run
+- **THEN** the result SHALL report the predicted total, the observed total, and their ratio, and likewise for the longest task/shard
+
+#### Scenario: Comparison runs no pipeline
+- **WHEN** `ssd_compare_cost()` is called
+- **THEN** no pipeline SHALL run, no random numbers SHALL be drawn, and no file SHALL be written
+
+### Requirement: Cost-analysis documentation vignette
+The package SHALL include a vignette that demonstrates the analyse → compare →
+recalibrate loop: running (or loading) a small scenario through the `targets`
+pipeline, calling `ssd_analyse_cost()` to read observed durations, `ssd_compare_cost()`
+to place them beside the prediction, and `ssd_calibrate_cost_from_run()` to derive
+a run-based calibration. The vignette is documentation; it SHALL NOT be the
+mechanism by which analysis or recalibration is performed.
+
+#### Scenario: Vignette demonstrates the loop
+- **WHEN** the cost-analysis vignette is rendered
+- **THEN** it SHALL call `ssd_analyse_cost()` and `ssd_compare_cost()` and display an observed total, an observed longest shard, and a predicted-vs-observed comparison for a worked run

--- a/openspec/changes/cost-analysis-targets/specs/cost-analysis/spec.md
+++ b/openspec/changes/cost-analysis-targets/specs/cost-analysis/spec.md
@@ -1,77 +1,133 @@
 ## ADDED Requirements
 
-### Requirement: Observed cost analysis from a targets store
-The package SHALL expose `ssd_analyse_cost(scenario, store)` that reads a
-completed `targets` run's meta store (via `targets::tar_meta()`), extracts the
-per-target `seconds`, attributes each shard target's duration to the
-`ssdsims_scenario` shard that produced it, and returns an `ssdsims_cost_analysis`
-object. The object SHALL carry the observed total compute (summed serial target
-seconds), the observed longest single shard duration, and a per-axis breakdown
-keyed the same way `ssd_estimate_cost()`'s breakdown is (`ci_method` × `nboot`).
-The function SHALL be read-only: it SHALL NOT run the pipeline, fit any
-distribution, draw random numbers, or write any file. It SHALL default `store`
-to `targets::tar_config_get("store")`.
+### Requirement: Per-task timings are captured in-band on the fit and hc layers
+The `fit` and `hc` step runners SHALL bracket each task's body
+(`ssd_run_fit_step()`, `ssd_run_hc_step()`) and record three columns in the
+shard's `part.parquet`: `.start` and `.end` (UTC timestamps of the task body's start and
+finish) and `.host` (the machine's CPU description, the grain the
+architecture-specific cost calibration pools on). On the `hc` layer the values
+repeat across a task's `proportion` rows. The timings SHALL be stored **in the
+shard Parquet itself, not in a sidecar file** — the shard-file count is the
+object-count budget at deliverable scale. The `sample` step SHALL NOT be timed
+and its output SHALL be unchanged. Timing capture SHALL NOT draw random numbers
+or alter any per-task result value.
 
-#### Scenario: Returns observed total and longest from the store
-- **WHEN** `ssd_analyse_cost()` is called on a scenario whose run was recorded in `store`
-- **THEN** the result SHALL report the observed total compute duration and the observed longest single shard duration, both as time quantities, computed from the store's `seconds` field
+#### Scenario: fit and hc shards carry timing columns
+- **WHEN** a `fit` or `hc` shard is written by its step runner
+- **THEN** the shard Parquet SHALL contain `.start`, `.end`, and `.host` for every task, with `.end` at or after `.start`, and no additional file SHALL be created beside `part.parquet`
+
+#### Scenario: sample shards are unchanged
+- **WHEN** a `sample` shard is written
+- **THEN** its Parquet SHALL contain no timing columns and its bytes SHALL remain deterministic for a fixed scenario and seed
+
+#### Scenario: Timing capture is RNG-neutral
+- **WHEN** the same scenario and seed are run with timing capture
+- **THEN** every per-task result value SHALL be byte-identical to the pre-instrumentation runner's (the timing columns excluded)
+
+### Requirement: The baseline runner carries the same timing columns
+`ssd_run_scenario_baseline()` SHALL record the same `.start`/`.end`/`.host`
+columns on its in-memory `fit` and `hc` result tibbles, so cost analysis works
+on any run — baseline, single-core sharded, or `targets` — and the byte-identity
+oracle compares result columns symmetrically. The legacy `ssd_sim_data()` /
+`ssd_fit_dists_sims()` / `ssd_hc_sims()` family SHALL NOT change under this
+capability.
+
+#### Scenario: Baseline fit/hc tibbles carry timings
+- **WHEN** `ssd_run_scenario_baseline()` completes
+- **THEN** its `fit` and `hc` tibbles SHALL carry `.start`, `.end`, and `.host` per task, alongside unchanged result columns
+
+### Requirement: Summaries retain the hc timing columns
+`ssd_summarise()` SHALL retain the `.start`/`.end`/`.host` columns in both the
+compact summary and the optional `path_with_samples` full summary (it SHALL
+continue to project out `dists`/`samples` from the compact summary), so observed
+cost is queryable from the summary Parquet alone — including when the shards are
+remote after upload.
+
+#### Scenario: summary.parquet is enough to read observed hc cost
+- **WHEN** `ssd_summarise()` writes the compact summary for a run with timing columns
+- **THEN** the summary SHALL contain `.start`/`.end`/`.host` per hc row while still excluding `dists`/`samples`
+
+### Requirement: Observed cost analysis from a run's in-band timings
+The package SHALL expose `ssd_analyse_cost(scenario, ...)` that reads the
+per-task timing columns off a completed run's `fit`/`hc` shards (or a baseline
+result) and returns an `ssdsims_cost_analysis` object carrying the observed
+total compute (summed task durations), the observed longest single task, and a
+per-axis breakdown keyed the same way `ssd_estimate_cost()`'s breakdown is
+(`ci_method` × `nboot`). Per-task durations SHALL be **measured** (from
+`.start`/`.end`), not inferred, whenever timing columns are present. The
+function SHALL be read-only: it SHALL NOT run the pipeline, fit any
+distribution, draw random numbers, or write any file.
+
+#### Scenario: Returns measured observed total and longest task
+- **WHEN** `ssd_analyse_cost()` is called on a run whose shards carry timing columns
+- **THEN** the result SHALL report the observed total compute and the observed longest single task as time quantities computed from the per-task `.start`/`.end`, with the breakdown aggregated from measured durations
 
 #### Scenario: Analysis does not execute the scenario
 - **WHEN** `ssd_analyse_cost()` is called
 - **THEN** no distributions SHALL be fitted, no bootstrap SHALL run, `.Random.seed` SHALL be unchanged, and no files SHALL be written
 
-#### Scenario: Errored or skipped targets do not break the analysis
-- **WHEN** the store contains a target with a missing or `NA` `seconds` value (an errored or not-yet-built shard)
-- **THEN** `ssd_analyse_cost()` SHALL exclude that target from the totals rather than abort, and SHALL report how many shard targets contributed observed durations
+### Requirement: The targets store supplies the shard envelope and the pre-timing fallback
+When given a `targets` store, `ssd_analyse_cost()` SHALL additionally read
+`targets::tar_meta()` per-target `seconds`, resolve each shard target name
+(`<step>_step_<pathcell>`) back to its scenario shard by **regenerating** the
+expected names from the scenario (never by parsing the name string), and report
+the per-shard **envelope overhead** — target seconds minus the shard's summed
+task durations (parent read + Parquet write + dispatch), the number that informs
+`partition_by` tuning. Non-shard targets (`summary`, `upload_<step>`) SHALL be
+excluded from attribution. For a run whose shards predate the timing columns,
+the tar_meta path SHALL serve as the fallback: shard seconds attributed to tasks
+proportional to the calibrated predicted per-task cost, with the result marked
+as inferred rather than measured. Targets with missing or `NA` `seconds`
+(errored or unbuilt shards) SHALL be excluded from totals rather than aborting,
+and the analysis SHALL report how many targets contributed.
 
-### Requirement: Shard target names resolve back to scenario shards
-The package SHALL map a `tar_map`-minted shard target name of the form
-`<step>_step_<pathcell>` back to its step and its `partition_by` path-cell axis
-values, using the scenario's shard layout as the source of truth, so observed
-durations attribute to the correct step (`sample`/`fit`/`hc`) and partition cell
-without re-running anything. The resolver SHALL match the target names the
-pipeline actually mints (the same names `ssd_scenario_targets()` produces), and
-SHALL ignore non-shard targets (e.g. `summary`, `upload_<step>`) for the per-task
-cost attribution.
+#### Scenario: Envelope overhead per shard
+- **WHEN** a store and timing-bearing shards are both available
+- **THEN** the analysis SHALL report, per shard, the target's seconds minus the summed measured task durations
 
-#### Scenario: A shard target attributes to its step and path cell
-- **WHEN** the store contains a shard target named for a known `partition_by` path cell of a step
-- **THEN** the resolver SHALL identify that target's step and the axis values of its shard, matching the shard `ssd_scenario_<step>_shards()` produced for that scenario
+#### Scenario: Pre-timing store falls back to inferred attribution
+- **WHEN** the shards carry no timing columns but the store records the run
+- **THEN** the analysis SHALL attribute shard seconds to tasks proportional to the predicted per-task cost and SHALL mark the attribution as inferred
 
-#### Scenario: Non-shard targets are excluded from per-task attribution
-- **WHEN** the store contains `summary` and `upload_<step>` targets alongside the shard targets
-- **THEN** those targets SHALL NOT be attributed to scenario shards in the per-axis cost breakdown
+#### Scenario: Non-shard and errored targets are handled
+- **WHEN** the store contains `summary`/`upload_<step>` targets and a target with `NA` seconds
+- **THEN** the former SHALL NOT be attributed to scenario shards and the latter SHALL be excluded from totals, with the contributing-target count reported
 
 ### Requirement: Recalibrate the cost model from an observed run
-The package SHALL expose `ssd_calibrate_cost_from_run(scenario, store)` that
-re-fits the per-task cost model from an observed run's `hc`-shard durations and
-returns an `ssdsims_cost_calibration` object of the same shape
-`ssd_calibrate_cost()` returns (per-`ci_method` `base`/`slope`/`n0`, a bounded
-`nrow_factor`, a `fixed_addend`, and provenance). The provenance SHALL record
-that the calibration was derived from a run (including the store path and the
-observed-run date) rather than from the synthetic `ssd_calibrate_cost()` sweep,
-so a consumer can tell a run-derived calibration from a sweep-derived one. The
-result SHALL be usable directly by `ssd_estimate_cost()`.
+The package SHALL expose `ssd_calibrate_cost_from_run(scenario, ...)` that
+re-fits the per-task cost model from a run's **measured** hc task durations
+(building the same sweep frame `ssd_calibrate_cost()` fits — `nrow`,
+`ci_method`, `nboot`, `time`) and derives the fixed addend from the measured fit
+task durations, returning an `ssdsims_cost_calibration` of the same shape with
+provenance marking it run-derived (source of the timings and the observed-run
+date). Because the calibration is architecture-specific, the function SHALL NOT
+silently pool timings from different `.host` values: a mixed-host run SHALL
+require an explicit host selection or fail with the hosts listed. The result
+SHALL be usable directly by `ssd_estimate_cost()`.
 
 #### Scenario: Run-derived calibration is usable by the estimator
 - **WHEN** `ssd_calibrate_cost_from_run()` returns a calibration and it is passed to `ssd_estimate_cost()`
-- **THEN** the estimate SHALL use that run's fitted coefficients rather than the shipped default
+- **THEN** the estimate SHALL use the run's measured coefficients rather than the shipped default
+
+#### Scenario: Mixed hosts are not silently pooled
+- **WHEN** the run's timing rows carry more than one distinct `.host`
+- **THEN** the function SHALL NOT pool them silently; it SHALL require an explicit host choice or abort naming the hosts found
 
 #### Scenario: Provenance marks the calibration as run-derived
 - **WHEN** `ssd_calibrate_cost_from_run()` completes
-- **THEN** the returned object's provenance SHALL identify it as derived from a targets run (carrying the store path), distinguishing it from a `ssd_calibrate_cost()` sweep result
+- **THEN** the returned object's provenance SHALL identify it as derived from a run, distinguishing it from an `ssd_calibrate_cost()` sweep result
 
 ### Requirement: Compare predicted against observed cost
-The package SHALL expose `ssd_compare_cost(scenario, store, calibration)` that
-places the predicted estimate (`ssd_estimate_cost(scenario, calibration)`) beside
-the observed analysis (`ssd_analyse_cost(scenario, store)`) and returns an
-`ssdsims_cost_comparison` object reporting, at minimum, the predicted and observed
-total compute, the predicted and observed longest task/shard, and the ratio of
-predicted to observed for each. The comparison SHALL be read-only.
+The package SHALL expose `ssd_compare_cost(scenario, ..., calibration)` that
+places the predicted estimate (`ssd_estimate_cost(scenario, calibration)`)
+beside the observed analysis (`ssd_analyse_cost()`) and returns an
+`ssdsims_cost_comparison` object reporting, at minimum, the predicted and
+observed total compute, the predicted and observed longest task, and the
+predicted/observed ratio for each. The comparison SHALL be read-only.
 
 #### Scenario: Comparison reports predicted, observed, and their ratio
 - **WHEN** `ssd_compare_cost()` is called on a scenario with a recorded run
-- **THEN** the result SHALL report the predicted total, the observed total, and their ratio, and likewise for the longest task/shard
+- **THEN** the result SHALL report the predicted total, the observed total, and their ratio, and likewise for the longest task
 
 #### Scenario: Comparison runs no pipeline
 - **WHEN** `ssd_compare_cost()` is called
@@ -79,12 +135,15 @@ predicted to observed for each. The comparison SHALL be read-only.
 
 ### Requirement: Cost-analysis documentation vignette
 The package SHALL include a vignette that demonstrates the analyse → compare →
-recalibrate loop: running (or loading) a small scenario through the `targets`
-pipeline, calling `ssd_analyse_cost()` to read observed durations, `ssd_compare_cost()`
-to place them beside the prediction, and `ssd_calibrate_cost_from_run()` to derive
-a run-based calibration. The vignette is documentation; it SHALL NOT be the
-mechanism by which analysis or recalibration is performed.
+recalibrate loop: running (or loading) a small scenario, calling
+`ssd_analyse_cost()` to read the observed per-task timings,
+`ssd_compare_cost()` to place them beside the prediction, and
+`ssd_calibrate_cost_from_run()` to derive a run-based calibration. It SHALL
+frame the observed total as serial-equivalent compute (the sum of task
+durations), distinct from elapsed wall time under parallel workers. The
+vignette is documentation; it SHALL NOT be the mechanism by which analysis or
+recalibration is performed.
 
 #### Scenario: Vignette demonstrates the loop
 - **WHEN** the cost-analysis vignette is rendered
-- **THEN** it SHALL call `ssd_analyse_cost()` and `ssd_compare_cost()` and display an observed total, an observed longest shard, and a predicted-vs-observed comparison for a worked run
+- **THEN** it SHALL call `ssd_analyse_cost()` and `ssd_compare_cost()` and display an observed total, an observed longest task, and a predicted-vs-observed comparison for a worked run

--- a/openspec/changes/cost-analysis-targets/specs/shard-runner/spec.md
+++ b/openspec/changes/cost-analysis-targets/specs/shard-runner/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: partition_by is a free re-layout — per-task results are byte-identical to the in-memory baseline
+The per-task **result** values produced by the sharded runner SHALL be identical
+to those of the in-memory baseline runner (`ssd_run_scenario_baseline()`) for
+the same scenario and seed, because the per-task `(seed, primer)` is derived
+from the task's canonical identity (`task_axes(step)`) and is invariant under
+`partition_by`. Changing a step's `partition_by` SHALL change only the shard
+file paths and the path/inner column placement, never the per-task result
+values. The `fit` and `hc` layers additionally carry the run-specific timing
+columns `.start`/`.end`/`.host` (the `cost-analysis` capability); those columns
+are **excluded** from the identity contract — equality is asserted over the
+result columns (every column except the timing columns), joined on the task's
+`<step>_id`. The `sample` layer carries no timing columns, so its shards remain
+byte-deterministic at the file level for a fixed scenario and seed.
+
+#### Scenario: Results match the in-memory oracle
+- **WHEN** a scenario is run through both `ssd_run_scenario_baseline()` and the sharded runner
+- **THEN** the per-task result rows (joined on the task's `<step>_id` identity, the `.start`/`.end`/`.host` columns excluded) SHALL be equal
+
+#### Scenario: Re-layout shifts paths but not results
+- **WHEN** the same scenario is run twice through the sharded runner with two different `partition_by` settings for a step
+- **THEN** the set of shard file paths SHALL differ, but the per-task result rows (joined on `<step>_id`, timing columns excluded) SHALL be byte-identical between the two runs
+
+#### Scenario: sample shards stay file-level deterministic
+- **WHEN** the same scenario and seed produce a `sample` shard twice
+- **THEN** the two `part.parquet` files SHALL be byte-identical (no timing columns are written on the `sample` layer)

--- a/openspec/changes/cost-analysis-targets/tasks.md
+++ b/openspec/changes/cost-analysis-targets/tasks.md
@@ -1,72 +1,92 @@
-## 1. Target-name → shard resolver
+## 1. Timing instrumentation (fit/hc runners + baseline)
 
-- [ ] 1.1 Add an internal resolver in `R/cost-analysis.R` that regenerates the
-  expected `<step>_step_<pathcell>` shard target names for a scenario (reusing
-  `scenario_partition_axes()` / the `shard_cell_names()` naming logic) and
-  returns a tibble mapping each shard target name to its step and the shard's
-  `tasks` rows.
-- [ ] 1.2 Join the store's `tar_meta()` `name`/`seconds` rows to the regenerated
-  names; exclude non-shard targets (`summary`, `upload_<step>`) from per-task
-  attribution; report the count of matched shard targets and surface unmatched
-  ones rather than aborting.
-- [ ] 1.3 Unit-test the resolver against `ssd_scenario_<step>_shards()` output for
-  a small scenario (names match the shards; non-shard names excluded).
+- [ ] 1.1 Bracket each task body in `ssd_run_fit_step()` and `ssd_run_hc_step()`
+  with `Sys.time()` and write `.start`/`.end` (UTC, Parquet TIMESTAMP) and
+  `.host` (`cost_cpu_info()`) columns into the shard rows; on hc the values
+  repeat across a task's `proportion` rows. `sample` runner untouched.
+- [ ] 1.2 Add the same columns to `ssd_run_scenario_baseline()`'s in-memory
+  `fit`/`hc` tibbles (legacy `ssd_*_sims` untouched).
+- [ ] 1.3 Keep `.start`/`.end`/`.host` in both `ssd_summarise()` outputs while
+  still projecting out `dists`/`samples` from the compact summary.
+- [ ] 1.4 Migrate the byte-identity oracle, re-layout, and atomic-rewrite tests
+  to result-column comparisons (timing columns excluded, joined on `<step>_id`);
+  add a test that `sample` shards stay file-level byte-identical and that
+  fit/hc result columns are unchanged by instrumentation; update shard-schema
+  snapshots.
+- [ ] 1.5 Document the invalidation consequence in `ssd_scenario_targets()`'s
+  roxygen (fit/hc file hashes are volatile across recomputes; the §8.3 pin
+  covers code-edit recomputes).
 
-## 2. `ssd_analyse_cost()`
+## 2. Target-name → shard resolver (tar_meta layer)
 
-- [ ] 2.1 Implement `ssd_analyse_cost(scenario, store = targets::tar_config_get("store"))`:
-  `rlang::check_installed("targets")`, read the store, attribute shard `seconds`,
-  return an `ssdsims_cost_analysis` object (observed total, observed longest
-  shard, per-axis `ci_method` × `nboot` breakdown).
-- [ ] 2.2 Attribute a multi-task `hc` shard's seconds to its tasks proportional to
-  the calibrated predicted per-task seconds (design "Decisions"); aggregate the
-  breakdown keyed identically to `ssd_estimate_cost()`.
-- [ ] 2.3 Exclude `NA`/missing-`seconds` (errored/unbuilt) targets from totals and
-  report the contributing-target count.
-- [ ] 2.4 Add `format.ssdsims_cost_analysis` / `print.ssdsims_cost_analysis`
-  reusing `format_duration()`, mirroring the `ssdsims_cost_estimate` methods.
+- [ ] 2.1 Add an internal resolver in `R/cost-analysis.R` that regenerates the
+  expected `<step>_step_<pathcell>` names from the scenario (reusing
+  `shard_cell_names()`/`scenario_partition_axes()` logic) and joins them to
+  `tar_meta()`'s `name`/`seconds`; exclude `summary`/`upload_<step>`; report
+  matched/unmatched counts; exclude `NA`-seconds targets from totals.
+- [ ] 2.2 Unit-test the resolver against `ssd_scenario_<step>_shards()` for a
+  small scenario (names match; non-shard names excluded; unmatched reported).
 
-## 3. `ssd_calibrate_cost_from_run()`
+## 3. `ssd_analyse_cost()`
 
-- [ ] 3.1 Implement `ssd_calibrate_cost_from_run(scenario, store = ...)`: build the
-  `sweep` frame (`nrow`, `ci_method`, `nboot`, `time`) from observed `hc`-shard
-  per-task seconds and call the existing `calibrate_coefficients()` /
-  `calibrate_nrow_factor()` to return an `ssdsims_cost_calibration`.
-- [ ] 3.2 Set provenance to mark the calibration run-derived (a `source = "run"`
-  marker, the store path, the observed-run date) so it is distinguishable from a
-  `ssd_calibrate_cost()` sweep result; confirm it drops into `ssd_estimate_cost()`.
+- [ ] 3.1 Implement `ssd_analyse_cost()`: read the fit/hc shard glob projecting
+  only id + timing columns at the DuckDB level (never decoding blobs), compute
+  measured per-task durations, and return an `ssdsims_cost_analysis` (observed
+  total, observed longest task, `ci_method` × `nboot` breakdown keyed like
+  `ssd_estimate_cost()`'s); accept a baseline result as input too.
+- [ ] 3.2 When a `targets` store is supplied, add the per-shard envelope
+  (`target seconds − Σ task durations`) via the task-2 resolver; for pre-timing
+  shards fall back to proportional-to-prediction attribution and mark the
+  result inferred rather than measured.
+- [ ] 3.3 Add `format`/`print` methods reusing `format_duration()`; show
+  measured vs inferred provenance and (when available) longest task vs longest
+  shard envelope.
 
-## 4. `ssd_compare_cost()`
+## 4. `ssd_calibrate_cost_from_run()`
 
-- [ ] 4.1 Implement `ssd_compare_cost(scenario, store = ..., calibration = ssd_cost_calibration())`
-  placing `ssd_estimate_cost()` beside `ssd_analyse_cost()`; return an
-  `ssdsims_cost_comparison` reporting predicted/observed total and longest plus
-  the predicted/observed ratios.
-- [ ] 4.2 Add `format.ssdsims_cost_comparison` / `print.ssdsims_cost_comparison`.
+- [ ] 4.1 Build the sweep frame (`nrow`, `ci_method`, `nboot`, `time`) from
+  measured hc task durations and derive the fixed addend from measured fit
+  durations; fit via the existing `calibrate_coefficients()` /
+  `calibrate_nrow_factor()`.
+- [ ] 4.2 Make it host-aware: never silently pool distinct `.host` values —
+  explicit host argument or abort listing the hosts found.
+- [ ] 4.3 Set run-derived provenance (source, observed-run date); test the
+  result drops into `ssd_estimate_cost()` unchanged.
 
-## 5. Read-only guarantees & tests
+## 5. `ssd_compare_cost()`
 
-- [ ] 5.1 Test that `ssd_analyse_cost()` / `ssd_compare_cost()` leave
-  `.Random.seed` unchanged and write no files (a `withr::with_tempdir` + seed
-  snapshot assertion, mirroring the cost-estimation read-only tests).
-- [ ] 5.2 Add a deterministic store fixture (a tiny scenario run, or a synthesised
-  `tar_meta()`-shaped tibble) under `tests/testthat/` so the analysis assertions
-  and snapshots do not require a live cluster run.
-- [ ] 5.3 Snapshot the `print()` output of the three new objects.
+- [ ] 5.1 Implement `ssd_compare_cost()` placing `ssd_estimate_cost()` beside
+  `ssd_analyse_cost()`; return an `ssdsims_cost_comparison` with
+  predicted/observed totals, longest, and their ratios.
+- [ ] 5.2 Add `format`/`print` methods.
 
-## 6. Exports, docs, vignette
+## 6. Read-only guarantees & tests
 
-- [ ] 6.1 Roxygen-document the new functions; run `devtools::document()` so
-  `NAMESPACE` gains the exports and S3 methods.
-- [ ] 6.2 Add the new functions to `_pkgdown.yml`'s cost reference section.
-- [ ] 6.3 Add a `cost-analysis` vignette demonstrating the analyse → compare →
-  recalibrate loop on a small worked run; frame "total" as serial-equivalent.
-- [ ] 6.4 If the model's *form* discovery needs proof-of-work, put scripts under
-  `openspec/changes/cost-analysis-targets/exploration/` (never the repo top level).
+- [ ] 6.1 Test that `ssd_analyse_cost()` / `ssd_compare_cost()` leave
+  `.Random.seed` unchanged and write no files.
+- [ ] 6.2 Build a deterministic fixture: a tiny scenario run through
+  `ssd_run_scenario_shards()` (timing columns in-band) plus a synthesised
+  `tar_meta()`-shaped tibble for the envelope/fallback paths — no live cluster
+  needed.
+- [ ] 6.3 Snapshot the `print()` output of the new objects (use the
+  deterministic `test_cost_calibration()` fixture pattern).
 
-## 7. Finalise
+## 7. Exports, docs, vignette
 
-- [ ] 7.1 Format with `air`; run `devtools::check()` (or `R CMD check`) clean.
-- [ ] 7.2 `openspec validate cost-analysis-targets --strict` passes.
-- [ ] 7.3 Update `ROADMAP.md`: move `[cost-analysis-targets]` to its in-flight
-  state and add a `NEWS.md` bullet if appropriate.
+- [ ] 7.1 Roxygen-document the new functions; `devtools::document()` for
+  `NAMESPACE` exports and S3 methods.
+- [ ] 7.2 Add the new functions to `_pkgdown.yml`'s cost reference section.
+- [ ] 7.3 Add the `cost-analysis` vignette demonstrating analyse → compare →
+  recalibrate on a small worked run; frame the observed total as
+  serial-equivalent compute, distinct from wall time under workers.
+- [ ] 7.4 Any proof-of-work scripts go under
+  `openspec/changes/cost-analysis-targets/exploration/` (never the repo top
+  level).
+
+## 8. Finalise
+
+- [ ] 8.1 Format with `air`; `devtools::check()` clean.
+- [ ] 8.2 `openspec validate cost-analysis-targets --strict` passes.
+- [ ] 8.3 Update `ROADMAP.md` (in-flight marker) and `TARGETS-DESIGN.md` /
+  `GLOSSARY.md` if the timing columns warrant a mention in the shard contract
+  prose.

--- a/openspec/changes/cost-analysis-targets/tasks.md
+++ b/openspec/changes/cost-analysis-targets/tasks.md
@@ -1,0 +1,72 @@
+## 1. Target-name → shard resolver
+
+- [ ] 1.1 Add an internal resolver in `R/cost-analysis.R` that regenerates the
+  expected `<step>_step_<pathcell>` shard target names for a scenario (reusing
+  `scenario_partition_axes()` / the `shard_cell_names()` naming logic) and
+  returns a tibble mapping each shard target name to its step and the shard's
+  `tasks` rows.
+- [ ] 1.2 Join the store's `tar_meta()` `name`/`seconds` rows to the regenerated
+  names; exclude non-shard targets (`summary`, `upload_<step>`) from per-task
+  attribution; report the count of matched shard targets and surface unmatched
+  ones rather than aborting.
+- [ ] 1.3 Unit-test the resolver against `ssd_scenario_<step>_shards()` output for
+  a small scenario (names match the shards; non-shard names excluded).
+
+## 2. `ssd_analyse_cost()`
+
+- [ ] 2.1 Implement `ssd_analyse_cost(scenario, store = targets::tar_config_get("store"))`:
+  `rlang::check_installed("targets")`, read the store, attribute shard `seconds`,
+  return an `ssdsims_cost_analysis` object (observed total, observed longest
+  shard, per-axis `ci_method` × `nboot` breakdown).
+- [ ] 2.2 Attribute a multi-task `hc` shard's seconds to its tasks proportional to
+  the calibrated predicted per-task seconds (design "Decisions"); aggregate the
+  breakdown keyed identically to `ssd_estimate_cost()`.
+- [ ] 2.3 Exclude `NA`/missing-`seconds` (errored/unbuilt) targets from totals and
+  report the contributing-target count.
+- [ ] 2.4 Add `format.ssdsims_cost_analysis` / `print.ssdsims_cost_analysis`
+  reusing `format_duration()`, mirroring the `ssdsims_cost_estimate` methods.
+
+## 3. `ssd_calibrate_cost_from_run()`
+
+- [ ] 3.1 Implement `ssd_calibrate_cost_from_run(scenario, store = ...)`: build the
+  `sweep` frame (`nrow`, `ci_method`, `nboot`, `time`) from observed `hc`-shard
+  per-task seconds and call the existing `calibrate_coefficients()` /
+  `calibrate_nrow_factor()` to return an `ssdsims_cost_calibration`.
+- [ ] 3.2 Set provenance to mark the calibration run-derived (a `source = "run"`
+  marker, the store path, the observed-run date) so it is distinguishable from a
+  `ssd_calibrate_cost()` sweep result; confirm it drops into `ssd_estimate_cost()`.
+
+## 4. `ssd_compare_cost()`
+
+- [ ] 4.1 Implement `ssd_compare_cost(scenario, store = ..., calibration = ssd_cost_calibration())`
+  placing `ssd_estimate_cost()` beside `ssd_analyse_cost()`; return an
+  `ssdsims_cost_comparison` reporting predicted/observed total and longest plus
+  the predicted/observed ratios.
+- [ ] 4.2 Add `format.ssdsims_cost_comparison` / `print.ssdsims_cost_comparison`.
+
+## 5. Read-only guarantees & tests
+
+- [ ] 5.1 Test that `ssd_analyse_cost()` / `ssd_compare_cost()` leave
+  `.Random.seed` unchanged and write no files (a `withr::with_tempdir` + seed
+  snapshot assertion, mirroring the cost-estimation read-only tests).
+- [ ] 5.2 Add a deterministic store fixture (a tiny scenario run, or a synthesised
+  `tar_meta()`-shaped tibble) under `tests/testthat/` so the analysis assertions
+  and snapshots do not require a live cluster run.
+- [ ] 5.3 Snapshot the `print()` output of the three new objects.
+
+## 6. Exports, docs, vignette
+
+- [ ] 6.1 Roxygen-document the new functions; run `devtools::document()` so
+  `NAMESPACE` gains the exports and S3 methods.
+- [ ] 6.2 Add the new functions to `_pkgdown.yml`'s cost reference section.
+- [ ] 6.3 Add a `cost-analysis` vignette demonstrating the analyse → compare →
+  recalibrate loop on a small worked run; frame "total" as serial-equivalent.
+- [ ] 6.4 If the model's *form* discovery needs proof-of-work, put scripts under
+  `openspec/changes/cost-analysis-targets/exploration/` (never the repo top level).
+
+## 7. Finalise
+
+- [ ] 7.1 Format with `air`; run `devtools::check()` (or `R CMD check`) clean.
+- [ ] 7.2 `openspec validate cost-analysis-targets --strict` passes.
+- [ ] 7.3 Update `ROADMAP.md`: move `[cost-analysis-targets]` to its in-flight
+  state and add a `NEWS.md` bullet if appropriate.


### PR DESCRIPTION
Add the cost-analysis capability proposal, design, specs, and tasks:
read a completed targets run's per-target durations from the store,
attribute them back to scenario shards/axes, compare predicted against
observed cost, and recalibrate the per-task cost model from a real run.

https://claude.ai/code/session_01Wdd7UwyK5idVgeV6brRSgu