### PR TITLE
docs(openspec): require ssd_pmix() for min_pmix, dropping string forms

### DIFF
--- a/openspec/changes/pmix-constructor/design.md
+++ b/openspec/changes/pmix-constructor/design.md
@@ -39,13 +39,21 @@ makes `ssd_pmix(f)` / `ssd_pmix(pkg::g)` robust where `min_pmix = list(f)` is no
 (e.g. fall back to value-based names). Rejected: it preserves two code paths and
 the indirect-value trap; the constructor is the single, teachable surface.
 
-### 2. Loud failure over silent fallback (BREAKING)
-The retired forms (`min_pmix` as a function or a list) abort in the user-facing
-call's context with an actionable message. This is the "old interface fails
-loudly" requirement: a pre-release tightening preferred over silently accepting an
-ambiguous input. `min_pmix` as a **character vector of names** stays valid (it is
-already explicit and value-based), so the simplest call
-(`min_pmix = "ssd_min_pmix"`, the new default) needs no constructor.
+### 2. `ssd_pmix()` only — no string magic, loud failure for everything else (BREAKING)
+`min_pmix` accepts **only** an `ssd_pmix()` collection. Every other form — a bare
+function, a (named or unnamed) plain list, **and a character vector of names** —
+aborts in the user-facing call's context with an actionable message. We
+deliberately do **not** keep a character-vector path: a name-string would have to
+be resolved to a function by lookup (in `ssdtools` or the caller's environment),
+which is exactly the "string magic" we are removing — implicit, environment-
+sensitive, and a second code path. Functions are passed directly through
+`ssd_pmix()`; to use the package default, pass the function
+(`ssd_pmix(ssd_min_pmix = ssdtools::ssd_min_pmix)`), which is also the default
+value of the argument.
+
+*Alternative considered:* accept a character vector of names as a terse shortcut
+(the prior draft). Rejected per the above — it reintroduces string→function
+resolution and a divergent input path.
 
 ### 3. `ssd_pmix()`, not `ssd_min_pmix()` — avoid the dependency clash
 `ssdtools::ssd_min_pmix` is the function users pass *into* the collection. An
@@ -58,12 +66,13 @@ constructor is `ssd_pmix()`.
 *Alternative considered:* `ssd_min_pmix_set()` / `ssd_min_pmixes()` — wordier and
 no clearer; `ssd_pmix()` reads as "a collection of min_pmix functions".
 
-### 4. Default `min_pmix = "ssd_min_pmix"` (a character name)
+### 4. Default `min_pmix = ssd_pmix(ssd_min_pmix = ssdtools::ssd_min_pmix)`
 The current default `list(ssdtools::ssd_min_pmix)` is the worst offender: an
 *unnamed* list whose name is recovered only by capturing the **default
-expression**. Switching the default to the character name `"ssd_min_pmix"`
-(resolved from `ssdtools` at construction) removes that capture entirely and is
-the minimal explicit form.
+expression**. The new default is an `ssd_pmix()` call evaluated at construction —
+an `ssdsims_pmix` **value**, named explicitly (`ssd_min_pmix =`) so no symbol
+capture, string resolution, or default-expression parsing is involved. It flows
+through the same single `ssd_pmix()`-only path as a user-supplied collection.
 
 ### 5. Independent of `distset-hc-axis`
 This change touches only `min_pmix`; `distset-hc-axis` touches only
@@ -74,11 +83,11 @@ typed-constructor philosophy and the `ssd_scenario_data()` precedent.
 
 ## Risks / Trade-offs
 
-- **Breaking existing call sites** → every `min_pmix` function/list call site in
-  examples, tests, snapshots, `scripts/`, `vignettes/`, and
+- **Breaking existing call sites** → every `min_pmix` function/list/character call
+  site in examples, tests, snapshots, `scripts/`, `vignettes/`, and
   `inst/targets-templates/` must migrate. Mitigation: pre-release; the migration
-  is mechanical (most become the terse `"ssd_min_pmix"` default), and the error
-  message names the replacement.
+  is mechanical (most just drop the argument and take the default, or wrap in
+  `ssd_pmix(...)`), and the error message names the replacement.
 - **Two pending changes touch `scenario-definition`** → `distset-hc-axis` and this
   one. Mitigation: their delta requirements are disjoint (`dists` vs `min_pmix`),
   so they compose without ordering.
@@ -86,9 +95,10 @@ typed-constructor philosophy and the `ssd_scenario_data()` precedent.
 ## Migration Plan
 
 Pre-release, no data migration (stored shape and hashes unchanged). Mechanical
-call-site sweep: `min_pmix = ssdtools::ssd_min_pmix` → `"ssd_min_pmix"` (or
-`ssd_pmix(...)`). Roll back by reverting the constructor commits; no persisted
-artefacts depend on the input surface.
+call-site sweep: `min_pmix = ssdtools::ssd_min_pmix` →
+`ssd_pmix(ssd_min_pmix = ssdtools::ssd_min_pmix)`, or drop the argument to take
+the (equivalent) default. Roll back by reverting the constructor commits; no
+persisted artefacts depend on the input surface.
 
 ## Open Questions
 

--- a/openspec/changes/pmix-constructor/proposal.md
+++ b/openspec/changes/pmix-constructor/proposal.md
@@ -16,36 +16,38 @@ ssd_define_scenario(..., min_pmix = list(f))  # name becomes "f", the local var
 ```
 
 We should adopt the **typed-collection constructor** pattern `ssd_scenario_data()` already
-establishes for datasets: a dedicated constructor owns naming, validation, and
-resolution **by value**, the scenario accepts only that typed collection (or an
-explicit character vector of names), and the loose/legacy forms **fail loudly**
-with a message pointing at the constructor — no silent magic, no indirect-value
-trap.
+establishes for datasets: a dedicated constructor owns naming and validation
+**by value**, the scenario accepts **only** that typed collection, and every
+other form **fails loudly** with a message pointing at the constructor — no
+string magic, no silent fallback, no indirect-value trap.
 
 ## What Changes
 
 - **BREAKING — add `ssd_pmix()`**, returning a validated `ssdsims_pmix`
-  collection of single-argument functions keyed by name: `ssd_pmix(ssd_min_pmix =
+  collection of single-argument **functions** keyed by name: `ssd_pmix(ssd_min_pmix =
   ssdtools::ssd_min_pmix, strict = my_pmix)`. It owns naming (from `...` names, or
   per-argument symbol capture for a bare `symbol`/`pkg::name`, exactly as
   `ssd_scenario_data()` does — **scoped to the constructor**, not a generic argument) and
-  validation (each a single-argument function, or a name-string resolved to one).
-- **`ssd_define_scenario(min_pmix = ...)` accepts an `ssd_pmix()` collection or a
-  character vector of names** (already explicit and value-based — kept). The
-  expression-inferred *function* and *list* forms SHALL abort with an error naming
-  `ssd_pmix()`.
+  validation (each entry is a single-argument function — **functions only, never a
+  name-string**, so the constructor performs no string→function resolution).
+- **`ssd_define_scenario(min_pmix = ...)` accepts ONLY an `ssd_pmix()` collection.**
+  Every other form — a bare function, a (named or unnamed) plain list, or a
+  character vector of names — SHALL abort with an error naming `ssd_pmix()`. There
+  is no string path: resolving a name-string to a function would be the very
+  "string magic" this change removes.
 - **Remove the expression-based name inference** for `min_pmix`:
   `min_pmix_expr <- rlang::enexpr(min_pmix)` and the `min_pmix` branches of
   `scenario_min_pmix_materialise()` are retired in favour of the constructor's
   value-based naming. `expr_to_name()`/`list_expr_names()` remain only where
   datasets still use bare-data-frame symbol capture.
-- **Change the `min_pmix` default** to the explicit `"ssd_min_pmix"` (a character
-  name, resolved from `ssdtools` at construction), so the default no longer relies
-  on capturing an unnamed-`list()` default expression.
-- **Loud-error contract:** the retired `min_pmix` forms abort in the user-facing
-  function's context with an actionable message ("supply an `ssd_pmix()`
-  collection or a character vector of names"), not a silent fallback or an obscure
-  `purrr`/`rlang` frame.
+- **Change the `min_pmix` default** to an `ssd_pmix()` collection,
+  `ssd_pmix(ssd_min_pmix = ssdtools::ssd_min_pmix)`, built at call time — a
+  **value** (an `ssdsims_pmix` object), not a string and not a captured
+  unnamed-`list()` expression.
+- **Loud-error contract:** every non-`ssd_pmix()` `min_pmix` aborts in the
+  user-facing function's context with an actionable message ("supply an
+  `ssd_pmix()` collection"), not a silent fallback or an obscure `purrr`/`rlang`
+  frame.
 
 The stored scenario shape is unchanged (names + materialised functions keyed by
 name); only the *input surface* and *where naming happens* change. Task hashing
@@ -77,25 +79,27 @@ design Decision 3.
 ### Modified Capabilities
 - `scenario-definition`: add `ssd_pmix()` as the validated, by-value collection
   constructor for the `min_pmix` input; the constructor owns naming/validation.
-  `ssd_define_scenario()` requires an `ssd_pmix()` collection or a character vector
-  of names for `min_pmix`; the expression-inferred function/list forms abort
-  loudly. The `min_pmix` default becomes `"ssd_min_pmix"`.
+  `ssd_define_scenario()` requires **only** an `ssd_pmix()` collection for
+  `min_pmix`; every other form (bare function, list, or character vector) aborts
+  loudly. The `min_pmix` default becomes
+  `ssd_pmix(ssd_min_pmix = ssdtools::ssd_min_pmix)`.
 
 ## Impact
 
 - **Specs**: `scenario-definition` delta (`ssd_pmix()` + tightened `min_pmix`
   acceptance + loud errors).
 - **Code**: `R/scenario.R` (drop `enexpr(min_pmix)` and the `min_pmix`
-  expression-inference branches; require the collection/character form; loud-error
+  expression-inference branches; require the `ssd_pmix()` collection; loud-error
   messages; default change), new `R/pmix.R` (constructor, validator, print
   method), `R/accessors.R` (`scenario_min_pmix()` reads the collection unchanged),
   `NAMESPACE`/`man/` (one new export).
 - **BREAKING**: pre-release API tightening. Existing call sites passing a
-  `min_pmix` function or list must migrate to `ssd_pmix()` (or a character vector
-  of names). Sweep examples, tests, snapshots, `scripts/`, `vignettes/`,
+  `min_pmix` function, list, or character vector must migrate to `ssd_pmix()`.
+  Sweep examples, tests, snapshots, `scripts/`, `vignettes/`,
   `inst/targets-templates/`.
 - **No RNG / results impact**: stored names and materialised functions are
   unchanged, so task hashes, per-task results, and caching are identical; this is
   an input-surface change only.
-- **Migration**: `min_pmix = ssdtools::ssd_min_pmix` → `min_pmix = "ssd_min_pmix"`
-  (default) or `min_pmix = ssd_pmix(ssd_min_pmix = ssdtools::ssd_min_pmix)`.
+- **Migration**: `min_pmix = ssdtools::ssd_min_pmix` →
+  `min_pmix = ssd_pmix(ssd_min_pmix = ssdtools::ssd_min_pmix)` (also the new
+  default).

--- a/openspec/changes/pmix-constructor/specs/scenario-definition/spec.md
+++ b/openspec/changes/pmix-constructor/specs/scenario-definition/spec.md
@@ -4,13 +4,13 @@
 The package SHALL expose `ssd_pmix(...)` as the single entry point that assembles
 one or more `min_pmix` functions into a validated, named collection — an
 `ssdsims_pmix` object keyed by name. Each entry SHALL be a single-argument
-function (inputs a row count, returns a proportion in `[0, 0.5]`) or a
-name-string resolved to one at construction (from `ssdtools` or the caller's
-environment). Names SHALL be taken from the `...` argument names where supplied,
-otherwise derived per argument by symbol capture for a bare `symbol` or
-`pkg::name` (scoped to this constructor, mirroring `ssd_scenario_data()`), and SHALL be
-unique. `ssd_define_scenario(min_pmix = ...)` SHALL accept an `ssd_pmix()`
-collection or a character vector of names.
+function (inputs a row count, returns a proportion in `[0, 0.5]`) — **functions
+only; a name-string SHALL NOT be accepted**, so the constructor performs no
+string→function resolution. Names SHALL be taken from the `...` argument names
+where supplied, otherwise derived per argument by symbol capture for a bare
+`symbol` or `pkg::name` (scoped to this constructor, mirroring
+`ssd_scenario_data()`), and SHALL be unique. `ssd_define_scenario(min_pmix = ...)`
+SHALL accept **only** an `ssd_pmix()` collection.
 
 #### Scenario: Functions assembled and named
 - **WHEN** `ssd_pmix(ssd_min_pmix = ssdtools::ssd_min_pmix, strict = my_pmix)` is called
@@ -18,45 +18,45 @@ collection or a character vector of names.
 
 #### Scenario: Name derived per argument for a bare reference
 - **WHEN** `ssd_pmix(ssdtools::ssd_min_pmix)` is called (unnamed)
-- **THEN** it SHALL derive the name `"ssd_min_pmix"` by per-argument symbol capture and validate the resolved single-argument function
+- **THEN** it SHALL derive the name `"ssd_min_pmix"` by per-argument symbol capture and validate that the supplied value is a single-argument function
 
 #### Scenario: Non-function or wrong-arity entry rejected
-- **WHEN** `ssd_pmix()` is given an entry that is not a function, a multi-argument function, or an unresolvable name
-- **THEN** it SHALL abort with an informative error naming the offending entry
+- **WHEN** `ssd_pmix()` is given an entry that is not a function, or is a multi-argument function, or a name-string
+- **THEN** it SHALL abort with an informative error naming the offending entry (no string→function resolution is attempted)
 
 ### Requirement: Legacy min_pmix input forms fail loudly
 `ssd_define_scenario()` SHALL reject the pre-constructor input forms for
 `min_pmix` with an actionable error raised in the user-facing function's context
 (not a silent fallback or an internal `rlang`/`purrr` frame). A `min_pmix`
-supplied as a bare function or as a (named or unnamed) plain list SHALL abort with
-a message naming `ssd_pmix()` (or a character vector of names). No input form
+supplied as a bare function, a (named or unnamed) plain list, or a character
+vector of names SHALL abort with a message naming `ssd_pmix()`. No input form
 SHALL rely on capturing or parsing the unevaluated argument expression of
-`min_pmix`.
+`min_pmix`, and no name-string SHALL be resolved to a function.
 
 #### Scenario: min_pmix function/list forms abort
 - **WHEN** `ssd_define_scenario(..., min_pmix = ssdtools::ssd_min_pmix)` or `min_pmix = list(ssdtools::ssd_min_pmix)` is called
-- **THEN** the constructor SHALL abort with an informative error instructing the caller to use `ssd_pmix()` or a character vector of names
+- **THEN** the constructor SHALL abort with an informative error instructing the caller to use `ssd_pmix()`
+
+#### Scenario: A character vector of names aborts
+- **WHEN** `ssd_define_scenario(..., min_pmix = "ssd_min_pmix")` (or `c("default", "strict")`) is called
+- **THEN** the constructor SHALL abort with an informative error instructing the caller to use `ssd_pmix()`, resolving no name-string to a function
 
 #### Scenario: Indirectly supplied value aborts cleanly
 - **WHEN** `fns <- list(ssdtools::ssd_min_pmix); ssd_define_scenario(..., min_pmix = fns)` is called (the form the expression-inference path mishandled)
 - **THEN** the constructor SHALL abort with the same actionable error naming `ssd_pmix()`, not an obscure internal frame
 
 #### Scenario: Naming never reads the argument expression
-- **WHEN** `min_pmix` is supplied through an `ssd_pmix()` collection or a character vector
-- **THEN** naming SHALL be determined entirely by value (collection names / character values), and `ssd_define_scenario()` SHALL NOT capture the unevaluated `min_pmix` argument expression
+- **WHEN** `min_pmix` is supplied through an `ssd_pmix()` collection
+- **THEN** naming SHALL be determined entirely by the collection's names, and `ssd_define_scenario()` SHALL NOT capture the unevaluated `min_pmix` argument expression
 
 ## MODIFIED Requirements
 
 ### Requirement: min_pmix referenced by name
-`ssd_define_scenario()` SHALL store `min_pmix` in the `fit` grid as one or more names (a character vector) — used for hashing and the task path — and SHALL additionally materialise the resolved single-argument **functions**, keyed by name, on the scenario for execution. The input SHALL be either an `ssd_pmix()` collection (which already carries validated functions keyed by name) or a character vector of names; a name-string SHALL be resolved to a function at construction (from `ssdtools` or the caller's environment), failing fast if it cannot be resolved to a single-argument function. The default SHALL be the character name `"ssd_min_pmix"` (resolved from `ssdtools`), so no unnamed-`list()` default expression is captured. Naming SHALL be value-based: `ssd_define_scenario()` SHALL NOT capture or parse the unevaluated `min_pmix` argument expression. The stored names — and therefore task hashes — SHALL be unchanged by the materialisation, and the function values SHALL NOT be hashed. Resolution of a name back to a function is the scenario accessor `scenario_min_pmix()`, not a separate registry.
+`ssd_define_scenario()` SHALL store `min_pmix` in the `fit` grid as one or more names (a character vector) — used for hashing and the task path — and SHALL additionally materialise the single-argument **functions**, keyed by name, on the scenario for execution. The input SHALL be an `ssd_pmix()` collection (which already carries validated functions keyed by name); no other form is accepted. The default SHALL be `ssd_pmix(ssd_min_pmix = ssdtools::ssd_min_pmix)` — an `ssdsims_pmix` value built at construction, not a string and not a captured unnamed-`list()` expression. Naming SHALL be value-based: `ssd_define_scenario()` SHALL NOT capture or parse the unevaluated `min_pmix` argument expression, and SHALL NOT resolve any name-string to a function. The names taken from the collection — and therefore task hashes — SHALL be unchanged versus supplying the same functions under those names the old way, and the function values SHALL NOT be hashed. Resolution of a name back to a function is the scenario accessor `scenario_min_pmix()`, not a separate registry.
 
-#### Scenario: Default min_pmix is the resolved name
-- **WHEN** `ssd_define_scenario()` is called without `min_pmix` (the default `"ssd_min_pmix"`)
-- **THEN** the object's `fit$min_pmix` SHALL be `"ssd_min_pmix"`, and the function resolved from `ssdtools` SHALL be materialised on the scenario keyed by that name
-
-#### Scenario: min_pmix names accepted directly and resolved
-- **WHEN** `ssd_define_scenario(..., min_pmix = c("default", "strict"))` is called
-- **THEN** the object SHALL store those names verbatim as `fit$min_pmix` and SHALL materialise the function each name resolves to, keyed by name
+#### Scenario: Default min_pmix is the ssd_pmix() collection
+- **WHEN** `ssd_define_scenario()` is called without `min_pmix` (the default `ssd_pmix(ssd_min_pmix = ssdtools::ssd_min_pmix)`)
+- **THEN** the object's `fit$min_pmix` SHALL be `"ssd_min_pmix"` (the collection's name), and the collection's function SHALL be materialised on the scenario keyed by that name
 
 #### Scenario: ssd_pmix() collection accepted and stored by name
 - **WHEN** `ssd_define_scenario(..., min_pmix = ssd_pmix(ssd_min_pmix = ssdtools::ssd_min_pmix, strict = my_pmix))` is called

--- a/openspec/changes/pmix-constructor/tasks.md
+++ b/openspec/changes/pmix-constructor/tasks.md
@@ -1,26 +1,26 @@
 ## 1. `ssd_pmix()` constructor
 
-- [ ] 1.1 Add `R/pmix.R`: `ssd_pmix(...)` returning an `ssdsims_pmix` collection (named list of single-argument functions). Names from `...` names, else per-argument symbol capture for a bare `symbol`/`pkg::name` (mirroring `ssd_scenario_data()`; capture each `...` promise individually). Resolve name-string entries to functions (from `ssdtools` or the caller env). Validate: each a single-argument function, names unique/non-missing. Abort in the constructor's context on a non-function, wrong arity, unresolvable name, or duplicate name.
+- [ ] 1.1 Add `R/pmix.R`: `ssd_pmix(...)` returning an `ssdsims_pmix` collection (named list of single-argument **functions only** — no name-string entries, no string→function resolution). Names from `...` names, else per-argument symbol capture for a bare `symbol`/`pkg::name` (mirroring `ssd_scenario_data()`; capture each `...` promise individually). Validate: each a single-argument function, names unique/non-missing. Abort in the constructor's context on a non-function, wrong arity, a name-string, or a duplicate name.
 - [ ] 1.2 Add a `print.ssdsims_pmix()` method (names + `<fn>` placeholders, snapshot-stable).
 - [ ] 1.3 Export `ssd_pmix`; `devtools::document()`.
 
 ## 2. Scenario constructor: require the typed collection, by value
 
-- [ ] 2.1 In `R/scenario.R`, change `min_pmix` to accept an `ssd_pmix()` collection **or** a character vector of names. Default to the character `"ssd_min_pmix"`. A bare function or plain list SHALL abort with a message naming `ssd_pmix()` (or a character vector of names).
+- [ ] 2.1 In `R/scenario.R`, change `min_pmix` to accept **only** an `ssd_pmix()` collection. Default to `ssd_pmix(ssd_min_pmix = ssdtools::ssd_min_pmix)`. A bare function, plain list, or character vector SHALL abort with a message naming `ssd_pmix()`.
 - [ ] 2.2 Remove `min_pmix_expr <- rlang::enexpr(min_pmix)` and the `min_pmix` branches of `scenario_min_pmix_materialise()`; materialise functions/names directly from the collection or character vector (value-based, no expression parsing).
 - [ ] 2.3 Retire `list_expr_names()`/`expr_to_name()` usage for `min_pmix`; keep them only where datasets still use bare-data-frame symbol capture (or remove if no longer referenced).
 - [ ] 2.4 Confirm the stored scenario shape (`fit$min_pmix` names, materialised `min_pmix_fns`) and therefore task hashes are unchanged versus supplying the same names/functions the old way.
 
 ## 3. Tests
 
-- [ ] 3.1 `ssd_pmix()` tests: names from `...` names; derived name for a bare `pkg::name`; name-string resolution; rejects non-function/wrong-arity/unresolvable/duplicate.
-- [ ] 3.2 Loud-error tests: `min_pmix` as a function and as a list both abort with a message naming `ssd_pmix()`; the indirect-value case (`fns <- list(...); min_pmix = fns`) that the old path mishandled now aborts cleanly with the same actionable message.
-- [ ] 3.3 Hash-stability test: a scenario built via `ssd_pmix()` (or the `"ssd_min_pmix"` default) produces the same `fit$min_pmix` names, materialised functions, and per-task primers/hashes as the equivalent names/functions supplied to the prior interface (no results/caching drift).
+- [ ] 3.1 `ssd_pmix()` tests: names from `...` names; derived name for a bare `pkg::name`; rejects a non-function, a multi-argument function, a name-string (no resolution attempted), and duplicate names.
+- [ ] 3.2 Loud-error tests: `min_pmix` as a function, a list, and a character vector each abort with a message naming `ssd_pmix()`; the indirect-value case (`fns <- list(...); min_pmix = fns`) that the old path mishandled now aborts cleanly with the same actionable message.
+- [ ] 3.3 Hash-stability test: a scenario built via `ssd_pmix()` (or the default `ssd_pmix(ssd_min_pmix = ssdtools::ssd_min_pmix)`) produces the same `fit$min_pmix` names, materialised functions, and per-task primers/hashes as the equivalent names/functions supplied to the prior interface (no results/caching drift).
 - [ ] 3.4 No-`enexpr` test: `min_pmix` naming is unaffected by how the argument is constructed (literal vs variable vs programmatic), since the expression is never read.
 
 ## 4. Call sites, docs, snapshots
 
-- [ ] 4.1 Sweep all `min_pmix` call sites — `@examples`, `tests/`, `scripts/`, `vignettes/`, `inst/targets-templates/`, `man/` — to the `"ssd_min_pmix"` default or `ssd_pmix(...)`.
+- [ ] 4.1 Sweep all `min_pmix` call sites — `@examples`, `tests/`, `scripts/`, `vignettes/`, `inst/targets-templates/`, `man/` — to `ssd_pmix(...)` or the default (drop the argument).
 - [ ] 4.2 Update roxygen `@param min_pmix`, the `defining-a-scenario` vignette, `GLOSSARY.md`, and `TARGETS-DESIGN.md` references to the `min_pmix` input; document the `ssd_min_pmix()`-clash rationale for `ssd_pmix()`.
 - [ ] 4.3 Re-record printed-scenario / printed-collection snapshots.
 - [ ] 4.4 Run `air format .`, `devtools::document()`, `devtools::test()`, `devtools::check()`.


### PR DESCRIPTION
## Summary

Refines the `pmix-constructor` OpenSpec proposal (already on `main` from #167) so the `min_pmix` input accepts **only** an `ssd_pmix()` collection — no string magic.

## What changed in the proposal

- **`min_pmix` accepts only an `ssd_pmix()` collection.** The character-vector-of-names path is removed; a bare function, a plain list, or a character vector each **fails loudly** with a message naming `ssd_pmix()`.
- **No string→function resolution anywhere.** `ssd_pmix()` accepts **functions only** — a name-string entry is rejected (no lookup in `ssdtools`/the caller env). Names still come from `...` names or per-argument symbol capture (the `ssd_scenario_data()` precedent), which is value-based, not string magic.
- **Default becomes a value, not a string:** `min_pmix = ssd_pmix(ssd_min_pmix = ssdtools::ssd_min_pmix)` — an `ssdsims_pmix` object built at call time, so the default carries neither a captured `list()` expression nor a resolvable string.

Updated across `proposal.md`, `design.md` (Decisions 2 & 4), the `scenario-definition` spec delta (the `ssd_pmix()` requirement, the loud-error requirement now lists character vectors, and the MODIFIED `min_pmix referenced by name`), and `tasks.md`. `openspec validate --strict` passes.

## Rationale

A name-string would have to be resolved to a function by environment/`ssdtools` lookup — implicit, environment-sensitive, and a second input path. Passing functions directly through one typed constructor keeps naming by-value and the input surface single. No RNG/results impact: stored names and materialised functions are unchanged, so task hashes and caching are identical.

Proposal only — no `R/` implementation yet; run `/opsx:apply pmix-constructor` when ready.

https://claude.ai/code/session_01U2GNAmGSmeFacu4CEkJV3B

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2GNAmGSmeFacu4CEkJV3B)_