### PR TITLE
docs(openspec): propose distset hc-axis for multi-pool reuse

### DIFF
--- a/openspec/changes/distset-hc-axis/.openspec.yaml
+++ b/openspec/changes/distset-hc-axis/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-10

--- a/openspec/changes/distset-hc-axis/design.md
+++ b/openspec/changes/distset-hc-axis/design.md
@@ -1,0 +1,136 @@
+## Context
+
+`ssdsims` expands a declarative `ssdsims_scenario` into per-step task tables
+(`sample`/`fit`/`hc`), shards them by `partition_by`, and runs them as a
+Hive-partitioned `targets` pipeline whose per-task results are byte-identical to
+the single-core baseline (`TARGETS-DESIGN.md` §§1–8). Today `dists` is a single
+fit-level **simulation setting** — one model-averaged `ssd_fit_dists()` call per
+fit task — settled by the `dists-simulation-setting` change precisely so that
+*individual distributions never fan out* (fanning out per distribution would
+dissolve the model averaging that defines a fit).
+
+The motivating `ssdaveragerr` "iwasaki" study needs the opposite of one pool: it
+fits a **superset** once and compares several model-averaging **pools** (BCANZ,
+the Iwasaki set, single distributions) carved from that one fit via
+`subset.fitdists()` — the pools share identical per-distribution fits and differ
+only in the analytical re-averaging over their members. Reproducing that on
+`ssdsims` today means one whole scenario per pool, re-fitting from scratch each
+time (no nested-fit reuse, `TARGETS-DESIGN.md` §"No nested reuse"): ~7× the fit
+cost for results that should share one fit.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let one scenario declare several distribution **sets** (pools) and compute each
+  pool's hc by subsetting **one** union fit — matching the iwasaki "fit superset,
+  subset" efficiency.
+- Keep the engine's invariants: name-only task hashing, byte-identity across the
+  three runners, path-axis-growth caching, and a side-effect-free target factory.
+- Preserve full back-compatibility: a bare character `dists` behaves exactly as
+  today (one anonymous pool, no new axis).
+
+**Non-Goals:**
+- Fanning out over *individual* distributions (that dissolves averaging — the
+  `dists-simulation-setting` guard stands; an axis value is always a whole pool).
+- Surfacing `ssd_gof()` diagnostics (`at_bound`/`computable`/`dropped`/top-dist/
+  `delta`) per `(sample × distset)` — a complementary follow-up change.
+- Nested-fit reuse across *different unions* (a wider union still re-fits; only
+  pools *within* one declared union share a fit).
+
+## Decisions
+
+### 1. The axis value is a set (a named character vector), keyed by name
+`dists` accepts a **named list of character vectors**. An axis value must be a
+complete averaging pool, so each value is itself a vector; the collection is a
+list. The set **name** (not its members) is what enters the `distset=` Hive path
+segment and the per-task primer — the exact by-name pattern already used for
+`min_pmix` and datasets (the members ride on the scenario for execution, isolated
+by the new `scenario_distset()` accessor, and never enter a hash). Names must be
+filesystem-safe; the iwasaki chemical-style strings the *datasets* carry are a
+separate concern (this is about set labels like `BCANZ`, which are already safe).
+
+*Alternative considered:* a `list of lists` where each member carries per-dist
+options — rejected: members are bare distribution names with no per-member
+structure, so a list-of-character-vectors is the precise shape.
+
+### 2. `distset` is an **hc** axis over a post-fit subset — not a fit axis
+The fit step fits the **union** `sort(unique(unlist(dists)))` once; `distset`
+enters `task_axes("hc")` only. Per hc task, the runner subsets the parent union
+fit to the task's members and re-averages.
+
+*Why hc, not fit:* a fit-level `distset` would mint one fit task per pool and
+re-fit each (≈7× cost, the very thing we are removing — `ssdsims`/`ssdtools` do
+not reuse nested `dists` fits). An hc-level axis fits once and re-averages per
+pool. With `ci = FALSE` (the iwasaki case) the re-average is purely analytical —
+no bootstrap, no RNG — so the per-pool cost is negligible. It also gives a clean
+caching property: the fit layer carries no `distset`, so adding a pool mints only
+new hc shards and caches every fit shard.
+
+### 3. The subset happens in the shared per-task primitive
+`hc_data_task_primer()` (the primitive both the baseline and the shard runners
+call) gains the set members and performs
+`subset(fits, select = members, strict = FALSE)` before `ssd_hc()`. Putting the
+subset at this single chokepoint makes the three runners byte-identical *by
+construction* — the same property the existing primers already guarantee — rather
+than duplicating subset logic in each runner. `strict = FALSE` tolerates a member
+that dropped out of the union fit (boundary/failed); an all-dropped set yields a
+zero-length subset → zero hc rows (the §6.2 survivor model), not an abort.
+
+### 4. Default `distset` to an inner (bundled) axis
+The default hc path stays `c("dataset", "sim")`, so `distset` is inner by
+default: one hc shard holds every pool for a `(dataset, sim)` cell, the runner
+decodes that cell's union fit **once**, and subsets it N ways in memory (a second
+layer of reuse on top of the one union fit). Users who want per-pool shards
+promote `distset` to `partition_by$hc`. This keeps shard counts sane (35 datasets
+× 1000 sims × 7 pools would be 245k tiny Parquets if `distset` were on the path
+by default).
+
+### 5. Correctness oracle: same-seed subset-reuse identity
+The premise — re-averaging a subset of the union equals fitting that subset alone
+— is asserted at a **fixed seed**: `ssd_hc(subset(union_fit, set))` byte-equals
+`ssd_hc(ssd_fit_dists(data, dists = set))` seeded identically (per-distribution
+fits are independent within `ssd_fit_dists()`). This is proven in
+`exploration/distset-subset-invariance.R` and asserted in a unit test. It is
+explicitly **not** an old-vs-new pipeline equality: `distset` joins the hc primer,
+so it re-seeds hc tasks (point `est` analytical/unchanged; CIs re-seeded,
+statistically equivalent) — the same re-baseline pattern as `est-method-setting`.
+
+## Risks / Trade-offs
+
+- **Re-baselining existing CI snapshots** → `distset` in the hc primer re-seeds
+  every hc task even for a single anonymous set. Mitigation: the single-set path
+  has exactly one `distset` value, and `est` is analytical/unchanged; only
+  `ci = TRUE` CI snapshots move, and those re-record like any primer change.
+  Document in the proposal Impact; back-compat is preserved for *behaviour*
+  (one pool), not for *bootstrap byte-streams*.
+- **Refining a settled decision** → the `dists-simulation-setting` decision said
+  "dists is not an axis". Mitigation: this does not contradict it — *individual
+  distributions still never fan out*; a named set of *pools* becomes an axis over
+  post-fit subsets. The TARGETS-DESIGN decision log and §"No nested reuse" get an
+  addendum stating the refinement (reuse now holds *within* one union).
+- **`subset.fitdists` semantics drift** → relying on `strict = FALSE` and on
+  subset-equals-direct-fit. Mitigation: the same-seed oracle test guards it and
+  `ssdtools (>= 2.6.0)` is already a hard dependency; no `ssdtools` change is
+  required.
+- **Shard explosion if a user paths on `distset`** → mitigated by the bundled
+  default and a vignette note; promoting `distset` to the path is an explicit,
+  documented opt-in.
+
+## Migration Plan
+
+Back-compatible: a bare character `dists` keeps today's behaviour. Named-list
+`dists` is purely additive. The only re-baseline is `ci = TRUE` CI snapshots
+(re-seeded by the primer change) and printed-scenario snapshots (the print method
+renders the set list). No data migration; results live under the per-layout
+`scenario_results_dir()`, so a changed scenario writes to a fresh layout root.
+
+## Open Questions
+
+- Should a single-element named list (`dists = list(BCANZ = ...)`) still carry a
+  `distset` axis of one (path segment `distset=BCANZ`), or collapse to the
+  anonymous-set path? Leaning toward **keep the named segment** (explicit label is
+  useful in the summary), with the bare-vector form as the only "no distset axis"
+  case.
+- Output column vs path-only: when `distset` is bundled (inner), should the hc
+  Parquet carry an explicit `distset` column (it must, to disambiguate rows within
+  a shard) — confirm the summary schema names it consistently with the path form.

--- a/openspec/changes/distset-hc-axis/proposal.md
+++ b/openspec/changes/distset-hc-axis/proposal.md
@@ -1,0 +1,113 @@
+## Why
+
+A motivating study (the `ssdaveragerr` "iwasaki" analysis) fits one **superset**
+of distributions to each simulated sample, then compares several
+**model-averaging pools** drawn from that single fit — BCANZ, the Iwasaki set,
+and individual distributions — scoring each against the same data. Today a
+scenario's `dists` is a single fit-level setting (one model-averaged
+`ssd_fit_dists()` per task), so reproducing that comparison means running one
+**whole scenario per pool**, re-fitting the data from scratch each time (there is
+no nested-fit reuse — `TARGETS-DESIGN.md` §"No nested reuse"). For 35 datasets ×
+1000 sims × 3 `nrow` that is ~105k fits paid 7× over, when the pools share
+identical per-distribution fits and differ only in the analytical re-averaging.
+
+## What Changes
+
+- **Accept a named list of distribution *sets* for `dists`.** A distribution set
+  is the pool of distributions model-averaged together to form one SSD (one
+  `est`). `dists = list(BCANZ = ssd_dists_bcanz(), Iwasaki = c("burrIII3", ...),
+  lnorm = "lnorm", ...)` declares several pools; a bare character vector keeps
+  today's behaviour (one anonymous pool, no new axis). The set **name** — not its
+  members — is what hashes onto the task path, mirroring the by-name treatment of
+  `min_pmix` and datasets.
+- **Fit the union once.** The fit step fits `sort(unique(unlist(dists)))` (the
+  superset every pool needs) as a single model-averaged fit per fit task;
+  `scenario$fit$dists` becomes that union. The named sets are stored separately
+  (`scenario$hc$distsets`).
+- **Introduce `distset` as an hc-level axis.** Add `"distset"` to
+  `task_axes("hc")` (`R/task-lists.R:369`). The hc step, per task, `subset()`s
+  the parent union fit down to its set's members (`strict = FALSE`) and
+  re-averages — reusing one fit across all pools rather than re-fitting. By
+  default `distset` is an **inner** (bundled) hc axis, so one hc shard decodes the
+  union fit once and serves every pool for that `(dataset, sim)` cell; users may
+  promote it to a path axis via `partition_by`.
+- **Add a `scenario_distset()` accessor** (name → member vector), the twin of
+  `scenario_min_pmix()`, and carry the distsets map on the hc scenario slice.
+- **Subset-then-average in the shared per-task primitive**
+  (`hc_data_task_primer()`, `R/task-lists.R:605`), so the single-core baseline,
+  the single-core shard runner, and the `targets` pipeline stay byte-identical by
+  construction.
+- **Extend `partition_by`/`bundle` vocabulary** so `distset` is an accepted `hc`
+  path/inner axis; the default hc path stays `c("dataset", "sim")` (distset
+  bundled).
+- **Empty-pool contract:** a set whose members all failed to fit yields a
+  zero-length subset; the hc task emits no rows for that `(task, distset)` cell
+  (the consumer's "estimable pools" filter), rather than aborting.
+- **Sweep docs and the decision log.** This **refines** the settled
+  `dists-simulation-setting` decision (`TARGETS-DESIGN.md` §"No nested reuse" /
+  decision log ~L2275): *individual distributions still never fan out* (each axis
+  value is a complete averaging pool, so the model-averaging science the prior
+  decision protected is intact); what changes is that a **named set of pools** is
+  now an hc-level axis over post-fit subsets of one union fit.
+
+Point estimates (`est`) for a pool are **analytical** and identical to fitting
+that pool directly (per-distribution fits are independent within
+`ssd_fit_dists()`); this subset-reuse identity is the correctness oracle. When
+`ci = TRUE`, each pool bootstraps from its own members and the hc primer (which
+hashes the hc-grid row, now including `distset`) re-seeds per pool — desired, and
+a re-baseline of any existing CI snapshots.
+
+## Capabilities
+
+### New Capabilities
+<!-- None: this extends existing capabilities (no new spec file). -->
+
+### Modified Capabilities
+- `scenario-definition`: `dists` accepts a named list of distribution sets;
+  the constructor derives and stores the fit **union** (`scenario$fit$dists`) and
+  the named sets (`scenario$hc$distsets`); validation, role-grouping, and the
+  print method cover the set list.
+- `task-lists`: `task_axes("hc")` gains `"distset"`; the hc task table fans out
+  over the declared sets (their **names** as the axis values), each row carrying
+  its set name and parent `fit_id`; the fit table is unchanged (it fits the
+  union).
+- `hazard-concentrations`: per hc cell, the union fit is subset to the cell's
+  distribution set (`strict = FALSE`) and re-averaged; **at a fixed seed** the
+  result is byte-identical to fitting that set alone and running
+  `ssdtools::ssd_hc()` with the same seed; an empty subset yields no rows.
+- `task-shards`: `partition_by`/`bundle` accept `"distset"` for the `hc` step
+  (default: bundled/inner, path stays `c("dataset", "sim")`); the hc shard runner
+  decodes each parent union fit once and subsets it per `distset` task.
+- `scenario-accessors`: a `scenario_distset()` accessor isolates a set's member
+  vector by name; the hc minimal scenario slice carries the distsets map.
+
+## Impact
+
+- **Specs**: `scenario-definition`, `task-lists`, `hazard-concentrations`,
+  `task-shards`, `scenario-accessors` deltas.
+- **Code**: `R/scenario.R` (`dists` signature/validation/union derivation/storage
+  in `fit`+`hc`, print, `partition_by` vocabulary in `validate_axis_list()`),
+  `R/task-lists.R` (`task_axes("hc")`, hc task-table fan-out, `hc_data_task_primer()`
+  subset), `R/accessors.R` (`scenario_distset()`, hc slice in `scenario_step_slice()`),
+  `R/targets-runner.R` / `R/shard-runner.R` (`ssd_run_hc_step()` reads/decodes
+  parent fit once and subsets per distset task), `R/hc-sims.R`/`R/internal.R` (the
+  in-memory hc path, kept consistent), `NAMESPACE`/`man/` (new export).
+- **Back-compatibility**: a bare character `dists` behaves exactly as today (one
+  anonymous pool, no `distset` axis), so existing scenarios are unaffected.
+- **RNG / re-baseline**: adding `distset` to `task_axes("hc")` makes it part of
+  the hc primer, re-seeding every hc task; `est` is unchanged (analytical),
+  bootstrap CIs change numerically (statistically equivalent). No stored-CI
+  migration is implied.
+- **Correctness gate**: a same-seed subset-reuse invariant test —
+  `hc(subset(union_fit, set))` equals `hc(fit(data, dists = set))` seeded with the
+  same primer — backed by `exploration/distset-subset-invariance.R`. Plus a
+  path-axis-growth test that adding a set mints only new hc shards and leaves all
+  fit shards (and other hc shards) cached.
+- **Cost**: hc task count becomes `fit-tasks × |distsets|`, but each added pool is
+  an analytical re-average of an already-fit superset (`ci = FALSE`) rather than a
+  fresh fit — the iwasaki comparison drops from ~7× fits to one union fit plus
+  cheap per-pool hc. `ssd_estimate_cost()` recalibration is consumed from the
+  task-table counts (no `cost-estimation` spec change).
+- **Out of scope (follow-up):** surfacing `ssd_gof()` diagnostics
+  (`at_bound`/`computable`/`dropped`/top-dist/`delta`) per `(sample × distset)` —
+  a separate, complementary change to the hc/summary output.

--- a/openspec/changes/distset-hc-axis/specs/hazard-concentrations/spec.md
+++ b/openspec/changes/distset-hc-axis/specs/hazard-concentrations/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Per-cell distribution-set subsetting reuses one union fit
+The hc computation for a given cell SHALL, when a scenario declares distribution
+sets, subset its parent **union** fit down to the cell's set members
+(`ssdtools::subset.fitdists(fit, select = members, strict = FALSE)`) and run
+`ssdtools::ssd_hc()` on that subset, rather than re-fitting the set. The subset
+SHALL be performed in the shared per-task primitive (`hc_data_task_primer()`), so
+the single-core baseline runner, the single-core shard runner, and the `targets`
+pipeline produce byte-identical per-task results. **At a fixed cell seed**, a
+pool's hc result SHALL be byte-identical to fitting that pool directly
+(`ssd_fit_dists(data, dists = members)`) and running `ssd_hc()` with the same seed
+and inputs — the per-distribution fits are independent within `ssd_fit_dists()`,
+so re-averaging a subset of the union equals fitting the subset alone. This is a
+same-seed invariant, NOT a claim of equality with the pre-change pipeline:
+`"distset"` joins the hc primer (`task_axes("hc")`), so its presence re-seeds each
+hc task; point estimates (`est`) are analytical and unchanged, bootstrap CIs are
+re-seeded (statistically equivalent). A set whose members all failed to fit
+(an empty subset) SHALL yield zero hc rows for that cell rather than aborting.
+
+#### Scenario: A pool re-averages one union fit, identical to a direct fit
+- **WHEN** a scenario declares `dists = list(BCANZ = ..., Iwasaki = ...)`, the fit step fits the union once, and the hc step computes a cell at a fixed seed for `distset = "Iwasaki"`
+- **THEN** the cell SHALL subset the union fit to the Iwasaki members and run `ssd_hc()` on the subset, producing a result byte-identical to `ssd_hc()` on `ssd_fit_dists(data, dists = <Iwasaki members>)` seeded the same way (no re-fit)
+
+#### Scenario: All three runners agree on the subset-and-average result
+- **WHEN** the same distset scenario is run via the single-core baseline runner, the single-core shard runner, and the `targets` pipeline
+- **THEN** the per-task hc results SHALL be byte-identical across the three runners (the subset is performed in the shared per-task primitive)
+
+#### Scenario: An empty subset yields no rows
+- **WHEN** a cell's distribution set has no members that fitted (the subset is zero-length)
+- **THEN** the hc computation SHALL emit zero rows for that `(cell, distset)` rather than aborting, leaving the survivors of the run intact

--- a/openspec/changes/distset-hc-axis/specs/scenario-accessors/spec.md
+++ b/openspec/changes/distset-hc-axis/specs/scenario-accessors/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Isolate a distribution set by name from a scenario
+The package SHALL provide `scenario_distset(scenario, name)` that returns the
+member character vector of the distribution set stored on the scenario under
+`name` (from `scenario$hc$distsets`), and SHALL abort with an informative error
+when `name` is not one of the scenario's distribution-set names. Like the other
+accessors it SHALL resolve by name without registration, persistence, or
+re-validation — the set members were validated at construction
+(`ssd_define_scenario()`), and the hc runner uses this accessor to resolve a
+task's `distset` name back to the members it subsets the union fit by.
+
+#### Scenario: Returns the member vector for a known set name
+- **WHEN** `scenario_distset(scenario, name)` is called for a `name` in the scenario's distribution-set names
+- **THEN** it SHALL return that set's member character vector
+
+#### Scenario: Unknown distset name errors
+- **WHEN** `scenario_distset(scenario, name)` is called for a `name` not in the scenario's distribution-set names
+- **THEN** it SHALL abort with an informative error naming the unknown set
+
+## MODIFIED Requirements
+
+### Requirement: Isolate a step's minimal scenario slice
+The package SHALL provide an internal `scenario_step_slice(scenario, step, datasets)` that returns the minimal sub-scenario the named step's per-shard runner consumes, keeping the `ssdsims_scenario` class so the existing accessors (`scenario_dataset()`, `scenario_min_pmix()`, `scenario_distset()`) and the runners' `chk_s3_class()` contract work unchanged on the slice. Like the other accessors it SHALL resolve by name/structure without registration, persistence, or re-validation, and it SHALL be a **pure, deterministic** function of its arguments (no environment capture), so the slice is hashable and byte-identical across re-sourcings of the same scenario. The slice SHALL preserve name-only task hashing: it carries the `min_pmix` *functions* (which hash by name, not body) for `fit`, and the **distribution-set member vectors** (which hash by set name) for `hc`, so neither a function-body edit nor a set's membership riding for execution SHALL move a cached shard through the slice. The `datasets` argument SHALL restrict the `sample` slice's carried datasets to the named subset (those a *shard* reads, its `unique(tasks$dataset)`), defaulting to all of the scenario's datasets; it SHALL NOT affect the `fit`/`hc` slices, which carry no datasets.
+
+#### Scenario: Each step's slice carries its runner's inputs
+- **WHEN** `scenario_step_slice(scenario, "sample", datasets)`, `scenario_step_slice(scenario, "fit")`, and `scenario_step_slice(scenario, "hc")` are computed
+- **THEN** the `sample` slice SHALL carry the named `datasets` and `partition_by$sample`; the `fit` slice SHALL carry `fit$dists` (the union), the `min_pmix` functions, and `partition_by` for `sample` and `fit`; and the `hc` slice SHALL carry `hc$proportion`, `hc$samples`, the `hc$distsets` member vectors, and `partition_by` for `fit` and `hc`
+
+#### Scenario: The sample slice carries only the named datasets
+- **WHEN** `scenario_step_slice(scenario, "sample", datasets)` is computed for a subset of the scenario's datasets, and again for a scenario that additionally defines further datasets
+- **THEN** both slices SHALL be byte-identical (carrying only the named `datasets`), so a sample shard's slice is independent of the datasets it does not read
+
+#### Scenario: The slice is deterministic and hashable
+- **WHEN** `scenario_step_slice(scenario, step, datasets)` is computed twice for the same arguments
+- **THEN** the two slices SHALL be byte-identical, so they produce the same dependency hash

--- a/openspec/changes/distset-hc-axis/specs/scenario-definition/spec.md
+++ b/openspec/changes/distset-hc-axis/specs/scenario-definition/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: dists declares one or more distribution sets
+`ssd_define_scenario()` SHALL accept `dists` as either a bare character vector
+(one anonymous **distribution set** — today's behaviour, no new axis) or a
+**named list of character vectors**. A distribution set is the pool of
+distributions model-averaged together to form one SSD (one `est`); each named
+list entry is one such set keyed by a
+unique, non-missing, filesystem-safe name (the name becomes a `distset=` Hive
+path segment). Each set's members SHALL be a non-empty character vector drawn
+from `ssdtools::ssd_dists_all()`, unique and non-missing. The constructor SHALL
+derive the fit **union** `sort(unique(unlist(dists)))` and store it as
+`scenario$fit$dists` (the single model-averaged superset fit every set is a subset
+of), and SHALL store the named sets as `scenario$hc$distsets` for the hc step to
+subset by name. The set **names** — not their members — are what hash onto the
+hc task path (mirroring `min_pmix` and dataset name referencing); the member
+vectors are carried for execution and SHALL NOT enter any task hash.
+
+#### Scenario: Bare character vector is one anonymous set
+- **WHEN** `ssd_define_scenario(..., dists = ssdtools::ssd_dists_bcanz())` is called
+- **THEN** `scenario$fit$dists` SHALL be that vector, `scenario$hc$distsets` SHALL be a single set, and no `distset` cross-join axis SHALL be introduced (one hc pool, today's behaviour)
+
+#### Scenario: Named list declares multiple pools and a fit union
+- **WHEN** `ssd_define_scenario(..., dists = list(BCANZ = ssdtools::ssd_dists_bcanz(), Iwasaki = c("burrIII3", "gamma", "llogis", "lnorm", "weibull"), lnorm = "lnorm"))` is called
+- **THEN** `scenario$fit$dists` SHALL be the sorted union of all three sets' members, and `scenario$hc$distsets` SHALL be the named list of the three sets verbatim
+
+#### Scenario: Set members carried for execution but not hashed
+- **WHEN** a scenario is constructed with a named-list `dists`
+- **THEN** the object SHALL carry each set's member vector keyed by set name for execution, and those member vectors SHALL NOT contribute to any task hash (the hc task path carries the set name only)
+
+#### Scenario: Invalid set membership rejected
+- **WHEN** `dists` is a named list with a set whose member is not in `ssdtools::ssd_dists_all()`, or with a duplicate/missing set name, or an empty set
+- **THEN** the constructor SHALL abort, in the context of the user-facing function, with an informative error naming the offending set
+
+## MODIFIED Requirements
+
+### Requirement: Declarative-only field set
+The `ssdsims_scenario` object SHALL store `seed` (a scalar integer), `nsim`, `nrow`, dataset names, the `fit` and `hc` argument-vector grids, and `partition_by`, and SHALL NOT store materialized task tables or RNG states. It SHALL NOT carry an `upload` field: the upload destination is an execution concern supplied to the runner (`ssd_scenario_targets(..., upload = ...)`), not part of the scenario's declarative identity. For name-referenced parameters it additionally carries the **materialised value needed for execution** — the `min_pmix` functions keyed by name, and the **distribution-set member vectors keyed by set name** — which are used only when running a task and SHALL NOT enter any task hash (task identities use the names, not the values). The `fit` grid's `dists` field SHALL be the **union** of all declared distribution sets (the single model-averaged superset fit), and the `hc` grid SHALL carry the named sets as `hc$distsets`.
+
+#### Scenario: Seed is a scalar integer
+- **WHEN** a scenario is constructed with `seed = 42L`
+- **THEN** the object SHALL store `seed` as a single integer that fully re-roots the scenario's RNG when changed
+
+#### Scenario: partition_by defaults are populated
+- **WHEN** `ssd_define_scenario()` is called without an explicit `partition_by`
+- **THEN** the object SHALL carry the documented per-step defaults (data, fit, hc path axes)
+
+#### Scenario: No upload field on the scenario
+- **WHEN** an `ssdsims_scenario` is constructed
+- **THEN** the object SHALL NOT contain an `upload` field, and `ssd_define_scenario()` SHALL NOT accept an `upload` argument
+
+#### Scenario: min_pmix functions are carried for execution but not hashed
+- **WHEN** a scenario is constructed with a `min_pmix` reference
+- **THEN** the object SHALL carry the resolved `min_pmix` function keyed by name for execution, and that function value SHALL NOT contribute to any task hash
+
+#### Scenario: fit stores the union and hc stores the named sets
+- **WHEN** a scenario is constructed with a named-list `dists`
+- **THEN** `scenario$fit$dists` SHALL be the sorted union of every set's members, and `scenario$hc$distsets` SHALL carry the named sets (their member vectors) for the hc step to subset by name

--- a/openspec/changes/distset-hc-axis/specs/task-lists/spec.md
+++ b/openspec/changes/distset-hc-axis/specs/task-lists/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Derive the hc task table from a scenario
+The package SHALL derive an `hc` task table by crossing each fit-task identity with each row of the scenario's `hc` argument grid (`nboot`, `ci_method`, `parametric`) **and with the scenario's declared distribution sets** (`distset`, the set *names* from `scenario$hc$distsets`). `"distset"` SHALL be a member of `task_axes("hc")` so it enters the per-task primer and the partition/path split. When the scenario declares a single (anonymous) set, the `distset` axis SHALL have one value and SHALL NOT multiply the table. The scenario's scalar `ci` flag SHALL be applied uniformly to every hc row — it is not a cross-join axis and is absent from `task_axes("hc")`. `est_method` SHALL likewise NOT be a cross-join axis: it is an hc simulation setting (a within-task dimension), absent from `task_axes("hc")`, and every requested `est_method` is summarised from the single bootstrap sample set of its hc task rather than fanning out into separate tasks. When `ci = FALSE`, the bootstrap-only knobs (`nboot`, `ci_method`, `parametric`) SHALL be canonically `NA` on every hc row (so they do not enter task identity for a no-bootstrap estimate), leaving the `distset` axis as the only fan-out — one hc row per (fit task × distset); when `ci = TRUE`, the grid SHALL fan out over `distset × nboot × ci_method × parametric`. Each hc task row SHALL carry its `distset` name and its parent `fit_id` (the union fit it subsets).
+
+#### Scenario: hc tasks cross fit identity with the hc grid and the distribution sets
+- **WHEN** the hc task table is derived from a fit task table of `K` rows, an `hc` argument grid of `H` rows (over `nboot × ci_method × parametric`), and `D` declared distribution sets
+- **THEN** the hc task table SHALL have `K * H * D` rows, each carrying its parent fit-task identity columns, the hc-grid argument columns, and its `distset` name, and SHALL NOT be multiplied by the number of `est_method` values
+
+#### Scenario: A single anonymous set does not multiply the table
+- **WHEN** the hc task table is derived from a scenario whose `dists` is a bare character vector (one anonymous set)
+- **THEN** the `distset` axis SHALL have exactly one value and the table SHALL match the pre-change row count (one hc row per fit task when `ci = FALSE`)
+
+#### Scenario: ci = FALSE yields one hc row per fit task per distset
+- **WHEN** the hc task table is derived from a scenario with the scalar `ci = FALSE`, `D` distribution sets, and multiple `est_method` values
+- **THEN** the expansion SHALL produce exactly `D` hc rows per fit task (one per `distset`) with `nboot`/`ci_method`/`parametric` set to `NA`, and SHALL NOT fan out across `est_method`
+
+#### Scenario: ci = TRUE fans out over the distset and bootstrap knobs
+- **WHEN** the hc task table is derived from a scenario with the scalar `ci = TRUE`, `D` distribution sets, and multiple `nboot`/`ci_method`/`parametric` values
+- **THEN** the expansion SHALL fan out over `distset × nboot × ci_method × parametric`, `"distset"` SHALL appear among the per-task identity axes (`task_axes("hc")`), and neither `ci` nor `est_method` SHALL

--- a/openspec/changes/distset-hc-axis/specs/task-shards/spec.md
+++ b/openspec/changes/distset-hc-axis/specs/task-shards/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: distset is a valid hc partition axis, bundled by default
+`"distset"` SHALL be an accepted `hc` axis for both `partition_by` (path) and
+`bundle` (inner), since it is a member of `task_axes("hc")`. The documented
+default hc path SHALL remain `c("dataset", "sim")`, leaving `distset` as an
+**inner** (bundled) hc axis by default: one hc shard then holds every declared
+pool for its `(dataset, sim)` cell, so the shard runner decodes the parent union
+fit once and serves all pools from it. A user MAY promote `distset` to a path
+axis via `partition_by$hc` to obtain one shard per `(…, distset)` cell.
+
+#### Scenario: distset accepted as an hc path axis
+- **WHEN** `ssd_define_scenario(..., dists = list(BCANZ = ..., Iwasaki = ...), partition_by = list(hc = c("dataset", "sim", "distset")))` is called
+- **THEN** the constructor SHALL accept it and the hc shards SHALL be keyed by `dataset`, `sim`, and `distset` (one shard per pool per `(dataset, sim)`)
+
+#### Scenario: distset is bundled by default
+- **WHEN** a distset scenario is constructed without an explicit `hc` `partition_by`
+- **THEN** the hc path SHALL be `c("dataset", "sim")` and `distset` SHALL be an inner axis, so one hc shard carries all declared pools for each `(dataset, sim)` cell
+
+### Requirement: The hc shard runner subsets the union fit per distset, decoding each parent fit once
+The hc shard runner (`ssd_run_hc_step()`) SHALL read each distinct parent `fit`
+shard the shard's tasks reference, decode each union fit **once** per `fit_id`,
+and for each hc task subset that decoded fit to the task's `distset` members
+before estimating the hazard concentration. Multiple `distset` tasks sharing a
+`fit_id` SHALL reuse the one decoded fit (no repeated deserialisation), and each
+output row SHALL be tagged with its `hc_id`, parent `fit_id`, and `distset`.
+
+#### Scenario: One decode per fit serves every pool in the shard
+- **WHEN** an hc shard bundles several `distset` tasks that share a parent `fit_id`
+- **THEN** the runner SHALL decode that union fit once and subset it per `distset`, writing one Parquet for the shard with rows tagged by `hc_id`, `fit_id`, and `distset`
+
+#### Scenario: Adding a distribution set mints only new hc shards
+- **WHEN** a scenario gains an additional distribution set (with `distset` on the hc path) and the pipeline is re-run
+- **THEN** only the new hc shards SHALL be built; every `sample` and `fit` shard, and every pre-existing hc shard, SHALL be served from cache (the fit layer carries no `distset` axis)

--- a/openspec/changes/distset-hc-axis/tasks.md
+++ b/openspec/changes/distset-hc-axis/tasks.md
@@ -1,0 +1,45 @@
+## 1. Exploration / correctness oracle
+
+- [ ] 1.1 Write `exploration/distset-subset-invariance.R`: at a fixed seed, show `ssdtools::ssd_hc(subset(union_fit, set, strict = FALSE))` is byte-identical to `ssd_hc(ssd_fit_dists(data, dists = set))` for both averaged pools (BCANZ, Iwasaki) and single-distribution sets, with `ci = FALSE` and `ci = TRUE`. This is the premise of the whole change; capture it before coding.
+
+## 2. Scenario constructor: dists as distribution sets
+
+- [ ] 2.1 In `R/scenario.R`, accept `dists` as either a bare character vector (one anonymous set — unchanged) or a named list of character vectors. Validate: unique non-missing filesystem-safe set names; each set a non-empty, unique, non-`NA` character vector ⊆ `ssdtools::ssd_dists_all()`. Abort in the user-facing function's context with the offending set named.
+- [ ] 2.2 Derive the fit union `sort(unique(unlist(dists)))` and store it as `scenario$fit$dists`; store the named sets as `scenario$hc$distsets` (member vectors keyed by set name). The bare-vector form stores the vector as `fit$dists` and a single anonymous set in `hc$distsets`.
+- [ ] 2.3 Keep `dists` in the simulation-settings block of the signature (it remains a fit-level setting feeding the union); update its `@param`/roxygen to describe the named-set form and the union/by-name semantics.
+- [ ] 2.4 Render the distribution sets in `print.ssdsims_scenario()` via `fmt_grid_value()` (set names + members, no large dumps).
+
+## 3. Axis vocabulary and hc task table
+
+- [ ] 3.1 Add `"distset"` to `task_axes("hc")` in `R/task-lists.R` (hc axes become `nboot`, `ci_method`, `parametric`, `distset`).
+- [ ] 3.2 Derive the hc task table by crossing each fit-task identity with the hc grid **and** the `distset` names: `ci = FALSE` → `D` rows per fit task (one per set, bootstrap knobs `NA`); `ci = TRUE` → `distset × nboot × ci_method × parametric`. Each hc row carries its `distset` name and parent `fit_id`. A single anonymous set yields one `distset` value (row count unchanged from pre-change).
+- [ ] 3.3 Confirm `partition_by`/`bundle` validation accepts `"distset"` for the `hc` step (falls out of `task_axes("hc")`); keep the default hc path `c("dataset", "sim")` so `distset` is inner by default.
+
+## 4. Accessor and scenario slice
+
+- [ ] 4.1 Add `scenario_distset(scenario, name)` in `R/accessors.R` returning the set's member vector from `scenario$hc$distsets`, aborting on an unknown name; export it (`@export`) and `devtools::document()`.
+- [ ] 4.2 Extend the `hc` branch of `scenario_step_slice()` (`R/targets-runner.R`) to carry `hc$distsets` (so the hc runner can resolve `distset` → members), keeping the slice a pure/deterministic function and the `ssdsims_scenario` class.
+
+## 5. hc execution: subset the union fit per distset
+
+- [ ] 5.1 In `hc_data_task_primer()` (`R/task-lists.R:605`), accept the set members and `subset(fits, select = members, strict = FALSE)` before `ssd_hc()`; an empty subset returns zero rows (no abort). This single chokepoint keeps all three runners byte-identical.
+- [ ] 5.2 In `ssd_run_hc_step()` (`R/targets-runner.R`) — and the single-core `R/shard-runner.R` path — decode each parent union fit **once** per `fit_id`, resolve each hc task's `distset` to members via `scenario_distset()`, subset, and tag each output row with `hc_id`, `fit_id`, and `distset`. Reuse the one decoded fit across all `distset` tasks sharing the `fit_id`.
+- [ ] 5.3 Keep the in-memory `ssd_hc_sims()` path (`R/hc-sims.R`/`R/internal.R`) consistent with the subset-then-average contract (and the baseline runner `ssd_run_scenario_baseline()`), so baseline == shards == targets.
+- [ ] 5.4 Ensure the hc Parquet/summary carries an explicit `distset` column (it disambiguates rows within a bundled shard) consistent with the `distset=` path form.
+
+## 6. Tests
+
+- [ ] 6.1 Same-seed subset-reuse invariant unit test (per §1.1): collapsed pool result equals direct-fit-then-hc at the same primer, across averaged and single-dist sets and both `ci` values. NOT an old-vs-new pipeline equality.
+- [ ] 6.2 Byte-identity test: baseline runner, single-core shard runner, and `targets` pipeline agree per task for a multi-set scenario.
+- [ ] 6.3 Path-axis-growth test: adding a distribution set (with `distset` on the hc path) mints only new hc shards and caches all sample/fit shards and pre-existing hc shards.
+- [ ] 6.4 Task-table tests: `D` sets multiply hc rows by `D` (not by `est_method`); a bare-vector `dists` leaves the row count unchanged.
+- [ ] 6.5 Empty-subset test: a set whose members all dropped yields zero hc rows, and `ssd_summarise()` unions the survivors.
+
+## 7. Docs, snapshots, decision log
+
+- [ ] 7.1 Update `TARGETS-DESIGN.md`: the `dists-simulation-setting` decision log entry and the §"No nested reuse" note get an addendum — *individual distributions still never fan out*; a named set of pools is an hc-level axis over post-fit subsets of one union fit (reuse now holds within one union).
+- [ ] 7.2 Update `GLOSSARY.md` (define "distribution set" / `distset` axis) and `task_axes("hc")` references that list the hc axes.
+- [ ] 7.3 Update the `defining-a-scenario` and `sharded-pipeline` vignettes with a multi-set example (and the bundled-vs-path `distset` trade-off); add a worked iwasaki-style snippet.
+- [ ] 7.4 Re-record affected snapshots (printed scenarios; hc task-count assertions; `ci = TRUE` CI snapshots re-seeded by the primer change).
+- [ ] 7.5 Run `air format .`, `devtools::document()`, `devtools::test()`, `devtools::check()`; verify a multi-set `ci = FALSE` scenario fits the union once and re-averages per pool (one fit, cheap per-pool hc).
+- [ ] 7.6 Move the ROADMAP item for distribution sets to Done with the archive link on completion.


### PR DESCRIPTION
## Summary

This PR proposes a new `distset` (distribution set) axis for the hc step, enabling efficient reuse of a single union fit across multiple model-averaging pools. This addresses the motivating "iwasaki" study use case, which fits a superset of distributions once and compares several analytical pools (BCANZ, Iwasaki set, single distributions) carved from that fit, rather than re-fitting from scratch for each pool (~7× cost reduction).

## What Changes

**Scenario definition:**
- `dists` now accepts either a bare character vector (one anonymous pool, today's behaviour) or a **named list of character vectors** (multiple pools)
- The constructor derives the fit **union** `sort(unique(unlist(dists)))` and stores it as `scenario$fit$dists`
- Named sets are stored as `scenario$hc$distsets` for the hc step to subset by name
- Set **names** (not members) hash onto the task path, mirroring `min_pmix` and dataset referencing

**Task structure:**
- `"distset"` becomes a member of `task_axes("hc")`, introducing a new hc-level axis
- The hc task table crosses fit identity with the hc grid **and** the declared distribution sets
- By default `distset` is an **inner** (bundled) hc axis, so one hc shard decodes the union fit once and serves all pools for a `(dataset, sim)` cell
- Users may promote `distset` to a path axis via `partition_by$hc` for per-pool shards

**Execution:**
- The fit step fits the union once as a single model-averaged fit per fit task
- The hc step subsets the parent union fit to each pool's members (`strict = FALSE`) and re-averages in the shared per-task primitive (`hc_data_task_primer()`)
- All three runners (baseline, single-core shard, `targets` pipeline) remain byte-identical by construction
- An empty subset (all members failed to fit) yields zero hc rows rather than aborting

**Accessors:**
- New `scenario_distset(scenario, name)` returns a set's member vector by name
- `scenario_step_slice()` extended to carry `hc$distsets` for the hc runner

## Correctness & Compatibility

- **Same-seed invariant:** at a fixed seed, `ssd_hc(subset(union_fit, set))` is byte-identical to `ssd_hc(ssd_fit_dists(data, dists = set))` — the premise of the whole change, proven in `exploration/distset-subset-invariance.R`
- **Back-compatible:** a bare character `dists` behaves exactly as today (one anonymous pool, no new axis)
- **Re-baseline:** adding `distset` to `task_axes("hc")` re-seeds every hc task; `est` is analytical/unchanged, bootstrap CIs change numerically (statistically equivalent)

## Deliverables

This PR adds:
- **Design document** (`design.md`): context, goals, decisions, risks, migration plan, open questions
- **Proposal** (`proposal.md`): why, what changes, capabilities, impact, cost analysis
- **Specifications** (5 files):
  - `scenario-definition`: dists as named-list distribution sets, union derivation, storage
  - `task-lists`: distset as hc axis, task-table fan-out
  - `hazard-concentrations`: subset-then-average contract, same-seed invariant, empty-subset handling
  - `task-shards`: distset as valid hc partition axis (bundled by default), shard runner reuse
  - `scenario-accessors`: `scenario_distset()` accessor, `scenario_step_slice()` extension
- **Tasks** (`tasks.md`): 6 sections covering exploration, implementation, testing, and documentation

## Impact

- **Specs affected:** scenario-definition, task-lists, hazard-concentrations, task-shards, scenario-accessors
- **Code modules:** R/scenario.R, R/task-lists.R,

https://claude.ai/code/session_01U2GNAmGSmeFacu4CEkJV3B