### PR TITLE
openspec: default `replace` to TRUE in scenario definition

### DIFF
--- a/openspec/changes/replace-default-true/design.md
+++ b/openspec/changes/replace-default-true/design.md
@@ -1,27 +1,30 @@
 ## Context
 
 `nrow-max-setting` (same branch, PR #149) fixed the shared `sample` draw at the
-scenario's `nrow_max` setting and validates each `nrow` against the effective
-draw size — `min(nrow_max, nrow(data))` per dataset when `replace` includes
-`FALSE`, `nrow_max` when it includes `TRUE`. With that in place, the
-`replace = FALSE` default is the limiting choice: it caps the default
-scenario's `nrow` sweep at the dataset size, while the with-replacement draw
-(the standard resampling model for a simulation study) has no such ceiling.
+scenario's `nrow_max` setting and defines the effective draw size —
+`min(nrow_max, nrow(data))` per dataset when `replace` includes `FALSE`,
+`nrow_max` when it includes `TRUE`. With that in place, the `replace = FALSE`
+default is the limiting choice: it caps the default scenario's `nrow` sweep at
+the dataset size, while the with-replacement draw (the standard resampling model
+for a simulation study) has no such ceiling.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
 - Default `replace` to `TRUE` in `ssd_define_scenario()`.
-- Pin the mixed-`replace` semantics as a contract: the grid is a rectangular
-  cross-join, so an `nrow` infeasible under *any* included `replace` value for
-  *any* dataset aborts construction — no cell dropout, no short draws.
+- Pin the mixed-`replace` semantics as a contract: an `nrow` infeasible for the
+  `replace = FALSE` permutation draw of a given dataset is **silently
+  discarded** from that dataset's `replace = FALSE` cells — the rest of the grid
+  (every `replace = TRUE` cell, every feasible `replace = FALSE` cell) runs
+  unchanged.
 
 **Non-Goals:**
 
-- No change to `replace` as an axis (vocabulary, partitioning, primers).
-- No change to the validation logic itself — `nrow-max-setting` implemented it;
-  this change flips one default and adds the spec scenarios + tests.
+- No change to `replace` as an axis (vocabulary, partitioning, primers) beyond
+  the per-dataset feasibility filter.
+- No change to the effective-draw-size definition itself — `nrow-max-setting`
+  defines it; this change consumes it to decide which cells are feasible.
 - No change to the legacy `ssd_sim_data()`/`ssd_run_scenario()` defaults
   (superseded; reworked in `migrate-public-api`).
 
@@ -38,45 +41,96 @@ blobs), and the `fit` step still operates on `head(draw, nrow)`.
 default `nrow` ceiling to each dataset's size, which is exactly the limitation
 `nrow_max` was introduced to remove.
 
-### Decision: mixed `replace` keeps the rectangular-grid abort
+### Decision: discard infeasible `replace = FALSE` cells rather than abort
 
-With `replace = c(FALSE, TRUE)`, every `nrow` must satisfy **both** modes for
-**every** dataset: `nrow <= nrow_max` (the `TRUE` draw) and
-`nrow <= min(nrow_max, nrow(data))` per dataset (the `FALSE` draw). One
-violation aborts construction in the user-facing frame, naming the offending
-dataset and its effective draw size on the `FALSE` branch.
+With `replace = c(FALSE, TRUE)` (or the default `TRUE` widened to include
+`FALSE`) over an `nrow` sweep, a large `nrow` is feasible for the with-
+replacement draw but not for the permutation draw of a small dataset. The
+constructor materialises the task grid as a cross-join, then **drops** the
+`(dataset, nrow)` cells where `replace == FALSE` and
+`nrow > min(nrow_max, nrow(data))`. The drop is per dataset and silent (no
+warning, no short draw): the feasible cells — all `replace = TRUE` cells and the
+in-cap `replace = FALSE` cells — are unaffected.
 
-*Alternative considered — drop infeasible `(replace = FALSE, nrow)` cells.*
-Rejected: the task graph is a pure cross-join of the scenario's axis values
-(`task-lists`); a non-rectangular grid would make task counts, ids, and shard
-sets depend on per-dataset row counts, breaking the "shard set is a pure
-function of the scenario" model for marginal convenience. A user who wants
-both modes with a large `nrow` should either drop `FALSE` or lower `nrow` —
-the error says which constraint failed.
+The task set is therefore the cross-join *minus the infeasible
+`replace = FALSE` cells*. It is still a deterministic function of the scenario
+(the datasets, and hence their row counts, are part of the scenario), and task
+ids stay stable — they are derived from the `(dataset, sim, replace, nrow)`
+tuple, and discarding a cell simply omits its tuple. Downstream code must
+compute task/shard counts from the materialised grid rather than assuming a
+strict `D × nsim × R × |nrow|` rectangle.
 
-*Alternative considered — cap the infeasible truncation silently.* Rejected:
-`head(draw, nrow)` returning fewer than `nrow` rows is a silently wrong
-simulation cell.
+*Alternative considered — abort the whole scenario.* Rejected (this reverses the
+change's earlier draft): a rectangular-grid abort lets one infeasible
+permutation cell poison an otherwise-fine scenario, forcing the user to drop
+`FALSE` or lower `nrow` even when most cells are runnable. With `replace = TRUE`
+now the default, mixed-`replace` sweeps where the with-replacement run wants the
+full `nrow` range and the permutation run wants only its feasible prefix are a
+common, reasonable request; "run `replace = FALSE` where it is feasible" is the
+least-surprising semantics.
+
+*Alternative considered — cap the infeasible truncation silently (short draw).*
+Rejected: `head(draw, nrow)` returning fewer than `nrow` rows is a silently
+wrong simulation cell. Discarding the *task* is correct; shortening its *data*
+is not.
+
+*Alternative considered — emit a message naming the discarded cells.* Rejected
+for now: the directive is to discard silently, and `replace = FALSE` infeasible
+for a sweep is the expected, not exceptional, case. (A future opt-in summary
+could list discarded cells without changing the default.)
+
+### Decision: `replace = TRUE` over-`nrow_max` and an empty grid still abort
+
+Two cases remain hard errors in the user-facing frame, because neither is a
+per-dataset permutation-feasibility question:
+
+- `nrow > nrow_max` while `replace` includes `TRUE` — `nrow_max` is the
+  scenario's own draw ceiling, independent of any dataset, so exceeding it is a
+  misconfiguration, not an infeasible cell.
+- The `replace = FALSE` discard leaves **no** feasible task at all (e.g.
+  `replace = FALSE` only, every `nrow` above every dataset's cap). An empty
+  pipeline is a user error, so the constructor aborts rather than returning a
+  scenario that produces nothing.
+
+### Decision: filter in task expansion, not the constructor's stored axes
+
+The scenario stores its axes (`datasets`, `nrow`, `replace`) verbatim; the
+feasibility filter lives where the grid is materialised (`R/task-lists.R`,
+`sample_task_grid` / `fit_task_table`). The `fit` grid drops rows where
+`replace == FALSE` and `nrow` exceeds the dataset's effective draw size; a
+`(dataset, replace = FALSE)` `sample` cell is dropped only when *no* `nrow`
+survives for it. This keeps the stored scenario a faithful record of what the
+user asked for and confines the non-rectangular logic to one place.
 
 ## Risks / Trade-offs
 
+- **The task/shard set is no longer a plain rectangle.** It now depends on
+  per-dataset row counts. Mitigation: it remains deterministic given the
+  scenario (datasets are part of it) and task ids are unchanged for surviving
+  cells; only count-derivation code that assumed rectangularity must read the
+  materialised grid.
+- **Silent discard can surprise.** A user may expect `replace = FALSE` results
+  for an `nrow` that was quietly dropped. Accepted per the directive; the
+  empty-grid guard catches the degenerate all-dropped case, and the
+  per-dataset semantics are documented and tested.
 - **Behavioural re-baseline for default scenarios.** Intended and pre-1.0;
   draws, `replace=TRUE` ids, prints, and snapshots re-record. Explicit
-  `replace` is untouched.
-- **Default draws grow** (`nrow_max = 1000L` rows with replacement vs the old
-  `max(nrow)` permutation prefix). Accepted in `nrow-max-setting`'s storage
-  analysis; tunable per scenario.
+  `replace` is otherwise untouched.
 
 ## Migration Plan
 
 1. Flip the signature default; update `@param replace` and the GLOSSARY entry.
-2. Re-point default-`replace` tests (`TRUE` expectations, `replace=TRUE` ids);
+2. Move per-dataset `replace = FALSE` feasibility from a construction abort
+   (introduced by `nrow-max-setting`) to a silent discard in `R/task-lists.R`;
+   keep the `replace = TRUE` / `nrow_max` abort and add the empty-grid guard.
+3. Re-point default-`replace` tests (`TRUE` expectations, `replace=TRUE` ids);
    make permutation-cap tests explicit `replace = FALSE`; add mixed-`replace`
-   and per-dataset abort tests; re-record snapshots.
-3. `devtools::document()`; render vignettes; `air format`; full test run;
+   discard, per-dataset, and empty-grid tests; re-record snapshots.
+4. `devtools::document()`; render vignettes; `air format`; full test run;
    `openspec validate --strict`.
 
-Rollback is a one-line revert of the default plus the re-recorded snapshots.
+Rollback is a one-line revert of the default plus restoring the construction
+abort and the re-recorded snapshots.
 
 ## Open Questions
 

--- a/openspec/changes/replace-default-true/proposal.md
+++ b/openspec/changes/replace-default-true/proposal.md
@@ -10,15 +10,18 @@ sweep a simulation study wants. `replace = FALSE` (a permutation draw) remains
 available as an explicit choice.
 
 Flipping the default also surfaces a behaviour worth pinning: **what happens
-when `replace = c(FALSE, TRUE)` and some `nrow` exceeds a dataset's size?** The
-scenario grid is a rectangular cross-join, so every `(dataset, sim, replace)`
-cell must support every `nrow` truncation. One infeasible cell — an `nrow`
-above the `replace = FALSE` effective draw size (`min(nrow_max, nrow(data))`)
-for *any* dataset — therefore poisons the whole scenario: construction aborts
-(naming the offending dataset and draw size) rather than silently dropping
-cells or producing a short draw. This is the already-implemented behaviour of
-`nrow-max-setting`'s validation; this change makes it an explicit spec scenario
-with per-dataset tests, so the mixed-`replace` semantics are contractual, not
+when `replace = c(FALSE, TRUE)` and some `nrow` exceeds a dataset's size?**
+Under `replace = FALSE` the effective draw caps at `min(nrow_max, nrow(data))`,
+so an `nrow` above that cap has no valid permutation draw for that dataset.
+Rather than poisoning the whole scenario — aborting construction because one
+cell of an otherwise-feasible cross-join cannot be drawn — the pipeline
+**silently discards** those infeasible `(dataset, replace = FALSE, nrow)` tasks.
+Every feasible cell still runs: all `replace = TRUE` cells, and the
+`replace = FALSE` cells within each dataset's cap. The task set therefore stays
+a deterministic function of the scenario (the datasets are part of it) — it is
+simply the cross-join minus the cells that cannot be drawn, rather than a strict
+rectangle. This change makes that discard an explicit spec scenario with
+per-dataset tests, so the mixed-`replace` semantics are contractual, not
 incidental.
 
 ## What Changes
@@ -26,14 +29,18 @@ incidental.
 - **`replace` defaults to `TRUE`** in `ssd_define_scenario()` (was `FALSE`).
   Nothing else about `replace` changes: it remains a structural cross-join axis
   (1–2 unique logical values), and an explicit `replace = FALSE` or
-  `replace = c(FALSE, TRUE)` behaves exactly as before.
-- **Mixed-`replace` infeasibility is pinned**: with `replace` containing
-  `FALSE`, each `nrow` is validated against `min(nrow_max, nrow(data))` for
-  **every** dataset; with `replace` containing `TRUE`, against `nrow_max`. Any
-  violation aborts construction in the user-facing frame — the cross-join is
-  rectangular, so there is no per-cell dropout. The error names the offending
-  dataset (for the `replace = FALSE` branch) so multi-dataset scenarios are
-  debuggable.
+  `replace = c(FALSE, TRUE)` behaves as described below.
+- **Infeasible `replace = FALSE` cells are silently discarded**: where `replace`
+  includes `FALSE`, any `(dataset, nrow)` combination with
+  `nrow > min(nrow_max, nrow(data))` is dropped from the `replace = FALSE`
+  portion of the task grid (no warning, no short draw), while the matching
+  `replace = TRUE` cells and all feasible `replace = FALSE` cells are untouched.
+  The discard is per dataset, so on a multi-dataset scenario only the datasets
+  too small for a given `nrow` lose their `replace = FALSE` cell at that `nrow`.
+- **`replace = TRUE` infeasibility still aborts**: an `nrow` above `nrow_max`
+  (the scenario's own draw ceiling, independent of any dataset) remains a
+  construction error, as does a scenario whose grid is left **empty** after the
+  `replace = FALSE` discard.
 - **BREAKING (pre-1.0)**: every scenario built without an explicit `replace`
   now samples with replacement — the default draw is `nrow_max` rows (not the
   dataset permutation), so default-scenario draws, task ids
@@ -51,22 +58,26 @@ incidental.
 
 ### Modified Capabilities
 
-- `scenario-definition`: `replace` defaults to `TRUE`; the mixed-`replace`
-  rectangular-grid abort (any `nrow` infeasible under any included `replace`
-  value, for any dataset, aborts construction naming the offender) becomes an
-  explicit requirement scenario.
+- `scenario-definition`: `replace` defaults to `TRUE`; infeasible
+  `(dataset, replace = FALSE, nrow)` cells are silently discarded from the task
+  grid rather than aborting the scenario, while `replace = TRUE` over-`nrow_max`
+  and the all-empty grid still abort — captured as explicit requirement
+  scenarios.
 
 ## Impact
 
-- **Code**: `R/scenario.R` (one default flip; the validation already
-  implements the pinned behaviour), `R/params.R` (`@param replace` notes the
-  default).
+- **Code**: `R/scenario.R` (default flip; relax the per-dataset
+  `replace = FALSE` construction abort introduced by `nrow-max-setting` to the
+  `replace = TRUE` / `nrow_max` and empty-grid cases), `R/task-lists.R` (filter
+  infeasible `replace = FALSE` cells out of the `sample`/`fit` grids),
+  `R/params.R` (`@param replace` notes the default).
 - **Tests**: default-`replace` expectations flip (`unique(tasks$replace)`,
   `replace=TRUE` path ids); tests whose *point* is the permutation cap set
-  `replace = FALSE` explicitly; new mixed-`replace` and per-dataset abort
-  tests; snapshots re-record (`_snaps/scenario.md`, `_snaps/task-lists.md`).
+  `replace = FALSE` explicitly; new mixed-`replace` discard and per-dataset
+  tests (task counts reflect dropped cells; empty-grid abort); snapshots
+  re-record (`_snaps/scenario.md`, `_snaps/task-lists.md`).
 - **Docs**: `man/` regenerated; `GLOSSARY.md` `replace` entry notes the
   default; vignettes re-render (prose already conditional on `replace`).
 - **Dependencies**: builds on `nrow-max-setting` (same branch, PR #149) — the
-  effective-draw-size validation this change pins is implemented there. No
+  effective-draw-size definition this change filters on is implemented there. No
   dependants.

--- a/openspec/changes/replace-default-true/specs/scenario-definition/spec.md
+++ b/openspec/changes/replace-default-true/specs/scenario-definition/spec.md
@@ -7,17 +7,23 @@ without an explicit `replace` samples with replacement and its shared draw is
 `nrow` sweep from each dataset's size. `replace` SHALL remain a structural
 cross-join axis (one or two unique, non-missing logical values), and an
 explicit `replace = FALSE` (the permutation draw, capped at
-`min(nrow_max, nrow(data))`) SHALL behave unchanged.
+`min(nrow_max, nrow(data))`) SHALL behave as specified below.
 
-Because the task grid is a rectangular cross-join, every `nrow` SHALL be
-feasible under **every** included `replace` value for **every** dataset:
-`nrow <= nrow_max` where `replace` includes `TRUE`, and
-`nrow <= min(nrow_max, nrow(data))` per dataset where `replace` includes
-`FALSE`. Any violation SHALL abort construction in the user-facing frame — the
-constructor SHALL NOT drop infeasible cells or permit a short draw — and the
-`replace = FALSE` branch's error SHALL name the offending dataset and its
-effective draw size, so a multi-dataset scenario identifies which dataset is
-too small.
+Because a `replace = FALSE` permutation draw cannot exceed
+`min(nrow_max, nrow(data))` for a given dataset, where `replace` includes
+`FALSE` any `(dataset, nrow)` combination with
+`nrow > min(nrow_max, nrow(data))` SHALL be silently discarded from the
+`replace = FALSE` portion of the task grid — the constructor SHALL NOT abort, emit
+a warning, or permit a short draw for it. The discard SHALL be per dataset, and
+the corresponding `replace = TRUE` cells together with all feasible
+`replace = FALSE` cells SHALL be unaffected. The task grid SHALL therefore be
+the cross-join of the scenario's axes minus these infeasible `replace = FALSE`
+cells, and SHALL remain a deterministic function of the scenario.
+
+An `nrow` exceeding `nrow_max` itself (the scenario's own draw ceiling,
+independent of any dataset) SHALL still abort construction in the user-facing
+frame where `replace` includes `TRUE`, and a scenario whose grid is left empty
+by the `replace = FALSE` discard SHALL likewise abort.
 
 #### Scenario: replace defaults to TRUE
 - **WHEN** `ssd_define_scenario()` is called without `replace`
@@ -25,16 +31,23 @@ too small.
   table's `replace` values SHALL all be `TRUE`, and an `nrow` above a dataset's
   row count (but within `nrow_max`) SHALL be accepted
 
-#### Scenario: mixed replace aborts on an nrow infeasible for the FALSE draw
+#### Scenario: mixed replace discards an nrow infeasible for the FALSE draw
 - **WHEN** `ssd_define_scenario(..., nrow = 50L, replace = c(FALSE, TRUE))` is
   called with a dataset of fewer than 50 rows
-- **THEN** the constructor SHALL abort in the user-facing frame (the
-  `replace = FALSE` cell cannot support the truncation), even though the
-  `replace = TRUE` cell could — no infeasible cell is silently dropped
+- **THEN** the constructor SHALL succeed, the `replace = TRUE` cells at
+  `nrow = 50L` SHALL be present in the task grid, and the `replace = FALSE`
+  cells at `nrow = 50L` SHALL be absent (silently discarded, with no warning)
 
-#### Scenario: the abort names the offending dataset
+#### Scenario: the discard is per dataset
 - **WHEN** `ssd_define_scenario()` is called with `replace` including `FALSE`,
   several datasets, and an `nrow` exceeding only the smallest dataset's
   effective draw size
-- **THEN** the constructor SHALL abort with an error naming that dataset and
-  its effective draw size
+- **THEN** only that dataset's `replace = FALSE` cell at that `nrow` SHALL be
+  discarded; the other datasets SHALL retain their `replace = FALSE` cells at
+  that `nrow`
+
+#### Scenario: an all-infeasible FALSE-only grid aborts
+- **WHEN** `ssd_define_scenario()` is called with `replace = FALSE` only and
+  every `nrow` exceeds every dataset's effective draw size
+- **THEN** the discard SHALL leave no feasible task and the constructor SHALL
+  abort in the user-facing frame rather than return an empty scenario

--- a/openspec/changes/replace-default-true/tasks.md
+++ b/openspec/changes/replace-default-true/tasks.md
@@ -1,16 +1,22 @@
 ## 1. Default flip (`R/scenario.R`, `R/params.R`)
 
-- [x] 1.1 Change the `ssd_define_scenario()` signature default `replace = FALSE` → `replace = TRUE`; confirm the existing effective-draw-size validation already covers both branches (no logic change).
-- [x] 1.2 Note the `TRUE` default (and the permutation alternative) in `@param replace` — as a scenario-specific `@param` override in `R/scenario.R`, since the shared `R/params.R` entry is inherited by the legacy `ssd_sim_data()`/`ssd_run_scenario()` whose default stays `FALSE`; `GLOSSARY.md`: note the default in the `replace` entry.
+- [ ] 1.1 Change the `ssd_define_scenario()` signature default `replace = FALSE` → `replace = TRUE`.
+- [ ] 1.2 Note the `TRUE` default (and the permutation alternative) in `@param replace` — as a scenario-specific `@param` override in `R/scenario.R`, since the shared `R/params.R` entry is inherited by the legacy `ssd_sim_data()`/`ssd_run_scenario()` whose default stays `FALSE`; `GLOSSARY.md`: note the default in the `replace` entry.
 
-## 2. Tests
+## 2. Discard infeasible `replace = FALSE` cells (`R/scenario.R`, `R/task-lists.R`)
 
-- [x] 2.1 Re-point default-`replace` expectations: `unique(tasks$replace)` is `TRUE`; `sample_id`/path-key strings become `replace=TRUE`; default-scenario draw size is `nrow_max` rows.
-- [x] 2.2 Make tests whose point is the `replace = FALSE` permutation cap explicit (`replace = FALSE` in the call), including the `nrow`-exceeds-`nrow(data)` validation snapshot and the full-permutation baseline-draw test.
-- [x] 2.3 Add mixed-`replace` tests: `replace = c(FALSE, TRUE)` with `nrow` above the dataset size aborts (snapshot); with two datasets and an `nrow` exceeding only the smaller one, the error names that dataset; default-`replace` accepts `nrow > nrow(data)` within `nrow_max`.
-- [x] 2.4 Re-record affected snapshots (`_snaps/scenario.md` prints, `_snaps/task-lists.md` tables/ids).
+- [ ] 2.1 Relax the per-dataset `replace = FALSE` construction abort (introduced by `nrow-max-setting`) so it no longer poisons the scenario; keep the `replace = TRUE` / `nrow > nrow_max` abort in the user-facing frame.
+- [ ] 2.2 In `R/task-lists.R`, drop the infeasible cells when materialising the grid: in `fit_task_table()` (and the `sample` grid) remove rows where `replace == FALSE` and `nrow > min(nrow_max, nrow(data))` for that dataset; keep all `replace = TRUE` cells and all feasible `replace = FALSE` cells. Drop a `(dataset, replace = FALSE)` `sample` cell only when no `nrow` survives for it.
+- [ ] 2.3 Add the empty-grid guard: if the discard leaves no feasible task at all, abort construction in the user-facing frame.
 
-## 3. Docs and finalise
+## 3. Tests
 
-- [x] 3.1 `devtools::document()`; sweep vignettes/templates for prose assuming the `FALSE` default; re-render the vignettes.
-- [x] 3.2 `air format .`; full `devtools::test()`; `openspec validate replace-default-true --strict`.
+- [ ] 3.1 Re-point default-`replace` expectations: `unique(tasks$replace)` is `TRUE`; `sample_id`/path-key strings become `replace=TRUE`; default-scenario draw size is `nrow_max` rows.
+- [ ] 3.2 Make tests whose point is the `replace = FALSE` permutation cap explicit (`replace = FALSE` in the call), including the full-permutation baseline-draw test.
+- [ ] 3.3 Add discard tests: `replace = c(FALSE, TRUE)` with `nrow` above the dataset size keeps the `replace = TRUE` cells and drops the `replace = FALSE` ones (task-count / `replace`-value assertions, no warning); with two datasets and an `nrow` exceeding only the smaller one, only that dataset's `replace = FALSE` cell is dropped; `replace = FALSE`-only with every `nrow` infeasible aborts (snapshot); default-`replace` accepts `nrow > nrow(data)` within `nrow_max`.
+- [ ] 3.4 Re-record affected snapshots (`_snaps/scenario.md` prints, `_snaps/task-lists.md` tables/ids).
+
+## 4. Docs and finalise
+
+- [ ] 4.1 `devtools::document()`; sweep vignettes/templates for prose assuming the `FALSE` default or the rectangular-grid abort; re-render the vignettes.
+- [ ] 4.2 `air format .`; full `devtools::test()`; `openspec validate replace-default-true --strict`.


### PR DESCRIPTION
## Summary

Changes the default value of `replace` from `FALSE` to `TRUE` in `ssd_define_scenario()`, making with-replacement sampling the default draw mode for simulation studies. This is a breaking change (pre-1.0) that aligns with standard resampling practices.

## Key Changes

**Behavior change:** When `replace` is not explicitly specified, scenarios now sample with replacement (drawing up to `nrow_max` rows) instead of without replacement (capped at dataset size).

**Mixed-`replace` semantics:** When a scenario includes both `replace = FALSE` and `replace = TRUE` (e.g., `replace = c(FALSE, TRUE)`), infeasible `(dataset, nrow)` combinations for the permutation draw are now **silently discarded** from the task grid rather than aborting construction:
- Any `(dataset, nrow)` pair where `nrow > min(nrow_max, nrow(data))` is dropped from `replace = FALSE` cells only
- All `replace = TRUE` cells remain unaffected
- The discard is per-dataset, so only datasets too small for a given `nrow` lose their `replace = FALSE` cell at that `nrow`
- The task grid is no longer strictly rectangular but remains deterministic given the scenario

**Hard errors preserved:** Construction still aborts for:
- `nrow > nrow_max` where `replace` includes `TRUE` (scenario's own draw ceiling exceeded)
- Empty grid after `replace = FALSE` discard (no feasible tasks remain)

## Implementation Details

- **`R/scenario.R`**: Flip `replace = FALSE` → `replace = TRUE` in signature; relax per-dataset `replace = FALSE` validation to allow construction to proceed
- **`R/task-lists.R`**: Filter infeasible `replace = FALSE` cells when materialising the `sample` and `fit` task grids; add empty-grid guard
- **`R/params.R`**: Update `@param replace` documentation to note the new default
- **Tests & snapshots**: Re-point default-`replace` expectations; add discard and per-dataset tests; re-record affected snapshots

## Breaking Changes

- Default scenarios now use `replace = TRUE` (with-replacement draw at `nrow_max` rows) instead of `replace = FALSE` (permutation draw capped at dataset size)
- Task IDs and counts change for default scenarios
- Explicit `replace = FALSE` or `replace = c(FALSE, TRUE)` behavior changes: infeasible cells are silently dropped instead of aborting

## Migration

Users who relied on the `replace = FALSE` default should explicitly set `replace = FALSE` in their scenario definitions. Users with mixed-`replace` scenarios expecting an abort on infeasible permutation cells should be aware that only the infeasible cells are now dropped, not the entire scenario.

Rollback is a one-line revert of the default plus restoration of the construction abort and re-recorded snapshots.

https://claude.ai/code/session_01GDxWsFFg8vt63edYqZ4Ea2