### PR TITLE
fix(cost-analysis): weave seed into the resolver's regenerated shard names

### DIFF
--- a/R/cost-analysis.R
+++ b/R/cost-analysis.R
@@ -70,9 +70,15 @@ cost_shard_target_names <- function(scenario) {
       fit = ssd_scenario_fit_shards(scenario),
       hc = ssd_scenario_hc_shards(scenario)
     )
+    # Mirror the factory's naming: the `seed` is woven into every shard target
+    # name (`scenario_results_dir()` keys the tree on `seed=` too), so the
+    # resolver must carry the `seed` column and lead the `names` with it.
+    shards$seed <- scenario$seed
     mapped <- tarchetypes::tar_map(
       values = shards,
-      names = tidyselect::all_of(scenario_partition_axes(scenario, step)$path),
+      names = tidyselect::all_of(
+        c("seed", scenario_partition_axes(scenario, step)$path)
+      ),
       targets::tar_target_raw(paste0(step, "_step"), quote(NULL))
     )
     nm <- shard_cell_names(mapped, shards, scenario, step)

--- a/inst/targets-templates/design/design.R
+++ b/inst/targets-templates/design/design.R
@@ -7,27 +7,38 @@
 # `scenario` identity column. Edit to taste.
 library(ssdsims)
 
-data <- ssd_scenario_data(ssddata::ccme_boron)
-
-# A coarse grid everywhere ...
-coarse <- ssd_define_scenario(
-  data,
-  nsim = 2L,
-  seed = 42L,
-  nrow = c(5L, 10L, 20L),
-  dists = ssd_distset(lnorm = "lnorm")
+# shard on (dataset, sim) so each (dataset, sim) is its own cell
+pb <- list(
+  sample = c("dataset", "sim"),
+  fit = c("dataset", "sim"),
+  hc = c("dataset", "sim")
 )
 
-# ... plus a dense refinement over just the extra `nrow` values. It shares the
-# `seed`, dataset, and distributions with `coarse`, so it reuses every `sample`
-# shard (the draw does not depend on `nrow`) and only its new `nrow` cells are
-# extra work - the irregular (ragged) grid.
-dense <- ssd_define_scenario(
-  data,
-  nsim = 2L,
+# A coarse grid over BOTH datasets (a broad, shallow sweep) ...
+coarse <- ssd_define_scenario(
+  ssd_scenario_data(
+    boron = ssddata::ccme_boron,
+    cadmium = ssddata::ccme_cadmium
+  ),
+  nsim = 5L,
   seed = 42L,
-  nrow = c(12L, 14L, 16L, 18L),
-  dists = ssd_distset(lnorm = "lnorm")
+  nrow = c(5L, 10L, 20L),
+  dists = ssd_distset(lnorm = "lnorm"),
+  partition_by = pb
+)
+
+# ... plus a dense ZOOM into one region: only `boron`, more replicates, and a
+# finer `nrow` sweep. The union is ragged - `boron` sims 1-5 are shared with
+# `coarse` (built once, their `nrow` tasks merged), `cadmium` stays coarse-only,
+# and `boron` sims 6-15 are the dense-only refinement. `boron` must be identical
+# in both members (the consistency contract); `cadmium` appears only in `coarse`.
+dense <- ssd_define_scenario(
+  ssd_scenario_data(boron = ssddata::ccme_boron),
+  nsim = 15L,
+  seed = 42L,
+  nrow = c(8L, 12L, 16L),
+  dists = ssd_distset(lnorm = "lnorm"),
+  partition_by = pb
 )
 
 # `ssd_design()` validates the collection (names must be unique and safe; a name

--- a/openspec/changes/scenario-combine/design.md
+++ b/openspec/changes/scenario-combine/design.md
@@ -206,10 +206,13 @@ The factory performs no network I/O.
 
 ## Migration Plan
 
-Additive only: two new exports, no signature or behaviour change to existing
-functions, no re-baselining (per-task results unchanged). Promotion of a flat
-`ssd_scenario_targets()` run into a design recomputes (it gains the `seed=` level),
-as documented. Nothing to roll back beyond reverting the commit.
+Two new exports, and the single-scenario tree gains a `seed=` level
+(`scenario_results_dir()` now keys on `seed=`/`layout=`, and `root` is the base in
+both factories) — a one-time re-path of an existing `layout=`-only store, with no
+re-baselining (per-task results unchanged). With both factories rooting and naming
+shards identically, promoting a flat `ssd_scenario_targets()` run into a design is
+**cache-preserving** (the design reuses every existing shard; only the summary
+targets are new). Nothing to roll back beyond reverting the commit.
 
 ## Open Questions
 

--- a/openspec/changes/scenario-combine/tasks.md
+++ b/openspec/changes/scenario-combine/tasks.md
@@ -90,9 +90,8 @@
 
 - [x] 8.1 Roxygen for `ssd_design()` (the consistency contract), `ssd_design_targets()`
       (ragged union, naked `seed=`/`layout=` addressing, varying-seed support, the
-      per-overlap readout aggregation and `ci`-routing, the `nrow_max` undefined-
-      behaviour note, and the safe-but-recomputing flat→design note), and
-      `ssd_summarise_design()`; regenerate `NAMESPACE`/`man/`
+      `nrow_max` undefined-behaviour note, and the cache-preserving flat→design
+      migration note), and `ssd_summarise_design()`; regenerate `NAMESPACE`/`man/`
 - [x] 8.2 Add a design section to `vignettes/sharded-pipeline.qmd` led by the
       **irregular-grid** use case (finer detail in a subregion without the full
       cross-product), with setting-comparison secondary; pointer in `README.Rmd`;
@@ -102,8 +101,8 @@
       **single-scenario → design migration** end to end: a standalone
       `ssd_scenario_targets()` run, the one-line switch to
       `ssd_design_targets(ssd_design(scenario))` (byte-identical results, the
-      safe-but-recomputing `seed=` note), then adding a refining member that reuses
-      the cached cells; register it in `_pkgdown.yml`
+      cache-preserving `seed=`/`layout=` addressing), then adding a refining member
+      that reuses the cached cells; register it in `_pkgdown.yml`
 - [x] 8.4 `GLOSSARY.md` *Design terms* entries (`scenario`/`design`/`study`);
       `ROADMAP.md`: mark the entry in-flight and move to `## Done` on archive
 - [ ] 8.5 Format with `air`, run `devtools::check()`, and confirm the `task-shards`

--- a/tests/testthat/fixtures/design-ragged-targets.R
+++ b/tests/testthat/fixtures/design-ragged-targets.R
@@ -1,20 +1,32 @@
-# Test fixture: a ragged design - two members sharing a seed and dataset but
-# covering different `nrow` (a fit inner axis): coarse {5,10} and dense {6,7,8}.
-# They share every `sample` shard and the `fit`/`hc` shard cells (the union merges
-# their per-`nrow` tasks), so the design computes the union of cells once. Used by
-# test-design-targets.R.
+# Test fixture: a genuinely ragged design - two members covering *different,
+# overlapping* regions of the (dataset, sim) grid.
+#
+#   coarse: datasets {a, b} x sim {1, 2}              (a broad, shallow sweep)
+#   dense : dataset  {a}    x sim {1, 2, 3, 4}        (zoom into `a`: more sims,
+#           with a finer `nrow` sweep too)
+#
+# Cells (the partition_by path is (dataset, sim)):
+#   shared        : (a,1) (a,2)   -> built ONCE, read by both members
+#   coarse-only    : (b,1) (b,2)
+#   dense-only      : (a,3) (a,4)
+# so the union is 6 sample/fit/hc shards (not coarse's 4 + dense's 4 = 8). On the
+# shared (a,1)/(a,2) cells the fit/hc tasks merge both members' `nrow` sweeps.
+# Used by test-design-targets.R.
 library(targets)
 library(tarchetypes)
 library(ssdsims)
 
-data <- ssd_scenario_data(d = readRDS("data.rds"))
+d <- readRDS("data.rds")
 pb <- list(
   sample = c("dataset", "sim"),
   fit = c("dataset", "sim"),
   hc = c("dataset", "sim")
 )
+
+# `a` is identical in both members (the consistency contract); `b` only appears
+# in `coarse`.
 coarse <- ssd_define_scenario(
-  data,
+  ssd_scenario_data(a = d, b = d),
   nsim = 2L,
   seed = 42L,
   nrow = c(5L, 10L),
@@ -22,10 +34,10 @@ coarse <- ssd_define_scenario(
   partition_by = pb
 )
 dense <- ssd_define_scenario(
-  data,
-  nsim = 2L,
+  ssd_scenario_data(a = d),
+  nsim = 4L,
   seed = 42L,
-  nrow = c(6L, 7L, 8L),
+  nrow = c(5L, 7L, 8L, 10L),
   dists = ssd_distset(lnorm = "lnorm"),
   partition_by = pb
 )

--- a/tests/testthat/test-design-targets.R
+++ b/tests/testthat/test-design-targets.R
@@ -103,13 +103,16 @@ test_that("a ragged design shares cells and unions members into one summary", {
   progress <- targets::tar_progress()
   built <- progress$name[progress$progress %in% c("completed", "built")]
 
-  # sample axes are (dataset, sim); both members have nsim = 2 over one dataset,
-  # so the sample shards are shared: exactly 2 sample targets (not 4).
-  expect_length(grep("^sample_step_", built), 2L)
-  # fit/hc cells are also (dataset, sim) - shared; the differing `nrow` is an
-  # inner axis the union merges into each shared shard's tasks.
-  expect_length(grep("^fit_step_", built), 2L)
-  expect_length(grep("^hc_step_", built), 2L)
+  # The (dataset, sim) cells are ragged across the two members:
+  #   coarse {a,b} x {1,2}; dense {a} x {1,2,3,4}.
+  # Union = (a,1) (a,2) (a,3) (a,4) (b,1) (b,2) = 6 cells, with (a,1)/(a,2) shared
+  # and built ONCE - so 6 targets per step, not coarse's 4 + dense's 4 = 8.
+  for (step in c("sample", "fit", "hc")) {
+    expect_length(grep(paste0("^", step, "_step_"), built), 6L)
+  }
+  # the shared cells (a,1)/(a,2) appear once each (dedup, not one-per-member)
+  expect_length(grep("^sample_step_42_a_1$", built), 1L)
+  expect_length(grep("^sample_step_42_a_2$", built), 1L)
 
   # no duplicate target names
   expect_false(anyDuplicated(progress$name) > 0L)
@@ -117,15 +120,20 @@ test_that("a ragged design shares cells and unions members into one summary", {
   # the combined summary tags each row with its scenario; both members present.
   summary <- ssd_read_parquet("results/summary.parquet")
   expect_true(all(c("coarse", "dense") %in% summary$scenario))
-  # each member's rows are filtered to its own `nrow` cells (encoded in `hc_id`):
-  # coarse {5,10}, dense {6,7,8}. This proves the per-member filter of the shared
-  # shards works.
+
   coarse_ids <- summary$hc_id[summary$scenario == "coarse"]
   dense_ids <- summary$hc_id[summary$scenario == "dense"]
-  expect_true(all(grepl("/nrow=5/|/nrow=10/", coarse_ids)))
-  expect_false(any(grepl("/nrow=6/|/nrow=7/|/nrow=8/", coarse_ids)))
-  expect_true(all(grepl("/nrow=6/|/nrow=7/|/nrow=8/", dense_ids)))
-  expect_false(any(grepl("/nrow=5/|/nrow=10/", dense_ids)))
+  # coarse covers datasets {a,b} x sims {1,2}; dense covers {a} x sims {1,2,3,4}.
+  expect_true(any(grepl("dataset=b/", coarse_ids)))
+  expect_false(any(grepl("dataset=b/", dense_ids)))
+  expect_false(any(grepl("/sim=3/|/sim=4/", coarse_ids)))
+  expect_true(any(grepl("/sim=3/|/sim=4/", dense_ids)))
+  # on the shared (a,1) cell each member keeps its own `nrow` sweep (coarse
+  # {5,10}, dense {5,7,8,10}) - the per-member filter of the shared shard.
+  a1_coarse <- grep("dataset=a/sim=1/", coarse_ids, value = TRUE)
+  a1_dense <- grep("dataset=a/sim=1/", dense_ids, value = TRUE)
+  expect_false(any(grepl("/nrow=7/|/nrow=8/", a1_coarse)))
+  expect_true(any(grepl("/nrow=7/|/nrow=8/", a1_dense)))
 })
 
 # ---- byte-identity vs a standalone run -------------------------------------
@@ -160,10 +168,11 @@ test_that("design per-task hc results equal a standalone scenario run", {
   writeLines(
     c(
       "library(targets); library(tarchetypes); library(ssdsims)",
-      "data <- ssd_scenario_data(d = readRDS('data.rds'))",
+      "d <- readRDS('data.rds')",
       "pb <- list(sample = c('dataset','sim'), fit = c('dataset','sim'), hc = c('dataset','sim'))",
-      "coarse <- ssd_define_scenario(data, nsim = 2L, seed = 42L,",
-      "  nrow = c(5L, 10L), dists = ssd_distset(lnorm = 'lnorm'), partition_by = pb)",
+      "coarse <- ssd_define_scenario(ssd_scenario_data(a = d, b = d), nsim = 2L,",
+      "  seed = 42L, nrow = c(5L, 10L), dists = ssd_distset(lnorm = 'lnorm'),",
+      "  partition_by = pb)",
       "ssd_scenario_targets(coarse, root = 'results')"
     ),
     file.path(dir1, "_targets.R")

--- a/vignettes/scenario-to-design.qmd
+++ b/vignettes/scenario-to-design.qmd
@@ -43,16 +43,29 @@ with `ssd_scenario_targets()`:
 
 ```{r}
 #| label: scenario
-data <- ssd_scenario_data(ssddata::ccme_boron)
+data <- ssd_scenario_data(
+  boron = ssddata::ccme_boron,
+  cadmium = ssddata::ccme_cadmium
+)
+# shard on (dataset, sim) so each (dataset, sim) is its own cell
+pb <- list(
+  sample = c("dataset", "sim"),
+  fit = c("dataset", "sim"),
+  hc = c("dataset", "sim")
+)
 coarse <- ssd_define_scenario(
   data,
-  nsim = 10L,
+  nsim = 5L,
   seed = 42L,
   nrow = c(5L, 10L, 20L),
-  dists = ssd_distset(lnorm = "lnorm")
+  dists = ssd_distset(lnorm = "lnorm"),
+  partition_by = pb
 )
 coarse
 ```
+
+This sweeps **both** datasets shallowly: a regular `{boron, cadmium} x sim 1:5 x
+nrow {5, 10, 20}` grid.
 
 ```{r}
 #| label: scenario-targets
@@ -100,20 +113,22 @@ targets and paths to the standalone run. Re-running into the same store is a ful
 cache hit; only the per-member and combined `summary` targets are new.
 :::
 
-## Refine: add a denser member
+## Refine: zoom into one region
 
-Now add the refinement. Suppose you want a finer `nrow` sweep --- but only the
-extra sizes, not a whole new rectangular run. Define a second scenario covering
-just the new region and add it to the design:
+Now the irregular part. Suppose `boron` deserves a closer look --- more
+replicates *and* a finer `nrow` sweep --- but `cadmium` does not. Define a second
+scenario covering just that **region** (only `boron`, `sim 1:15`, a finer `nrow`)
+and add it to the design:
 
 ```{r}
 #| label: design-refine
 dense <- ssd_define_scenario(
-  data,
-  nsim = 10L,
+  ssd_scenario_data(boron = ssddata::ccme_boron),
+  nsim = 15L,
   seed = 42L,
-  nrow = c(12L, 14L, 16L, 18L),
-  dists = ssd_distset(lnorm = "lnorm")
+  nrow = c(8L, 12L, 16L),
+  dists = ssd_distset(lnorm = "lnorm"),
+  partition_by = pb
 )
 study <- ssd_design(coarse = coarse, dense = dense)
 study
@@ -126,15 +141,29 @@ study
 ssd_design_targets(study, root = "results")
 ```
 
-Both members share the same `seed`, dataset, and distributions, differing only
-in their `nrow` coverage. So they **share** every `sample` shard (the draw does
-not depend on `nrow`) and the `fit`/`hc` shard *cells* --- the union merges
-their per-`nrow` tasks into the shared shards. Re-running `tar_make()` builds
-only the genuinely new work; the cells `coarse` already computed stay cached.
+The union is genuinely **ragged** --- neither a rectangle nor a strict nesting.
+Over the `(dataset, sim)` cells:
 
-The combined `results/summary.parquet` carries a `scenario` column (`"coarse"`
-or `"dense"`), and each member's rows are filtered to exactly its own cells ---
-ready to plot the coarse and refined sweeps together.
+```
+  sim:    1   2   3   4   5   6  ...  15
+  boron   ■   ■   ■   ■   ■   □  ...  □      ■ shared (coarse + dense)
+  cadmium ◆   ◆   ◆   ◆   ◆                  ◆ coarse-only
+                          └── □ dense-only (boron, sim 6:15) ──┘
+```
+
+- **`boron` sims 1--5 are shared** --- built **once** and read by both members;
+  their `fit`/`hc` tasks merge both `nrow` sweeps (`{5,10,20}` ∪ `{8,12,16}`).
+- **`cadmium` stays coarse-only**; the refinement never touches it.
+- **`boron` sims 6--15 are the dense-only** zoom.
+
+A single scenario could not express this without computing the full
+`{boron, cadmium} x sim 1:15 x {5,8,10,12,16,20}` cross-product --- most of which
+you never wanted. Re-running `tar_make()` builds only the genuinely new cells; the
+shared `boron` 1--5 stay cached.
+
+The combined `results/summary.parquet` carries a `scenario` column (`"coarse"` or
+`"dense"`), and each member's rows are filtered to exactly its own cells --- ready
+to plot the broad sweep and the zoom together.
 
 ## Notes
 


### PR DESCRIPTION
## Hotfix: cost-analysis resolver (unblocks `main`)

PR #174 (the `seed=` unification) and PR #173 (cost-analysis) landed independently; their interaction left `main`'s `test-cost-analysis.R` failing. #174 wove the scenario `seed` into every shard target name (`sample_step_42_d_1_TRUE`), but the cost-analysis **resolver** (`cost_shard_target_names()`), which regenerates the factory's names to attribute `tar_meta()` timings, still minted the pre-seed names. The resolver now mirrors the factory (carries the `seed` column, leads the `tar_map()` `names` with `"seed"`), so the names match again. This is the only behavioural change (the NEWS-worthy `fix`).

## Also bundled (test/docs/examples — non-functional)

- **Genuinely cell-ragged design example.** The ragged example was only ragged in the inner `nrow` axis (cells fully overlapped). It now varies **cell-level coverage**: `coarse` over `{a,b} × sim 1:2`, `dense` zooming into `{a} × sim 1:4` with a finer `nrow` sweep — so members have **shared, coarse-only, and dense-only** cells. Updated:
  - `tests/testthat/fixtures/design-ragged-targets.R` + the `test-design-targets.R` assertions (shared `(a,1)/(a,2)` built once → 6 cells, not 8; per-member dataset/sim/nrow coverage).
  - `vignettes/scenario-to-design.qmd` (boron+cadmium; zoom into boron; an ASCII ragged-grid diagram).
  - `inst/targets-templates/design/design.R`.
- **Doc scrub:** removed the last stale "safe but recomputing" notes (`scenario-combine` `tasks.md`/`design.md`) — the migration is **cache-preserving**.

## Verified
- `R CMD INSTALL` clean; `test-cost-analysis.R`, `test-cost-timing.R`, `test-design-targets.R` (29 incl. the new ragged assertions) all pass on `main` + this branch.
- `devtools::check()` on the merged tree: 0 errors, 0 notes, 1 environmental warning (`qpdf` not installed for the PDF-size check).

https://claude.ai/code/session_01CaRPfNJDNNywmtnBJoRaDF