### PR TITLE
docs(openspec): add scenario-combine design and specification

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -183,6 +183,44 @@ Terminology used throughout `ssdsims`.
   packed into jobs. Branches and shards exist with or without a
   scheduler; jobs only exist on a cluster.
 
+## Design terms
+
+These three nest, finest to coarsest: a **scenario** is one regular grid, a
+**design** unions scenarios into one pipeline run, and a **study** aggregates
+design-runs across infrastructure, time, and software versions.
+
+- **scenario**: A single, purely declarative `ssdsims_scenario`
+  (`ssd_define_scenario()`) — one **regular** cross-join of the **axes** at each
+  step (a rectangular sub-grid). It is the construction-time root of one
+  `targets` pipeline (`ssd_scenario_targets()`), carrying a `seed`, the knobs,
+  and the dataset *names*; it draws no random numbers and expands no tasks
+  (TARGETS-DESIGN.md §1). Vignette prose that calls a scenario "the study" is
+  the loose gloss this section tightens: a scenario is one **arm** of a study,
+  not the study.
+- **design**: A named set of scenarios run as **one pipeline** — one `targets`
+  store, one `tar_make()`, one provenance/execution context — built with
+  `ssd_design()` and turned into targets by `ssd_design_targets()`. Where a
+  single scenario is one regular grid, a design unions several into the full,
+  possibly **non-regular** (ragged) experimental design: the union of regular
+  sub-grids is exactly how an irregular design region is expressed. "Design" is
+  used here in the **design-of-experiments** sense (the set of conditions to
+  run); it is distinct from the *software*-design sense of `TARGETS-DESIGN.md`
+  and the openspec `design.md` artifact. Each scenario is a member of the
+  design, addressed by its collection **name** (the `scenario=<name>` results
+  level and the `<name>_` target-name prefix); names enter addressing only,
+  never task identity, the **primer**, or any result value. The design's
+  results table is the combined `summary.parquet`, with a `scenario` identity
+  column.
+- **study**: The whole investigation a design serves — the longitudinal
+  aggregate that may span **multiple design-runs** executed on different
+  infrastructure (laptop / cluster), at different times, or under different
+  software versions. Unlike a scenario or a design, a study is **not a
+  constructible object**: its members are realised in separate sessions, so it
+  is reconstructed on the **read side** by unioning result trees (a future
+  `study` column over several designs' summaries). Reserved for that umbrella
+  level; not built by the design machinery. Distinct from **experiment**, which
+  in this repo names the proof-of-work `scripts/experiment-*.R`.
+
 ## Simulation terms
 
 - **`sim`**: The index of a simulation replicate.

--- a/openspec/changes/scenario-combine/.openspec.yaml
+++ b/openspec/changes/scenario-combine/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-10

--- a/openspec/changes/scenario-combine/design.md
+++ b/openspec/changes/scenario-combine/design.md
@@ -19,47 +19,58 @@ factories' output in one `_targets.R`":
 
 Meanwhile the motivating comparisons — `dists`, `est_method`, `nrow_max`,
 `ci` — are deliberately *simulation settings*, scenario-wide and absent from
-`task_axes()`, so they cannot fan out inside one scenario. Comparing them means
-multiple scenarios; today that means multiple stores and multiple `tar_make()`
-invocations with no shared controller and no single summary.
+`task_axes()`, so they cannot fan out inside one scenario. A single scenario is
+one **regular** grid; comparing settings means **unioning regular sub-grids into
+a non-regular design**. Today that means multiple stores and multiple
+`tar_make()` invocations with no shared controller and no single summary.
+
+This change names that union a **design** (DoE sense: the set of conditions to
+run), the middle level of the `GLOSSARY.md` *Design terms* hierarchy
+**scenario ⊂ design ⊂ study**.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- One `_targets.R`, one store, one `tar_make()` for N scenarios — sharing the
+- One `_targets.R`, one store, one `tar_make()` for a whole design — sharing the
   `crew` controller and the keep-going `error` policy across all shards.
 - Per-scenario results byte-identical to running each scenario alone (combining
   changes *addressing* — names and roots — never `(seed, primer)`).
-- A combined cross-scenario compact summary with a `scenario` identity column,
-  with the same DuckDB-level no-R-materialise and survivors-union properties as
-  `ssd_summarise()`.
+- A combined design summary (the compact estimate table) with a `scenario`
+  identity column, with the same DuckDB-level no-R-materialise and
+  survivors-union properties as `ssd_summarise()`.
 - The single-scenario `ssd_scenario_targets()` public contract is unchanged.
 
 **Non-Goals:**
 
+- **The study level.** A *study* aggregates design-runs across infrastructure,
+  time, and software versions; it is not a constructible object (its members are
+  realised in separate sessions) but a read-side union of result trees. This
+  change builds the *design* (one pipeline, one provenance context); the study
+  is a future read-side concept (a `study` column over several designs'
+  summaries), out of scope here.
 - **Cross-scenario shard dedup.** Two scenarios whose task sets overlap (same
   seed, same axes) recompute the overlap under their own roots. Sharing shards
   across scenario trees would couple their invalidation and break the
-  "scenario = self-contained results tree" model; if a study needs shared
-  draws it should widen one scenario's axes instead.
+  "scenario = self-contained results tree" model; if a study needs shared draws
+  it should widen one scenario's axes instead.
 - **A combined `summary-samples.parquet`.** Retained bootstrap draws stay
   per-scenario (`<root>/scenario=<name>/.../summary-samples.parquet`); the
-  cross-scenario product is the compact estimate table.
-- **A `name` field on the scenario object.** Names live on the collection
-  (the `ssd_data()` pattern), not the scenario — the scenario's declarative
-  identity (and every hash derived from it) is untouched.
+  design-level product is the compact estimate table.
+- **A `name` field on the scenario object.** Names live on the design
+  collection (the `ssd_data()` pattern), not the scenario — the scenario's
+  declarative identity (and every hash derived from it) is untouched.
 - The legacy `ssd_run_scenario()` path, the manifest, and replay tooling.
 
 ## Decisions
 
-### Decision: compose per-scenario factories, not a merged scenario
+### Decision: a design composes per-scenario factories, not a merged scenario
 
-`ssd_scenarios_targets()` loops the named scenarios and emits, for each, the
-*same* target set the single-scenario factory builds — prefixed and re-rooted —
-then appends one combined summary target. No merged "multi-scenario" object
-exists; each scenario keeps its own seed, grids, `partition_by`, layout hash,
-and results tree.
+`ssd_design_targets()` loops the design's named scenarios and emits, for each,
+the *same* target set the single-scenario factory builds — prefixed and
+re-rooted — then appends one combined summary target. No merged
+"multi-scenario" object exists; each scenario keeps its own seed, grids,
+`partition_by`, layout hash, and results tree.
 
 *Alternative considered:* a mega-scenario whose settings become axes — rejected;
 `dists`/`est_method`/`nrow_max`/`ci` are scenario-wide **by design** (the
@@ -70,18 +81,18 @@ separate `_targets.R` stores driven by a script — rejected; that is the status
 quo being replaced (no shared scheduling, no single store, no combined
 summary, N invocations).
 
-### Decision: `ssd_scenarios(...)` owns naming, mirroring `ssd_data()`
+### Decision: `ssd_design(...)` owns naming, mirroring `ssd_data()`
 
-A collection constructor returns a classed `ssdsims_scenarios` named list.
-Names come from explicit argument names or are derived from the argument
-expression (the established `ssd_data()` derivation), and are validated:
-unique, non-empty, non-`NA`, and shaped to serve as both a target-name prefix
-and a Hive directory level (start with a letter; letters, digits, `_` only —
-the conservative intersection of valid R symbol fragments and path-safe
-strings). Each element must be an `ssdsims_scenario`.
-`ssd_scenarios_targets()` accepts **only** this collection — consistent with
-the package direction (`scenario-input-types` removes the bare convenience
-forms from `ssd_define_scenario()`; collections own naming and validation).
+A collection constructor returns a classed `ssdsims_design` named list of
+scenarios. Names come from explicit argument names or are derived from the
+argument expression (the established `ssd_data()` derivation), and are
+validated: unique, non-empty, non-`NA`, and shaped to serve as both a
+target-name prefix and a Hive directory level (start with a letter; letters,
+digits, `_` only — the conservative intersection of valid R symbol fragments and
+path-safe strings). Each element must be an `ssdsims_scenario`.
+`ssd_design_targets()` accepts **only** this collection — consistent with the
+package direction (`scenario-input-types` removes the bare convenience forms
+from `ssd_define_scenario()`; collections own naming and validation).
 
 *Alternative considered:* accept a bare named list — rejected for two entry
 points to the same validation and inconsistency with where the package is
@@ -94,9 +105,9 @@ the `summary` target name) gain an internal `prefix` parameter (default `""`),
 prepended to every minted target name: `<prefix>sample_step_<cells>`,
 `<prefix>upload_<step>_<cells>`, `<prefix>summary`. `ssd_scenario_targets()`
 passes the empty prefix, so its emitted target definitions are unchanged
-byte-for-byte; `ssd_scenarios_targets()` passes `<name>_`. The per-child
-upstream edges and the summary's `edge_block()` resolve through
-`shard_cell_names()`, so prefixed names flow through one source of truth.
+byte-for-byte; `ssd_design_targets()` passes `<name>_`. The per-child upstream
+edges and the summary's `edge_block()` resolve through `shard_cell_names()`, so
+prefixed names flow through one source of truth.
 
 *Alternative considered:* post-hoc renaming of the returned target objects —
 rejected; the per-child edge blocks splice target names into *commands*, so
@@ -115,19 +126,19 @@ subtree; the old one is abandoned, the standard layout-change behaviour).
 
 ### Decision: the combined summary unions per-scenario compact summaries
 
-A top-level `summary` target (the only unprefixed name the multi factory
+A top-level `summary` target (the only unprefixed name the design factory
 mints) names every per-scenario `<name>_summary` target for ordering and
-invalidation, then calls a new `ssd_summarise_scenarios(summaries, path)` with
-the named per-scenario *compact* summary paths (computed from the roots — when
-a scenario retains draws its summary target returns two paths; only the
-compact one feeds the union). Each file is read lazily via `duckplyr`, tagged
-with a literal `scenario` column, and `union_all`-ed straight to
-`<root>/summary.parquet` inside DuckDB — never collecting into R. Files that
-did not land are skipped (the per-scenario summaries carry the pipeline's
-keep-going policy), so the combined summary unions the surviving scenarios,
-mirroring `ssd_summarise()`'s §6.2 property. Schemas align across scenarios
-because the compact hc summary's column set is fixed (bootstrap-only columns
-ride as `NA` under `ci = FALSE`).
+invalidation, then calls a new `ssd_summarise_design(summaries, path)` with the
+named per-scenario *compact* summary paths (computed from the roots — when a
+scenario retains draws its summary target returns two paths; only the compact
+one feeds the union). Each file is read lazily via `duckplyr`, tagged with a
+literal `scenario` column, and `union_all`-ed straight to
+`<root>/summary.parquet` inside DuckDB — never collecting into R. Files that did
+not land are skipped (the per-scenario summaries carry the pipeline's keep-going
+policy), so the combined summary unions the surviving scenarios, mirroring
+`ssd_summarise()`'s §6.2 property. Schemas align across scenarios because the
+compact hc summary's column set is fixed (bootstrap-only columns ride as `NA`
+under `ci = FALSE`).
 
 ### Decision: upload destinations get a per-scenario prefix extension
 
@@ -140,13 +151,13 @@ prefix. The factory still performs no network I/O.
 
 ### Decision: shared seeds are common random numbers, documented not forbidden
 
-Two scenarios with the same `seed` and overlapping task identities share
-`(seed, primer)` pairs — their overlapping draws are *identical*. That is the
-classic variance-reduction pairing for setting comparisons (the primer hashes
-axes only, so scenarios differing in a simulation setting are exactly paired),
-so the factory neither warns nor validates seed distinctness; the behaviour is
-documented on `ssd_scenarios_targets()`. Distinct seeds give independent
-streams as always.
+Two scenarios in a design with the same `seed` and overlapping task identities
+share `(seed, primer)` pairs — their overlapping draws are *identical*. That is
+the classic variance-reduction pairing for setting comparisons (the primer
+hashes axes only, so scenarios differing in a simulation setting are exactly
+paired), so the factory neither warns nor validates seed distinctness; the
+behaviour is documented on `ssd_design_targets()`. Distinct seeds give
+independent streams as always.
 
 ## Risks / Trade-offs
 
@@ -154,7 +165,7 @@ streams as always.
   cell suffix echoing another scenario's prefix, e.g. names `a` / `a_sample`)
   → the name validation forbids the pathological shapes we can see, and
   `targets` itself aborts on duplicate target names at sourcing time — a loud,
-  immediate backstop, never a silent merge. Documented on `ssd_scenarios()`.
+  immediate backstop, never a silent merge. Documented on `ssd_design()`.
 - **Sourcing cost scales with the union of shard counts** (every scenario's
   task tables are computed when `_targets.R` is sourced, on every worker) →
   already the single-scenario model and the §1 "task set is a pure function of
@@ -165,7 +176,8 @@ streams as always.
 - **`union_all` schema drift across scenarios** (a future hc column change
   could misalign older trees) → the combined summary unions *this pipeline's*
   fresh per-scenario summaries (same package version writes all of them), not
-  arbitrary historical files.
+  arbitrary historical files. Cross-version aggregation is the *study* level's
+  problem, deferred by Non-Goal.
 
 ## Migration Plan
 
@@ -175,7 +187,7 @@ back beyond reverting the commit.
 
 ## Open Questions
 
-- Whether to ship a multi-scenario `inst/targets-templates/` template or fold
-  a multi-scenario section into the existing template and vignette — resolved
-  during implementation (leaning: vignette section + extend the existing
-  template's comments; a third template is more surface to keep in sync).
+- Whether to ship a design `inst/targets-templates/` template or fold a design
+  section into the existing template and vignette — resolved during
+  implementation (leaning: vignette section + extend the existing template's
+  comments; a third template is more surface to keep in sync).

--- a/openspec/changes/scenario-combine/design.md
+++ b/openspec/changes/scenario-combine/design.md
@@ -124,6 +124,32 @@ never mix shards, and each scenario's subtree is byte-identical in layout to a
 standalone run under that root. A scenario rename is addressing-only (a fresh
 subtree; the old one is abandoned, the standard layout-change behaviour).
 
+### Decision: growable studies start as a design of one; the flat entry point stays
+
+`ssd_design()` accepts a single scenario, and a design of one is shaped exactly
+like any larger design — the member keeps its name, `<name>_` prefix, and
+`scenario=<name>` root, with no special-casing. Because member addressing is
+independent of the design's other members, growing a design is purely additive:
+adding a scenario changes no existing member's target names, commands, or
+`format = "file"` outputs, so every existing shard is cached and only the new
+member (plus the combined summary) builds — the path-axis-growth contract, one
+level up. The docs and template therefore steer studies that may grow toward
+starting as a design of one. `ssd_scenario_targets()` is untouched and remains
+the entry point for one-off runs and the byte-identity oracle the design
+factory is tested against; promoting a flat run into a design later is *safe
+but recomputing* — task identity and every `(seed, primer)` are unchanged, but
+the addressing is not (names gain the prefix, the root gains the `scenario=`
+level), so no prior shard satisfies the cache. Documented, not mitigated.
+
+*Alternative considered:* leaving the design's first member unprefixed/unrooted
+(flat addressing) so an existing flat run grows in place — rejected; it forks
+the design into two addressing shapes, makes a member's addressing depend on
+its position and the design's history, and breaks the "rename is
+addressing-only" uniformity. *Alternative considered:* retiring the flat layout
+so every run is a design of one — rejected; a breaking re-path of every
+existing store and template to optimise a promotion that starting with
+`ssd_design(one)` avoids upfront.
+
 ### Decision: the combined summary unions per-scenario compact summaries
 
 A top-level `summary` target (the only unprefixed name the design factory

--- a/openspec/changes/scenario-combine/design.md
+++ b/openspec/changes/scenario-combine/design.md
@@ -1,0 +1,181 @@
+# Design: scenario-combine
+
+## Context
+
+`ssd_scenario_targets()` is a target factory: sourcing `_targets.R` computes the
+shard tables and returns one named `format = "file"` target per `partition_by`
+path cell per step, plus a `summary` fan-in, all written under the per-layout
+`scenario_results_dir(scenario)` root. Two facts block "just concatenate two
+factories' output in one `_targets.R`":
+
+- **Target names collide.** A step target's name is `<step>_step_<path cells>`
+  (`tar_map()` suffixes from the path-axis values), so two scenarios over the
+  same dataset/sim cells mint identical names, and `targets` aborts on
+  duplicates. The `summary` target name is a constant.
+- **Roots collide.** `scenario_results_dir()` keys on `partition_by` only, so
+  two scenarios with the same layout write into the *same* Hive tree, and the
+  depth-agnostic readers (`<step>/**/part.parquet`) would union both scenarios'
+  shards into each other's results.
+
+Meanwhile the motivating comparisons — `dists`, `est_method`, `nrow_max`,
+`ci` — are deliberately *simulation settings*, scenario-wide and absent from
+`task_axes()`, so they cannot fan out inside one scenario. Comparing them means
+multiple scenarios; today that means multiple stores and multiple `tar_make()`
+invocations with no shared controller and no single summary.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One `_targets.R`, one store, one `tar_make()` for N scenarios — sharing the
+  `crew` controller and the keep-going `error` policy across all shards.
+- Per-scenario results byte-identical to running each scenario alone (combining
+  changes *addressing* — names and roots — never `(seed, primer)`).
+- A combined cross-scenario compact summary with a `scenario` identity column,
+  with the same DuckDB-level no-R-materialise and survivors-union properties as
+  `ssd_summarise()`.
+- The single-scenario `ssd_scenario_targets()` public contract is unchanged.
+
+**Non-Goals:**
+
+- **Cross-scenario shard dedup.** Two scenarios whose task sets overlap (same
+  seed, same axes) recompute the overlap under their own roots. Sharing shards
+  across scenario trees would couple their invalidation and break the
+  "scenario = self-contained results tree" model; if a study needs shared
+  draws it should widen one scenario's axes instead.
+- **A combined `summary-samples.parquet`.** Retained bootstrap draws stay
+  per-scenario (`<root>/scenario=<name>/.../summary-samples.parquet`); the
+  cross-scenario product is the compact estimate table.
+- **A `name` field on the scenario object.** Names live on the collection
+  (the `ssd_data()` pattern), not the scenario — the scenario's declarative
+  identity (and every hash derived from it) is untouched.
+- The legacy `ssd_run_scenario()` path, the manifest, and replay tooling.
+
+## Decisions
+
+### Decision: compose per-scenario factories, not a merged scenario
+
+`ssd_scenarios_targets()` loops the named scenarios and emits, for each, the
+*same* target set the single-scenario factory builds — prefixed and re-rooted —
+then appends one combined summary target. No merged "multi-scenario" object
+exists; each scenario keeps its own seed, grids, `partition_by`, layout hash,
+and results tree.
+
+*Alternative considered:* a mega-scenario whose settings become axes — rejected;
+`dists`/`est_method`/`nrow_max`/`ci` are scenario-wide **by design** (the
+`dists-simulation-setting` / `est-method-setting` / `scalar-ci-flag` family
+moved them off the axes), and reversing that for combination would re-litigate
+landed decisions and change task identity. *Alternative considered:* a loop of
+separate `_targets.R` stores driven by a script — rejected; that is the status
+quo being replaced (no shared scheduling, no single store, no combined
+summary, N invocations).
+
+### Decision: `ssd_scenarios(...)` owns naming, mirroring `ssd_data()`
+
+A collection constructor returns a classed `ssdsims_scenarios` named list.
+Names come from explicit argument names or are derived from the argument
+expression (the established `ssd_data()` derivation), and are validated:
+unique, non-empty, non-`NA`, and shaped to serve as both a target-name prefix
+and a Hive directory level (start with a letter; letters, digits, `_` only —
+the conservative intersection of valid R symbol fragments and path-safe
+strings). Each element must be an `ssdsims_scenario`.
+`ssd_scenarios_targets()` accepts **only** this collection — consistent with
+the package direction (`scenario-input-types` removes the bare convenience
+forms from `ssd_define_scenario()`; collections own naming and validation).
+
+*Alternative considered:* accept a bare named list — rejected for two entry
+points to the same validation and inconsistency with where the package is
+heading.
+
+### Decision: thread an internal target-name prefix through the existing factory
+
+The single-scenario factory's internals (`step_map()`, `shard_cell_names()`,
+the `summary` target name) gain an internal `prefix` parameter (default `""`),
+prepended to every minted target name: `<prefix>sample_step_<cells>`,
+`<prefix>upload_<step>_<cells>`, `<prefix>summary`. `ssd_scenario_targets()`
+passes the empty prefix, so its emitted target definitions are unchanged
+byte-for-byte; `ssd_scenarios_targets()` passes `<name>_`. The per-child
+upstream edges and the summary's `edge_block()` resolve through
+`shard_cell_names()`, so prefixed names flow through one source of truth.
+
+*Alternative considered:* post-hoc renaming of the returned target objects —
+rejected; the per-child edge blocks splice target names into *commands*, so
+renaming after assembly would desynchronise the dependency graph from the
+names.
+
+### Decision: per-scenario roots at `<root>/scenario=<name>/layout=<hash>`
+
+Each scenario's targets write under
+`scenario_results_dir(scenario, root = file.path(root, paste0("scenario=", name)))`.
+The `scenario=` Hive-style level keeps the tree self-describing and isolates
+scenarios *before* the layout key, so two scenarios sharing a `partition_by`
+never mix shards, and each scenario's subtree is byte-identical in layout to a
+standalone run under that root. A scenario rename is addressing-only (a fresh
+subtree; the old one is abandoned, the standard layout-change behaviour).
+
+### Decision: the combined summary unions per-scenario compact summaries
+
+A top-level `summary` target (the only unprefixed name the multi factory
+mints) names every per-scenario `<name>_summary` target for ordering and
+invalidation, then calls a new `ssd_summarise_scenarios(summaries, path)` with
+the named per-scenario *compact* summary paths (computed from the roots — when
+a scenario retains draws its summary target returns two paths; only the
+compact one feeds the union). Each file is read lazily via `duckplyr`, tagged
+with a literal `scenario` column, and `union_all`-ed straight to
+`<root>/summary.parquet` inside DuckDB — never collecting into R. Files that
+did not land are skipped (the per-scenario summaries carry the pipeline's
+keep-going policy), so the combined summary unions the surviving scenarios,
+mirroring `ssd_summarise()`'s §6.2 property. Schemas align across scenarios
+because the compact hc summary's column set is fixed (bootstrap-only columns
+ride as `NA` under `ci = FALSE`).
+
+### Decision: upload destinations get a per-scenario prefix extension
+
+With a non-`NULL` `upload`, each scenario's paired `upload_<step>` targets ship
+under the destination's blob prefix extended by `scenario=<name>` (an internal
+"extend prefix" helper on the `ssdsims_upload` object; `ssd_upload_dryrun()`
+passes through unchanged). The remote layout then mirrors the local tree and
+`ssd_open_uploaded()` reads a single scenario back by pointing at the extended
+prefix. The factory still performs no network I/O.
+
+### Decision: shared seeds are common random numbers, documented not forbidden
+
+Two scenarios with the same `seed` and overlapping task identities share
+`(seed, primer)` pairs — their overlapping draws are *identical*. That is the
+classic variance-reduction pairing for setting comparisons (the primer hashes
+axes only, so scenarios differing in a simulation setting are exactly paired),
+so the factory neither warns nor validates seed distinctness; the behaviour is
+documented on `ssd_scenarios_targets()`. Distinct seeds give independent
+streams as always.
+
+## Risks / Trade-offs
+
+- **Constructed target names could still collide** (a scenario name plus a
+  cell suffix echoing another scenario's prefix, e.g. names `a` / `a_sample`)
+  → the name validation forbids the pathological shapes we can see, and
+  `targets` itself aborts on duplicate target names at sourcing time — a loud,
+  immediate backstop, never a silent merge. Documented on `ssd_scenarios()`.
+- **Sourcing cost scales with the union of shard counts** (every scenario's
+  task tables are computed when `_targets.R` is sourced, on every worker) →
+  already the single-scenario model and the §1 "task set is a pure function of
+  the scenario" contract; tiny tables, no new mechanism.
+- **A duplicated scenario object under two names doubles compute** (no
+  cross-scenario dedup, by Non-Goal) → identical results under both names;
+  cheap to detect later if it bites — out of scope here.
+- **`union_all` schema drift across scenarios** (a future hc column change
+  could misalign older trees) → the combined summary unions *this pipeline's*
+  fresh per-scenario summaries (same package version writes all of them), not
+  arbitrary historical files.
+
+## Migration Plan
+
+Additive only: two new exports, no signature or behaviour change to existing
+functions, no re-baselining (per-task results are unchanged). Nothing to roll
+back beyond reverting the commit.
+
+## Open Questions
+
+- Whether to ship a multi-scenario `inst/targets-templates/` template or fold
+  a multi-scenario section into the existing template and vignette — resolved
+  during implementation (leaning: vignette section + extend the existing
+  template's comments; a third template is more surface to keep in sync).

--- a/openspec/changes/scenario-combine/proposal.md
+++ b/openspec/changes/scenario-combine/proposal.md
@@ -5,41 +5,51 @@
 A simulation study routinely compares **simulation settings** — `dists`,
 `est_method`, `nrow_max`, `ci` — which are scenario-wide by design (not
 cross-join axes), so the comparison *cannot* be expressed inside one
-`ssd_scenario`. Today each configuration needs its own `_targets.R`, its own
-store, and its own `tar_make()`: no shared scheduling across a cluster
-controller, no single summary, and N pipelines to babysit. The ROADMAP books
-this as ❗️ [scenario-combine]: *provide a convenient way to run multiple
-`ssd_scenario` objects as a single targets pipeline.*
+`ssd_scenario`: a single scenario is one **regular** grid. The comparison is a
+**non-regular** design — a union of regular sub-grids. Today each scenario needs
+its own `_targets.R`, its own store, and its own `tar_make()`: no shared
+scheduling across a cluster controller, no single summary, and N pipelines to
+babysit. The ROADMAP books this as ❗️ [scenario-combine]: *provide a convenient
+way to run multiple `ssd_scenario` objects as a single targets pipeline.*
+
+This change introduces the **design** as that unit (DoE sense: the set of
+conditions to run): a named set of scenarios run as one pipeline. It sits in the
+hierarchy **scenario ⊂ design ⊂ study** the `GLOSSARY.md` *Design terms* section
+defines — a scenario is one regular grid, a design unions scenarios into one
+pipeline run, and a *study* (the longitudinal aggregate across infrastructure,
+time, and software versions) is reserved as a future read-side concept, not
+built here.
 
 ## What Changes
 
-- **New `ssd_scenarios(...)` collection constructor** — a validated, named
-  collection of `ssdsims_scenario` objects (class `ssdsims_scenarios`),
-  mirroring the `ssd_data()` naming convention: names from explicit `name =`
-  arguments or derived from the argument expression. Names must be unique,
-  non-empty, and safe for both target names and result paths (they become the
-  per-scenario target-name prefix and a `scenario=<name>` directory level).
-- **New `ssd_scenarios_targets(scenarios, ..., root, upload, cue)` target
-  factory** — the multi-scenario sibling of `ssd_scenario_targets()`. For each
-  named scenario it emits the full single-scenario target set with every target
-  name prefixed `<name>_` (no collisions), written under a per-scenario,
-  per-layout root `<root>/scenario=<name>/layout=<hash>` (no shard mixing, even
-  when two scenarios share a `partition_by`). A single `tar_make()` then runs
-  all scenarios' shards under one scheduler/controller.
-- **A combined cross-scenario summary**: a top-level `summary` target that
-  names every per-scenario summary target and unions the per-scenario compact
-  summaries into `<root>/summary.parquet` with a `scenario` identity column —
-  performed at the DuckDB level (the same no-R-materialise guarantee as
-  `ssd_summarise()`).
+- **New `ssd_design(...)` collection constructor** — a validated, named
+  collection of `ssdsims_scenario` objects (class `ssdsims_design`), mirroring
+  the `ssd_data()` naming convention: names from explicit `name =` arguments or
+  derived from the argument expression. Each name is a **scenario name** within
+  the design; names must be unique, non-empty, and safe for both target names
+  and result paths (they become the per-scenario target-name prefix and a
+  `scenario=<name>` directory level).
+- **New `ssd_design_targets(design, ..., root, upload, cue)` target factory** —
+  the multi-scenario sibling of `ssd_scenario_targets()`. For each named
+  scenario it emits the full single-scenario target set with every target name
+  prefixed `<name>_` (no collisions), written under a per-scenario, per-layout
+  root `<root>/scenario=<name>/layout=<hash>` (no shard mixing, even when two
+  scenarios share a `partition_by`). A single `tar_make()` then runs the whole
+  design's shards under one scheduler/controller.
+- **A combined design summary**: a top-level `summary` target that names every
+  per-scenario summary target and unions the per-scenario compact summaries into
+  `<root>/summary.parquet` with a `scenario` identity column — performed at the
+  DuckDB level (the same no-R-materialise guarantee as `ssd_summarise()`). This
+  is the design's results table.
 - **Per-scenario upload separation**: with a non-`NULL` `upload`, each
   scenario's shards ship under a `scenario=<name>` extension of the
   destination's blob prefix, so the remote layout mirrors the local one.
-- **Byte identity is preserved**: a scenario's per-task results in the combined
+- **Byte identity is preserved**: a scenario's per-task results in the design
   pipeline are byte-identical to running it alone through
   `ssd_scenario_targets()` — combining changes addressing (names, roots) only,
-  never `(seed, primer)`. Scenarios sharing a `seed` deliberately share
-  per-task streams on overlapping task identities (common random numbers for
-  paired comparisons); this is documented, not forbidden.
+  never `(seed, primer)`. Scenarios sharing a `seed` deliberately share per-task
+  streams on overlapping task identities (common random numbers for paired
+  comparisons); this is documented, not forbidden.
 - `ssd_scenario_targets()`'s public contract is **unchanged** — the prefix and
   root threading is an internal refactor the single-scenario factory composes
   with.
@@ -47,32 +57,32 @@ this as ❗️ [scenario-combine]: *provide a convenient way to run multiple
 ## Capabilities
 
 ### New Capabilities
-- `scenario-combine`: the named scenario collection (`ssd_scenarios()`), the
-  multi-scenario target factory (`ssd_scenarios_targets()`) with per-scenario
-  target-name prefixes and `scenario=<name>` result roots, the combined
-  cross-scenario summary with its `scenario` identity column, and the
+- `scenario-combine`: the **design** — a named scenario collection
+  (`ssd_design()`), the design target factory (`ssd_design_targets()`) with
+  per-scenario target-name prefixes and `scenario=<name>` result roots, the
+  combined design summary with its `scenario` identity column, and the
   per-scenario upload prefixing.
 
 ### Modified Capabilities
-<!-- None: `ssd_scenario_targets()`'s requirements are untouched; the combined
+<!-- None: `ssd_scenario_targets()`'s requirements are untouched; the design
      factory composes the existing single-scenario machinery internally. -->
 
 ## Impact
 
-- **New code**: `ssd_scenarios()` (collection constructor + validation,
-  `R/scenarios.R`); `ssd_scenarios_targets()` and the combined-summary fan-in
+- **New code**: `ssd_design()` (collection constructor + validation,
+  `R/design.R`); `ssd_design_targets()` and the combined-summary fan-in
   (`R/targets-runner.R` or a sibling file).
 - **Internal refactor**: thread a target-name prefix through the
   `ssd_scenario_targets()` internals (`step_map()`, `shard_cell_names()`, the
   `summary` target name) with the empty prefix reproducing today's names
   byte-for-byte.
-- **APIs**: two new exports (`ssd_scenarios()`, `ssd_scenarios_targets()`);
-  no breaking change to existing exports.
-- **Docs**: README / `vignettes/sharded-pipeline.qmd` (a multi-scenario
-  section), `_pkgdown.yml`, `GLOSSARY.md` (scenario *name*), `ROADMAP.md`
-  (move the entry), regenerated `man/`; optionally a multi-scenario
-  `inst/targets-templates/` template.
-- **Tests**: integration test running two tiny scenarios in one pipeline
+- **APIs**: two new exports (`ssd_design()`, `ssd_design_targets()`); no
+  breaking change to existing exports.
+- **Docs**: README / `vignettes/sharded-pipeline.qmd` (a design section),
+  `_pkgdown.yml`, `GLOSSARY.md` (the *Design terms* `scenario`/`design`/`study`
+  entries — landed in this change), `ROADMAP.md` (move the entry), regenerated
+  `man/`; optionally a design `inst/targets-templates/` template.
+- **Tests**: integration test running a two-scenario design in one pipeline
   (byte-identity against the single-scenario runs; combined summary content);
   validation tests for the collection (duplicate/empty/unsafe names);
   upload-prefix shape under `ssd_upload_dryrun()`.

--- a/openspec/changes/scenario-combine/proposal.md
+++ b/openspec/changes/scenario-combine/proposal.md
@@ -1,0 +1,81 @@
+# Proposal: scenario-combine
+
+## Why
+
+A simulation study routinely compares **simulation settings** — `dists`,
+`est_method`, `nrow_max`, `ci` — which are scenario-wide by design (not
+cross-join axes), so the comparison *cannot* be expressed inside one
+`ssd_scenario`. Today each configuration needs its own `_targets.R`, its own
+store, and its own `tar_make()`: no shared scheduling across a cluster
+controller, no single summary, and N pipelines to babysit. The ROADMAP books
+this as ❗️ [scenario-combine]: *provide a convenient way to run multiple
+`ssd_scenario` objects as a single targets pipeline.*
+
+## What Changes
+
+- **New `ssd_scenarios(...)` collection constructor** — a validated, named
+  collection of `ssdsims_scenario` objects (class `ssdsims_scenarios`),
+  mirroring the `ssd_data()` naming convention: names from explicit `name =`
+  arguments or derived from the argument expression. Names must be unique,
+  non-empty, and safe for both target names and result paths (they become the
+  per-scenario target-name prefix and a `scenario=<name>` directory level).
+- **New `ssd_scenarios_targets(scenarios, ..., root, upload, cue)` target
+  factory** — the multi-scenario sibling of `ssd_scenario_targets()`. For each
+  named scenario it emits the full single-scenario target set with every target
+  name prefixed `<name>_` (no collisions), written under a per-scenario,
+  per-layout root `<root>/scenario=<name>/layout=<hash>` (no shard mixing, even
+  when two scenarios share a `partition_by`). A single `tar_make()` then runs
+  all scenarios' shards under one scheduler/controller.
+- **A combined cross-scenario summary**: a top-level `summary` target that
+  names every per-scenario summary target and unions the per-scenario compact
+  summaries into `<root>/summary.parquet` with a `scenario` identity column —
+  performed at the DuckDB level (the same no-R-materialise guarantee as
+  `ssd_summarise()`).
+- **Per-scenario upload separation**: with a non-`NULL` `upload`, each
+  scenario's shards ship under a `scenario=<name>` extension of the
+  destination's blob prefix, so the remote layout mirrors the local one.
+- **Byte identity is preserved**: a scenario's per-task results in the combined
+  pipeline are byte-identical to running it alone through
+  `ssd_scenario_targets()` — combining changes addressing (names, roots) only,
+  never `(seed, primer)`. Scenarios sharing a `seed` deliberately share
+  per-task streams on overlapping task identities (common random numbers for
+  paired comparisons); this is documented, not forbidden.
+- `ssd_scenario_targets()`'s public contract is **unchanged** — the prefix and
+  root threading is an internal refactor the single-scenario factory composes
+  with.
+
+## Capabilities
+
+### New Capabilities
+- `scenario-combine`: the named scenario collection (`ssd_scenarios()`), the
+  multi-scenario target factory (`ssd_scenarios_targets()`) with per-scenario
+  target-name prefixes and `scenario=<name>` result roots, the combined
+  cross-scenario summary with its `scenario` identity column, and the
+  per-scenario upload prefixing.
+
+### Modified Capabilities
+<!-- None: `ssd_scenario_targets()`'s requirements are untouched; the combined
+     factory composes the existing single-scenario machinery internally. -->
+
+## Impact
+
+- **New code**: `ssd_scenarios()` (collection constructor + validation,
+  `R/scenarios.R`); `ssd_scenarios_targets()` and the combined-summary fan-in
+  (`R/targets-runner.R` or a sibling file).
+- **Internal refactor**: thread a target-name prefix through the
+  `ssd_scenario_targets()` internals (`step_map()`, `shard_cell_names()`, the
+  `summary` target name) with the empty prefix reproducing today's names
+  byte-for-byte.
+- **APIs**: two new exports (`ssd_scenarios()`, `ssd_scenarios_targets()`);
+  no breaking change to existing exports.
+- **Docs**: README / `vignettes/sharded-pipeline.qmd` (a multi-scenario
+  section), `_pkgdown.yml`, `GLOSSARY.md` (scenario *name*), `ROADMAP.md`
+  (move the entry), regenerated `man/`; optionally a multi-scenario
+  `inst/targets-templates/` template.
+- **Tests**: integration test running two tiny scenarios in one pipeline
+  (byte-identity against the single-scenario runs; combined summary content);
+  validation tests for the collection (duplicate/empty/unsafe names);
+  upload-prefix shape under `ssd_upload_dryrun()`.
+- **Dependencies**: none — independent of the in-flight
+  `scenario-input-types` (different functions; only GLOSSARY/vignette prose
+  could brush against it).

--- a/openspec/changes/scenario-combine/proposal.md
+++ b/openspec/changes/scenario-combine/proposal.md
@@ -28,7 +28,16 @@ built here.
   derived from the argument expression. Each name is a **scenario name** within
   the design; names must be unique, non-empty, and safe for both target names
   and result paths (they become the per-scenario target-name prefix and a
-  `scenario=<name>` directory level).
+  `scenario=<name>` directory level). A design of **one** scenario is valid and
+  uniformly shaped (no special-casing) — the recommended starting point for
+  studies that may grow.
+- **Design growth caches existing members**: adding a scenario to an
+  already-run design builds only the new member's targets plus the combined
+  summary; every existing member's targets are reported cached and their shards
+  stay byte-identical, because member addressing is independent of the design's
+  other members (the path-axis-growth contract, one level up). Promoting a flat
+  `ssd_scenario_targets()` run into a design is documented as safe but
+  recomputing (addressing changes; `(seed, primer)` does not).
 - **New `ssd_design_targets(design, ..., root, upload, cue)` target factory** —
   the multi-scenario sibling of `ssd_scenario_targets()`. For each named
   scenario it emits the full single-scenario target set with every target name
@@ -78,14 +87,19 @@ built here.
   byte-for-byte.
 - **APIs**: two new exports (`ssd_design()`, `ssd_design_targets()`); no
   breaking change to existing exports.
-- **Docs**: README / `vignettes/sharded-pipeline.qmd` (a design section),
+- **Docs**: README / `vignettes/sharded-pipeline.qmd` (a design section
+  steering growable studies to start as a design of one, with the
+  flat-to-design promotion documented as safe but recomputing),
   `_pkgdown.yml`, `GLOSSARY.md` (the *Design terms* `scenario`/`design`/`study`
   entries — landed in this change), `ROADMAP.md` (move the entry), regenerated
   `man/`; optionally a design `inst/targets-templates/` template.
 - **Tests**: integration test running a two-scenario design in one pipeline
   (byte-identity against the single-scenario runs; combined summary content);
-  validation tests for the collection (duplicate/empty/unsafe names);
-  upload-prefix shape under `ssd_upload_dryrun()`.
+  a design-growth test (design of one grown by a member: existing shards
+  cached and byte-identical, only the new member and combined summary build);
+  validation tests for the collection (duplicate/empty/unsafe names; a design
+  of one is valid, an empty call aborts); upload-prefix shape under
+  `ssd_upload_dryrun()`.
 - **Dependencies**: none — independent of the in-flight
   `scenario-input-types` (different functions; only GLOSSARY/vignette prose
   could brush against it).

--- a/openspec/changes/scenario-combine/specs/scenario-combine/spec.md
+++ b/openspec/changes/scenario-combine/specs/scenario-combine/spec.md
@@ -1,0 +1,136 @@
+# scenario-combine Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: A named scenario collection constructor
+The package SHALL provide `ssd_scenarios(...)` returning a classed
+`ssdsims_scenarios` named collection of `ssdsims_scenario` objects. Names SHALL
+be taken from explicit argument names or derived from the argument expression
+(mirroring the `ssd_data()` dataset-name derivation). The constructor SHALL
+validate that every element is an `ssdsims_scenario` and that the names are
+unique, non-empty, non-`NA`, and safe to serve as both a target-name prefix and
+a results directory level (starting with a letter; letters, digits, and
+underscore only), aborting with an informative error otherwise. Construction
+SHALL be RNG-free (no draws; `.Random.seed` unchanged).
+
+#### Scenario: Names are derived or explicit
+- **WHEN** `ssd_scenarios(base, wide = scenario2)` is called with `base` a
+  variable holding a scenario
+- **THEN** the collection SHALL contain the two scenarios named `"base"` (from
+  the argument expression) and `"wide"` (explicit), in input order
+
+#### Scenario: Invalid elements and names abort
+- **WHEN** `ssd_scenarios()` is called with an element that is not an
+  `ssdsims_scenario`, or with duplicate, empty, or unsafe names (e.g. a name
+  not matching the documented safe shape)
+- **THEN** it SHALL abort with an informative error identifying the offending
+  element or name
+
+### Requirement: A multi-scenario target factory builds one pipeline
+The package SHALL provide
+`ssd_scenarios_targets(scenarios, ..., root = "results", upload = NULL, cue = NULL)`
+that accepts an `ssdsims_scenarios` collection and returns the complete list of
+`targets` objects running every scenario in a single static-branching pipeline.
+For each named scenario it SHALL emit the same target set
+`ssd_scenario_targets()` builds for that scenario — the per-step shard targets,
+the per-child upstream edges, and the per-scenario summary — with every target
+name prefixed `<name>_` (so target names are disjoint across scenarios) and
+written under the per-scenario, per-layout root
+`<root>/scenario=<name>/layout=<hash>`. The factory SHALL place `...`
+immediately after `scenarios` and call `rlang::check_dots_empty()`, so `root`,
+`upload`, and `cue` MUST be passed by name. The factory SHALL perform no
+network I/O. The public contract of the single-scenario
+`ssd_scenario_targets()` SHALL be unchanged.
+
+#### Scenario: One tar_make runs all scenarios
+- **WHEN** a `_targets.R` builds two scenarios, calls
+  `ssd_scenarios_targets(ssd_scenarios(a, b))`, and `targets::tar_make()` runs
+- **THEN** every shard target of both scenarios SHALL build in the one
+  pipeline, each scenario's shards and summary landing under its own
+  `<root>/scenario=<name>/layout=<hash>` tree
+
+#### Scenario: Target names are disjoint across scenarios
+- **WHEN** two scenarios in the collection share path cells (e.g. the same
+  dataset and `sim` values) and the pipeline is sourced
+- **THEN** each scenario's targets SHALL carry its `<name>_` prefix and the
+  combined target list SHALL contain no duplicate target names
+
+#### Scenario: Scenarios sharing a layout do not mix shards
+- **WHEN** two scenarios in the collection have identical `partition_by` (the
+  same layout hash)
+- **THEN** their shards SHALL land under distinct `scenario=<name>` subtrees
+  and neither scenario's readers SHALL union the other scenario's shards
+
+#### Scenario: root, upload, and cue must be passed by name
+- **WHEN** `ssd_scenarios_targets()` is called with a positional argument
+  after `scenarios`, or a misspelled named argument
+- **THEN** `rlang::check_dots_empty()` SHALL abort with an informative error
+
+### Requirement: Combined-pipeline results are byte-identical to standalone runs
+A scenario's per-task `sample`, `fit`, and `hc` results produced through
+`ssd_scenarios_targets()` SHALL be byte-identical (as read-back R values) to
+those produced by running the same scenario alone through
+`ssd_scenario_targets()`: combination changes addressing only (target names
+and results roots), never any task's `(seed, primer)`. Scenario *names* SHALL
+NOT enter task identity, the per-task primer, or any result value. Two
+scenarios sharing a `seed` SHALL share `(seed, primer)` on overlapping task
+identities (common random numbers for paired settings comparisons); this
+SHALL be documented and SHALL NOT be warned about or rejected.
+
+#### Scenario: Per-task results equal the standalone pipeline's
+- **WHEN** a scenario is run both standalone (`ssd_scenario_targets()`) and as
+  a member of a combined pipeline (`ssd_scenarios_targets()`), and the
+  per-task results are aligned by the task-identity key (`<step>_id`)
+- **THEN** the `sample`, `fit`, and `hc` results SHALL be equal across the two
+  runs
+
+#### Scenario: Renaming a scenario leaves results unchanged
+- **WHEN** the same scenario object is combined under two different collection
+  names (in separate runs)
+- **THEN** the per-task results SHALL be identical across the two runs, with
+  only the target names and `scenario=<name>` paths differing
+
+### Requirement: A combined cross-scenario summary with a scenario identity column
+The multi-scenario pipeline SHALL include one top-level `summary` target (the
+only unprefixed target the factory mints) that names every per-scenario
+summary target (ordering and invalidation) and writes a combined
+`<root>/summary.parquet` unioning the per-scenario **compact** summaries, each
+row tagged with a `scenario` column holding the scenario's collection name.
+The union SHALL be performed at the DuckDB level (lazy reads written straight
+back out) so no per-scenario summary is collected into R. Per-scenario compact
+summary files that did not land SHALL be skipped, so the combined summary
+unions the surviving scenarios (the §6.2 keep-going property). Retained-draws
+(`summary-samples.parquet`) files SHALL remain per-scenario and SHALL NOT be
+combined.
+
+#### Scenario: Combined summary unions and tags the per-scenario summaries
+- **WHEN** a combined pipeline of scenarios `a` and `b` runs to completion
+- **THEN** `<root>/summary.parquet` SHALL contain the union of the two
+  per-scenario compact summaries with a `scenario` column equal to `"a"` or
+  `"b"` per row, and each per-scenario `summary.parquet` SHALL be unchanged by
+  the combination
+
+#### Scenario: A scenario whose summary did not land is skipped
+- **WHEN** one scenario's summary fails to land while the others succeed
+- **THEN** the combined summary SHALL union the surviving scenarios' compact
+  summaries rather than aborting
+
+### Requirement: Per-scenario upload prefixing
+With a non-`NULL` `upload`, `ssd_scenarios_targets()` SHALL pair each
+scenario's step shards with `upload_<step>` targets (per the `cloud-upload`
+capability) whose destination is the supplied upload object with its blob
+prefix extended by `scenario=<name>`, so the remote layout mirrors the local
+`scenario=<name>` trees and no two scenarios upload to the same blob path.
+With `upload = NULL` (the default) the factory SHALL emit no upload targets.
+The per-task results SHALL be unchanged and independent of `upload`.
+
+#### Scenario: Each scenario uploads under its own prefix
+- **WHEN** `ssd_scenarios_targets(scenarios, upload = <destination>)` is
+  called for scenarios `a` and `b`
+- **THEN** the returned list SHALL contain per-shard upload targets whose
+  destinations carry blob prefixes ending `scenario=a` and `scenario=b`
+  respectively (extending any prefix already on the destination)
+
+#### Scenario: upload defaults to no upload targets
+- **WHEN** `ssd_scenarios_targets(scenarios)` is called without `upload`
+- **THEN** the returned target list SHALL contain no `upload_<step>` targets

--- a/openspec/changes/scenario-combine/specs/scenario-combine/spec.md
+++ b/openspec/changes/scenario-combine/specs/scenario-combine/spec.md
@@ -9,7 +9,11 @@ set of conditions to run), the union of regular per-scenario grids into one
 possibly-non-regular design. Names SHALL be taken from explicit argument names
 or derived from the argument expression (mirroring the `ssd_data()` dataset-name
 derivation); each name is a **scenario name** within the design. The constructor
-SHALL validate that every element is an `ssdsims_scenario` and that the names
+SHALL accept **one or more** scenarios — a design of a single scenario is valid
+and SHALL be shaped exactly like any larger design (the member still gets its
+name, `<name>_` target-name prefix, and `scenario=<name>` results level; no
+special-casing) — and SHALL abort on an empty call. The constructor SHALL
+validate that every element is an `ssdsims_scenario` and that the names
 are unique, non-empty, non-`NA`, and safe to serve as both a target-name prefix
 and a results directory level (starting with a letter; letters, digits, and
 underscore only), aborting with an informative error otherwise. Construction
@@ -20,6 +24,13 @@ SHALL be RNG-free (no draws; `.Random.seed` unchanged).
   variable holding a scenario
 - **THEN** the design SHALL contain the two scenarios named `"base"` (from the
   argument expression) and `"wide"` (explicit), in input order
+
+#### Scenario: A design of one is valid and uniformly shaped
+- **WHEN** `ssd_design(base)` is called with a single scenario
+- **THEN** it SHALL return a one-member design whose member is addressed
+  exactly as in a larger design (named `"base"`, with the `base_` prefix and
+  `scenario=base` results level downstream), while a no-argument
+  `ssd_design()` call SHALL abort with an informative error
 
 #### Scenario: Invalid elements and names abort
 - **WHEN** `ssd_design()` is called with an element that is not an
@@ -69,9 +80,9 @@ be unchanged.
 - **THEN** `rlang::check_dots_empty()` SHALL abort with an informative error
 
 ### Requirement: Design-pipeline results are byte-identical to standalone runs
-A scenario's per-task `sample`, `fit`, and `hc` results produced through
-`ssd_design_targets()` SHALL be byte-identical (as read-back R values) to those
-produced by running the same scenario alone through `ssd_scenario_targets()`:
+A scenario's per-task `sample`, `fit`, and `hc` results SHALL be byte-identical
+(as read-back R values) between `ssd_design_targets()` and a run of the same
+scenario alone through `ssd_scenario_targets()`:
 combination changes addressing only (target names and results roots), never any
 task's `(seed, primer)`. Scenario *names* SHALL NOT enter task identity, the
 per-task primer, or any result value. Two scenarios in a design sharing a `seed`
@@ -91,6 +102,43 @@ be warned about or rejected.
   names (in separate runs)
 - **THEN** the per-task results SHALL be identical across the two runs, with
   only the target names and `scenario=<name>` paths differing
+
+### Requirement: Design growth mints the new member's targets and caches existing ones
+Design growth SHALL be additive: adding a scenario to a design that has already
+been `tar_make()`'d into a root SHALL mint new named targets only for the new
+member. On re-sourcing, `tar_make()` SHALL build only the new member's shard
+and summary targets plus the top-level combined `summary`, and every
+pre-existing member's target SHALL be reported cached (skipped) by `targets`
+with its Parquet byte-identical (no in-place rewrite, no recomputation). This
+holds because member addressing — the `<name>_` target-name prefix and the
+`scenario=<name>/layout=<hash>` root — is independent of the design's other
+members, so an existing member's target names, commands, and `format = "file"`
+outputs are unchanged by the addition (the path-axis-growth contract, one level
+up: extension is literally more named targets). Removing a member SHALL
+likewise leave every remaining member cached, with only the combined `summary`
+re-running (over the remaining members) and the removed member's
+`scenario=<name>` subtree abandoned in place, the standard addressing-change
+behaviour. The documentation SHALL steer studies that may grow toward starting
+as a **design of one** (growth is then purely additive), and SHALL document
+promoting a standalone `ssd_scenario_targets()` run into a design as **safe but
+recomputing** — task identity and every `(seed, primer)` are unchanged, but the
+addressing changes (names gain the `<name>_` prefix; the root gains the
+`scenario=<name>` level), so no prior shard satisfies the cache.
+
+#### Scenario: Adding a scenario builds only the new member and the combined summary
+- **WHEN** a design of scenario `a` is run to completion through
+  `ssd_design_targets()` + `tar_make()`, then the design is grown to
+  `ssd_design(a, b)` and `tar_make()` is re-run into the same root
+- **THEN** only `b`'s shard and summary targets and the top-level `summary`
+  SHALL build; every `a` target SHALL be reported cached (skipped) and `a`'s
+  shard and summary Parquets SHALL be byte-identical to before
+
+#### Scenario: Removing a scenario leaves the remaining members cached
+- **WHEN** the completed design `ssd_design(a, b)` is re-sourced as
+  `ssd_design(a)` and `tar_make()` is re-run into the same root
+- **THEN** every `a` target SHALL be reported cached (skipped), only the
+  combined `summary` SHALL re-run (unioning `a` alone), and the
+  `scenario=b` subtree SHALL remain on disk untouched
 
 ### Requirement: A combined design summary with a scenario identity column
 The design pipeline SHALL include one top-level `summary` target (the only

--- a/openspec/changes/scenario-combine/specs/scenario-combine/spec.md
+++ b/openspec/changes/scenario-combine/specs/scenario-combine/spec.md
@@ -2,109 +2,111 @@
 
 ## ADDED Requirements
 
-### Requirement: A named scenario collection constructor
-The package SHALL provide `ssd_scenarios(...)` returning a classed
-`ssdsims_scenarios` named collection of `ssdsims_scenario` objects. Names SHALL
-be taken from explicit argument names or derived from the argument expression
-(mirroring the `ssd_data()` dataset-name derivation). The constructor SHALL
-validate that every element is an `ssdsims_scenario` and that the names are
-unique, non-empty, non-`NA`, and safe to serve as both a target-name prefix and
-a results directory level (starting with a letter; letters, digits, and
+### Requirement: A design is a named scenario collection
+The package SHALL provide `ssd_design(...)` returning a classed `ssdsims_design`
+named collection of `ssdsims_scenario` objects — the **design** (DoE sense: the
+set of conditions to run), the union of regular per-scenario grids into one
+possibly-non-regular design. Names SHALL be taken from explicit argument names
+or derived from the argument expression (mirroring the `ssd_data()` dataset-name
+derivation); each name is a **scenario name** within the design. The constructor
+SHALL validate that every element is an `ssdsims_scenario` and that the names
+are unique, non-empty, non-`NA`, and safe to serve as both a target-name prefix
+and a results directory level (starting with a letter; letters, digits, and
 underscore only), aborting with an informative error otherwise. Construction
 SHALL be RNG-free (no draws; `.Random.seed` unchanged).
 
 #### Scenario: Names are derived or explicit
-- **WHEN** `ssd_scenarios(base, wide = scenario2)` is called with `base` a
+- **WHEN** `ssd_design(base, wide = scenario2)` is called with `base` a
   variable holding a scenario
-- **THEN** the collection SHALL contain the two scenarios named `"base"` (from
-  the argument expression) and `"wide"` (explicit), in input order
+- **THEN** the design SHALL contain the two scenarios named `"base"` (from the
+  argument expression) and `"wide"` (explicit), in input order
 
 #### Scenario: Invalid elements and names abort
-- **WHEN** `ssd_scenarios()` is called with an element that is not an
+- **WHEN** `ssd_design()` is called with an element that is not an
   `ssdsims_scenario`, or with duplicate, empty, or unsafe names (e.g. a name
   not matching the documented safe shape)
 - **THEN** it SHALL abort with an informative error identifying the offending
   element or name
 
-### Requirement: A multi-scenario target factory builds one pipeline
+### Requirement: A design target factory builds one pipeline
 The package SHALL provide
-`ssd_scenarios_targets(scenarios, ..., root = "results", upload = NULL, cue = NULL)`
-that accepts an `ssdsims_scenarios` collection and returns the complete list of
-`targets` objects running every scenario in a single static-branching pipeline.
-For each named scenario it SHALL emit the same target set
-`ssd_scenario_targets()` builds for that scenario — the per-step shard targets,
-the per-child upstream edges, and the per-scenario summary — with every target
-name prefixed `<name>_` (so target names are disjoint across scenarios) and
-written under the per-scenario, per-layout root
+`ssd_design_targets(design, ..., root = "results", upload = NULL, cue = NULL)`
+that accepts an `ssdsims_design` collection and returns the complete list of
+`targets` objects running every scenario in the design in a single
+static-branching pipeline. For each named scenario it SHALL emit the same target
+set `ssd_scenario_targets()` builds for that scenario — the per-step shard
+targets, the per-child upstream edges, and the per-scenario summary — with every
+target name prefixed `<name>_` (so target names are disjoint across scenarios)
+and written under the per-scenario, per-layout root
 `<root>/scenario=<name>/layout=<hash>`. The factory SHALL place `...`
-immediately after `scenarios` and call `rlang::check_dots_empty()`, so `root`,
-`upload`, and `cue` MUST be passed by name. The factory SHALL perform no
-network I/O. The public contract of the single-scenario
-`ssd_scenario_targets()` SHALL be unchanged.
+immediately after `design` and call `rlang::check_dots_empty()`, so `root`,
+`upload`, and `cue` MUST be passed by name. The factory SHALL perform no network
+I/O. The public contract of the single-scenario `ssd_scenario_targets()` SHALL
+be unchanged.
 
-#### Scenario: One tar_make runs all scenarios
+#### Scenario: One tar_make runs the whole design
 - **WHEN** a `_targets.R` builds two scenarios, calls
-  `ssd_scenarios_targets(ssd_scenarios(a, b))`, and `targets::tar_make()` runs
+  `ssd_design_targets(ssd_design(a, b))`, and `targets::tar_make()` runs
 - **THEN** every shard target of both scenarios SHALL build in the one
   pipeline, each scenario's shards and summary landing under its own
   `<root>/scenario=<name>/layout=<hash>` tree
 
 #### Scenario: Target names are disjoint across scenarios
-- **WHEN** two scenarios in the collection share path cells (e.g. the same
-  dataset and `sim` values) and the pipeline is sourced
+- **WHEN** two scenarios in the design share path cells (e.g. the same dataset
+  and `sim` values) and the pipeline is sourced
 - **THEN** each scenario's targets SHALL carry its `<name>_` prefix and the
   combined target list SHALL contain no duplicate target names
 
 #### Scenario: Scenarios sharing a layout do not mix shards
-- **WHEN** two scenarios in the collection have identical `partition_by` (the
-  same layout hash)
+- **WHEN** two scenarios in the design have identical `partition_by` (the same
+  layout hash)
 - **THEN** their shards SHALL land under distinct `scenario=<name>` subtrees
   and neither scenario's readers SHALL union the other scenario's shards
 
 #### Scenario: root, upload, and cue must be passed by name
-- **WHEN** `ssd_scenarios_targets()` is called with a positional argument
-  after `scenarios`, or a misspelled named argument
+- **WHEN** `ssd_design_targets()` is called with a positional argument after
+  `design`, or a misspelled named argument
 - **THEN** `rlang::check_dots_empty()` SHALL abort with an informative error
 
-### Requirement: Combined-pipeline results are byte-identical to standalone runs
+### Requirement: Design-pipeline results are byte-identical to standalone runs
 A scenario's per-task `sample`, `fit`, and `hc` results produced through
-`ssd_scenarios_targets()` SHALL be byte-identical (as read-back R values) to
-those produced by running the same scenario alone through
-`ssd_scenario_targets()`: combination changes addressing only (target names
-and results roots), never any task's `(seed, primer)`. Scenario *names* SHALL
-NOT enter task identity, the per-task primer, or any result value. Two
-scenarios sharing a `seed` SHALL share `(seed, primer)` on overlapping task
-identities (common random numbers for paired settings comparisons); this
-SHALL be documented and SHALL NOT be warned about or rejected.
+`ssd_design_targets()` SHALL be byte-identical (as read-back R values) to those
+produced by running the same scenario alone through `ssd_scenario_targets()`:
+combination changes addressing only (target names and results roots), never any
+task's `(seed, primer)`. Scenario *names* SHALL NOT enter task identity, the
+per-task primer, or any result value. Two scenarios in a design sharing a `seed`
+SHALL share `(seed, primer)` on overlapping task identities (common random
+numbers for paired settings comparisons); this SHALL be documented and SHALL NOT
+be warned about or rejected.
 
 #### Scenario: Per-task results equal the standalone pipeline's
 - **WHEN** a scenario is run both standalone (`ssd_scenario_targets()`) and as
-  a member of a combined pipeline (`ssd_scenarios_targets()`), and the
-  per-task results are aligned by the task-identity key (`<step>_id`)
+  a member of a design (`ssd_design_targets()`), and the per-task results are
+  aligned by the task-identity key (`<step>_id`)
 - **THEN** the `sample`, `fit`, and `hc` results SHALL be equal across the two
   runs
 
 #### Scenario: Renaming a scenario leaves results unchanged
-- **WHEN** the same scenario object is combined under two different collection
+- **WHEN** the same scenario object is placed in a design under two different
   names (in separate runs)
 - **THEN** the per-task results SHALL be identical across the two runs, with
   only the target names and `scenario=<name>` paths differing
 
-### Requirement: A combined cross-scenario summary with a scenario identity column
-The multi-scenario pipeline SHALL include one top-level `summary` target (the
-only unprefixed target the factory mints) that names every per-scenario
-summary target (ordering and invalidation) and writes a combined
-`<root>/summary.parquet` unioning the per-scenario **compact** summaries, each
-row tagged with a `scenario` column holding the scenario's collection name.
-The union SHALL be performed at the DuckDB level (lazy reads written straight
-back out) so no per-scenario summary is collected into R. Per-scenario compact
-summary files that did not land SHALL be skipped, so the combined summary
-unions the surviving scenarios (the §6.2 keep-going property). Retained-draws
+### Requirement: A combined design summary with a scenario identity column
+The design pipeline SHALL include one top-level `summary` target (the only
+unprefixed target the factory mints) that names every per-scenario summary
+target (ordering and invalidation) and writes a combined `<root>/summary.parquet`
+unioning the per-scenario **compact** summaries, each row tagged with a
+`scenario` column holding the scenario's name within the design. The union SHALL
+be performed at the DuckDB level (lazy reads written straight back out) so no
+per-scenario summary is collected into R. Per-scenario compact summary files
+that did not land SHALL be skipped, so the combined summary unions the surviving
+scenarios (the §6.2 keep-going property). Retained-draws
 (`summary-samples.parquet`) files SHALL remain per-scenario and SHALL NOT be
 combined.
 
 #### Scenario: Combined summary unions and tags the per-scenario summaries
-- **WHEN** a combined pipeline of scenarios `a` and `b` runs to completion
+- **WHEN** a design of scenarios `a` and `b` runs to completion
 - **THEN** `<root>/summary.parquet` SHALL contain the union of the two
   per-scenario compact summaries with a `scenario` column equal to `"a"` or
   `"b"` per row, and each per-scenario `summary.parquet` SHALL be unchanged by
@@ -116,21 +118,21 @@ combined.
   summaries rather than aborting
 
 ### Requirement: Per-scenario upload prefixing
-With a non-`NULL` `upload`, `ssd_scenarios_targets()` SHALL pair each
-scenario's step shards with `upload_<step>` targets (per the `cloud-upload`
-capability) whose destination is the supplied upload object with its blob
-prefix extended by `scenario=<name>`, so the remote layout mirrors the local
-`scenario=<name>` trees and no two scenarios upload to the same blob path.
-With `upload = NULL` (the default) the factory SHALL emit no upload targets.
-The per-task results SHALL be unchanged and independent of `upload`.
+With a non-`NULL` `upload`, `ssd_design_targets()` SHALL pair each scenario's
+step shards with `upload_<step>` targets (per the `cloud-upload` capability)
+whose destination is the supplied upload object with its blob prefix extended by
+`scenario=<name>`, so the remote layout mirrors the local `scenario=<name>`
+trees and no two scenarios upload to the same blob path. With `upload = NULL`
+(the default) the factory SHALL emit no upload targets. The per-task results
+SHALL be unchanged and independent of `upload`.
 
 #### Scenario: Each scenario uploads under its own prefix
-- **WHEN** `ssd_scenarios_targets(scenarios, upload = <destination>)` is
-  called for scenarios `a` and `b`
+- **WHEN** `ssd_design_targets(design, upload = <destination>)` is called for a
+  design of scenarios `a` and `b`
 - **THEN** the returned list SHALL contain per-shard upload targets whose
   destinations carry blob prefixes ending `scenario=a` and `scenario=b`
   respectively (extending any prefix already on the destination)
 
 #### Scenario: upload defaults to no upload targets
-- **WHEN** `ssd_scenarios_targets(scenarios)` is called without `upload`
+- **WHEN** `ssd_design_targets(design)` is called without `upload`
 - **THEN** the returned target list SHALL contain no `upload_<step>` targets

--- a/openspec/changes/scenario-combine/tasks.md
+++ b/openspec/changes/scenario-combine/tasks.md
@@ -1,16 +1,16 @@
 # Tasks: scenario-combine
 
-## 1. `ssd_scenarios()` collection constructor
+## 1. `ssd_design()` collection constructor
 
-- [ ] 1.1 Add `R/scenarios.R` with exported `ssd_scenarios(...)`: capture names
-      from explicit argument names or derive from the argument expression
+- [ ] 1.1 Add `R/design.R` with exported `ssd_design(...)`: capture names from
+      explicit argument names or derive from the argument expression
       (reuse/mirror the `ssd_data()` derivation helpers in `R/data.R`), return
-      a named list classed `ssdsims_scenarios`
+      a named list of scenarios classed `ssdsims_design`
 - [ ] 1.2 Validate: every element is an `ssdsims_scenario` (`chk_s3_class`),
       names unique, non-empty, non-`NA`, and matching the safe shape
       `^[A-Za-z][A-Za-z0-9_]*$` (target-name prefix + directory level), with
       informative errors naming the offending element; construction is RNG-free
-- [ ] 1.3 Unit tests in `tests/testthat/test-scenarios.R`: derived vs explicit
+- [ ] 1.3 Unit tests in `tests/testthat/test-design.R`: derived vs explicit
       names, input order preserved, duplicate/empty/unsafe-name and
       non-scenario-element errors, `.Random.seed` untouched
 
@@ -25,12 +25,12 @@
       prefix: existing factory tests pass untouched (no snapshot or
       target-name churn)
 
-## 3. `ssd_scenarios_targets()` multi-scenario factory
+## 3. `ssd_design_targets()` design factory
 
 - [ ] 3.1 Add exported
-      `ssd_scenarios_targets(scenarios, ..., root = "results", upload = NULL, cue = NULL)`:
-      `rlang::check_dots_empty()`, `chk_s3_class(scenarios, "ssdsims_scenarios")`,
-      same `upload` validation as the single factory
+      `ssd_design_targets(design, ..., root = "results", upload = NULL, cue = NULL)`:
+      `rlang::check_dots_empty()`, `chk_s3_class(design, "ssdsims_design")`,
+      same `upload` validation as the single-scenario factory
 - [ ] 3.2 Per scenario, assemble the single-scenario target set with
       `prefix = paste0(name, "_")` and
       `root = scenario_results_dir(scenario, root = file.path(root, paste0("scenario=", name)))`
@@ -39,31 +39,31 @@
       `ssdsims_upload` (azure: join with the existing `prefix`; dryrun:
       pass-through), keeping the factory free of network I/O
 
-## 4. Combined cross-scenario summary
+## 4. Combined design summary
 
-- [ ] 4.1 Add `ssd_summarise_scenarios(summaries, path)` (exported, next to
+- [ ] 4.1 Add `ssd_summarise_design(summaries, path)` (exported, next to
       `ssd_summarise()` in `R/targets-runner.R`): `summaries` a named character
       vector of per-scenario compact summary paths; lazily read each landed
       file via `duckplyr`, tag a literal `scenario` column, `union_all`, and
       write `path` inside DuckDB (no R materialisation); skip paths that do
       not exist (survivors union)
-- [ ] 4.2 In `ssd_scenarios_targets()`, mint the single top-level `summary`
+- [ ] 4.2 In `ssd_design_targets()`, mint the single top-level `summary`
       target (the only unprefixed name): an `edge_block()` over every
-      per-scenario `<name>_summary` target, then
-      `ssd_summarise_scenarios()` over the per-scenario compact summary paths
-      (computed from the roots — never the second `summary-samples` path) to
-      `<root>/summary.parquet`, `format = "file"`
+      per-scenario `<name>_summary` target, then `ssd_summarise_design()` over
+      the per-scenario compact summary paths (computed from the roots — never
+      the second `summary-samples` path) to `<root>/summary.parquet`,
+      `format = "file"`
 
 ## 5. Integration tests
 
 - [ ] 5.1 Pipeline test (mirroring the existing `_targets.R` fixture pattern in
-      `tests/testthat/fixtures/`): two tiny scenarios through
-      `ssd_scenarios_targets()`; one `tar_make()` builds both scenarios'
-      shards under their `scenario=<name>/layout=<hash>` trees with no
-      duplicate target names
+      `tests/testthat/fixtures/`): a two-scenario design through
+      `ssd_design_targets()`; one `tar_make()` builds both scenarios' shards
+      under their `scenario=<name>/layout=<hash>` trees with no duplicate
+      target names
 - [ ] 5.2 Byte-identity: each scenario's per-task `sample`/`fit`/`hc` results
       (aligned by `<step>_id`) equal a standalone `ssd_scenario_targets()` run
-      of the same scenario; rerun under a different collection name yields
+      of the same scenario; rerun under a different scenario name yields
       identical results (addressing-only)
 - [ ] 5.3 Combined summary: `<root>/summary.parquet` unions both compact
       summaries with the per-row `scenario` tag and leaves the per-scenario
@@ -78,16 +78,16 @@
 
 ## 6. Documentation
 
-- [ ] 6.1 Roxygen for `ssd_scenarios()`, `ssd_scenarios_targets()` (including
-      the common-random-numbers note for shared seeds and the name-safety
-      contract), and `ssd_summarise_scenarios()`; regenerate `NAMESPACE`/`man/`
-- [ ] 6.2 Add a multi-scenario section to `vignettes/sharded-pipeline.qmd` and
-      a pointer in `README.Rmd`; extend the `inst/targets-templates/` template
+- [ ] 6.1 Roxygen for `ssd_design()`, `ssd_design_targets()` (including the
+      common-random-numbers note for shared seeds and the name-safety
+      contract), and `ssd_summarise_design()`; regenerate `NAMESPACE`/`man/`
+- [ ] 6.2 Add a design section to `vignettes/sharded-pipeline.qmd` and a
+      pointer in `README.Rmd`; extend the `inst/targets-templates/` template
       comments (or add a template — resolve the design's open question);
       update `_pkgdown.yml`
-- [ ] 6.3 `GLOSSARY.md`: add the scenario *name* (collection key → target
-      prefix + `scenario=` path level); `ROADMAP.md`: mark the entry in-flight
-      and move to `## Done` on archive
+- [ ] 6.3 `GLOSSARY.md` *Design terms* entries (`scenario`/`design`/`study`)
+      landed with this change; `ROADMAP.md`: mark the entry in-flight and move
+      to `## Done` on archive
 - [ ] 6.4 Format with `air`, run `devtools::check()`, and confirm the
       `task-shards` capability needed no delta (single-scenario factory
       contract unchanged)

--- a/openspec/changes/scenario-combine/tasks.md
+++ b/openspec/changes/scenario-combine/tasks.md
@@ -6,12 +6,15 @@
       explicit argument names or derive from the argument expression
       (reuse/mirror the `ssd_data()` derivation helpers in `R/data.R`), return
       a named list of scenarios classed `ssdsims_design`
-- [ ] 1.2 Validate: every element is an `ssdsims_scenario` (`chk_s3_class`),
-      names unique, non-empty, non-`NA`, and matching the safe shape
-      `^[A-Za-z][A-Za-z0-9_]*$` (target-name prefix + directory level), with
-      informative errors naming the offending element; construction is RNG-free
+- [ ] 1.2 Validate: at least one scenario (empty call aborts; a design of one
+      is valid and uniformly shaped), every element is an `ssdsims_scenario`
+      (`chk_s3_class`), names unique, non-empty, non-`NA`, and matching the
+      safe shape `^[A-Za-z][A-Za-z0-9_]*$` (target-name prefix + directory
+      level), with informative errors naming the offending element;
+      construction is RNG-free
 - [ ] 1.3 Unit tests in `tests/testthat/test-design.R`: derived vs explicit
-      names, input order preserved, duplicate/empty/unsafe-name and
+      names, input order preserved, a design of one (named, no
+      special-casing), empty-call, duplicate/empty/unsafe-name and
       non-scenario-element errors, `.Random.seed` untouched
 
 ## 2. Thread a target-name prefix through the single-scenario factory
@@ -75,16 +78,27 @@
 - [ ] 5.5 Upload shape: `upload = ssd_upload_dryrun()` pairs each scenario's
       shards with upload targets and an azure-destination unit test shows the
       `scenario=<name>` prefix extension (no network)
+- [ ] 5.6 Design growth: run a design of one to completion, regrow the fixture
+      to a two-member design, and re-`tar_make()` into the same root — only
+      the new member's targets and the combined `summary` build, every
+      original target is reported skipped, and the original member's shard and
+      summary Parquets are byte-identical; shrinking back to one member leaves
+      the survivor cached, re-runs only the combined `summary`, and leaves the
+      removed `scenario=` subtree on disk
 
 ## 6. Documentation
 
 - [ ] 6.1 Roxygen for `ssd_design()`, `ssd_design_targets()` (including the
-      common-random-numbers note for shared seeds and the name-safety
-      contract), and `ssd_summarise_design()`; regenerate `NAMESPACE`/`man/`
+      common-random-numbers note for shared seeds, the name-safety contract,
+      the growth contract — adding a member caches all others — and the
+      safe-but-recomputing note on promoting a flat `ssd_scenario_targets()`
+      run into a design), and `ssd_summarise_design()`; regenerate
+      `NAMESPACE`/`man/`
 - [ ] 6.2 Add a design section to `vignettes/sharded-pipeline.qmd` and a
-      pointer in `README.Rmd`; extend the `inst/targets-templates/` template
-      comments (or add a template — resolve the design's open question);
-      update `_pkgdown.yml`
+      pointer in `README.Rmd`, steering studies that may grow toward starting
+      as a design of one; extend the `inst/targets-templates/` template
+      comments likewise (or add a template — resolve the design's open
+      question); update `_pkgdown.yml`
 - [ ] 6.3 `GLOSSARY.md` *Design terms* entries (`scenario`/`design`/`study`)
       landed with this change; `ROADMAP.md`: mark the entry in-flight and move
       to `## Done` on archive

--- a/openspec/changes/scenario-combine/tasks.md
+++ b/openspec/changes/scenario-combine/tasks.md
@@ -1,0 +1,93 @@
+# Tasks: scenario-combine
+
+## 1. `ssd_scenarios()` collection constructor
+
+- [ ] 1.1 Add `R/scenarios.R` with exported `ssd_scenarios(...)`: capture names
+      from explicit argument names or derive from the argument expression
+      (reuse/mirror the `ssd_data()` derivation helpers in `R/data.R`), return
+      a named list classed `ssdsims_scenarios`
+- [ ] 1.2 Validate: every element is an `ssdsims_scenario` (`chk_s3_class`),
+      names unique, non-empty, non-`NA`, and matching the safe shape
+      `^[A-Za-z][A-Za-z0-9_]*$` (target-name prefix + directory level), with
+      informative errors naming the offending element; construction is RNG-free
+- [ ] 1.3 Unit tests in `tests/testthat/test-scenarios.R`: derived vs explicit
+      names, input order preserved, duplicate/empty/unsafe-name and
+      non-scenario-element errors, `.Random.seed` untouched
+
+## 2. Thread a target-name prefix through the single-scenario factory
+
+- [ ] 2.1 In `R/targets-runner.R`, add an internal `prefix` parameter
+      (default `""`) flowing through `step_map()` (step and upload target
+      names), `shard_cell_names()`, and the `summary` target name, so every
+      minted name becomes `<prefix><name>`; per-child `edge_block()` wiring
+      resolves through `shard_cell_names()` and needs no separate handling
+- [ ] 2.2 Verify `ssd_scenario_targets()` output is unchanged with the empty
+      prefix: existing factory tests pass untouched (no snapshot or
+      target-name churn)
+
+## 3. `ssd_scenarios_targets()` multi-scenario factory
+
+- [ ] 3.1 Add exported
+      `ssd_scenarios_targets(scenarios, ..., root = "results", upload = NULL, cue = NULL)`:
+      `rlang::check_dots_empty()`, `chk_s3_class(scenarios, "ssdsims_scenarios")`,
+      same `upload` validation as the single factory
+- [ ] 3.2 Per scenario, assemble the single-scenario target set with
+      `prefix = paste0(name, "_")` and
+      `root = scenario_results_dir(scenario, root = file.path(root, paste0("scenario=", name)))`
+- [ ] 3.3 With non-`NULL` `upload`, extend the destination's blob prefix by
+      `scenario=<name>` per scenario via an internal helper on
+      `ssdsims_upload` (azure: join with the existing `prefix`; dryrun:
+      pass-through), keeping the factory free of network I/O
+
+## 4. Combined cross-scenario summary
+
+- [ ] 4.1 Add `ssd_summarise_scenarios(summaries, path)` (exported, next to
+      `ssd_summarise()` in `R/targets-runner.R`): `summaries` a named character
+      vector of per-scenario compact summary paths; lazily read each landed
+      file via `duckplyr`, tag a literal `scenario` column, `union_all`, and
+      write `path` inside DuckDB (no R materialisation); skip paths that do
+      not exist (survivors union)
+- [ ] 4.2 In `ssd_scenarios_targets()`, mint the single top-level `summary`
+      target (the only unprefixed name): an `edge_block()` over every
+      per-scenario `<name>_summary` target, then
+      `ssd_summarise_scenarios()` over the per-scenario compact summary paths
+      (computed from the roots — never the second `summary-samples` path) to
+      `<root>/summary.parquet`, `format = "file"`
+
+## 5. Integration tests
+
+- [ ] 5.1 Pipeline test (mirroring the existing `_targets.R` fixture pattern in
+      `tests/testthat/fixtures/`): two tiny scenarios through
+      `ssd_scenarios_targets()`; one `tar_make()` builds both scenarios'
+      shards under their `scenario=<name>/layout=<hash>` trees with no
+      duplicate target names
+- [ ] 5.2 Byte-identity: each scenario's per-task `sample`/`fit`/`hc` results
+      (aligned by `<step>_id`) equal a standalone `ssd_scenario_targets()` run
+      of the same scenario; rerun under a different collection name yields
+      identical results (addressing-only)
+- [ ] 5.3 Combined summary: `<root>/summary.parquet` unions both compact
+      summaries with the per-row `scenario` tag and leaves the per-scenario
+      summaries unchanged; with one scenario's summary missing, the combined
+      summary unions the survivor without aborting
+- [ ] 5.4 Same-layout isolation: two scenarios with identical `partition_by`
+      land under distinct `scenario=` subtrees and neither's readers see the
+      other's shards
+- [ ] 5.5 Upload shape: `upload = ssd_upload_dryrun()` pairs each scenario's
+      shards with upload targets and an azure-destination unit test shows the
+      `scenario=<name>` prefix extension (no network)
+
+## 6. Documentation
+
+- [ ] 6.1 Roxygen for `ssd_scenarios()`, `ssd_scenarios_targets()` (including
+      the common-random-numbers note for shared seeds and the name-safety
+      contract), and `ssd_summarise_scenarios()`; regenerate `NAMESPACE`/`man/`
+- [ ] 6.2 Add a multi-scenario section to `vignettes/sharded-pipeline.qmd` and
+      a pointer in `README.Rmd`; extend the `inst/targets-templates/` template
+      comments (or add a template — resolve the design's open question);
+      update `_pkgdown.yml`
+- [ ] 6.3 `GLOSSARY.md`: add the scenario *name* (collection key → target
+      prefix + `scenario=` path level); `ROADMAP.md`: mark the entry in-flight
+      and move to `## Done` on archive
+- [ ] 6.4 Format with `air`, run `devtools::check()`, and confirm the
+      `task-shards` capability needed no delta (single-scenario factory
+      contract unchanged)


### PR DESCRIPTION
This PR adds the design document, specification, and task list for the `scenario-combine` feature to the openspec directory.

## Summary

The `scenario-combine` feature introduces the **design** as a named collection of scenarios that can be run as a single targets pipeline. This addresses the need to compare simulation settings (like `dists`, `est_method`, `nrow_max`, `ci`) that are scenario-wide and cannot be expressed as cross-join axes within a single scenario.

## Changes

- **`openspec/changes/scenario-combine/design.md`**: Comprehensive design document covering:
  - Context and motivation (target name collisions, root collisions, non-regular design grids)
  - Goals and non-goals (one pipeline/store/make, byte-identical per-scenario results, combined summary with scenario identity column)
  - Key decisions (design composes per-scenario factories, `ssd_design()` owns naming, internal target-name prefix threading, per-scenario roots at `scenario=<name>/layout=<hash>`, growable studies start as design-of-one, combined summary unions per-scenario compacts)
  - Risks and trade-offs
  - Migration plan (additive only, no breaking changes)

- **`openspec/changes/scenario-combine/spec.md`**: Formal specification with requirements and scenarios covering:
  - `ssd_design()` collection constructor (validation, naming, design-of-one support)
  - `ssd_design_targets()` factory (one pipeline, disjoint target names, shard isolation, named-argument enforcement)
  - Byte-identical results and design growth (additive member addition, caching existing members)
  - Combined design summary with scenario identity column
  - Per-scenario upload prefixing

- **`openspec/changes/scenario-combine/tasks.md`**: Implementation task list covering:
  - Collection constructor and validation
  - Threading target-name prefix through single-scenario factory
  - Design factory implementation
  - Combined summary logic
  - Integration and unit tests
  - Documentation (roxygen, vignette, glossary, roadmap, templates)

- **`openspec/changes/scenario-combine/proposal.md`**: High-level proposal explaining the why, what changes, capabilities, and impact

- **`GLOSSARY.md`**: Added *Design terms* section defining the hierarchy:
  - **scenario**: One regular cross-join grid, the construction-time root of one targets pipeline
  - **design**: A named set of scenarios run as one pipeline (union of regular sub-grids into a possibly non-regular design)
  - **study**: Longitudinal aggregate across infrastructure/time/software versions (read-side concept, not built here)

- **`.openspec.yaml`**: Metadata file for the change

## Notes

This is a specification-only PR documenting the design and requirements for the `scenario-combine` feature. Implementation will follow in a separate PR. The design preserves byte-identity of per-scenario results, enables design growth with caching of existing members, and introduces the design as the middle level of the scenario/design/study hierarchy.

https://claude.ai/code/session_01FXDLpphWhVtVJMH538Wdq7