### PR TITLE
feat: aggregate hc readouts per overlapping cell across design members

### DIFF
--- a/R/design-targets.R
+++ b/R/design-targets.R
@@ -579,7 +579,12 @@ design_group_targets <- function(members, ref, sroot, upload, cue) {
       cue = cue
     )
     if (is.null(upload)) {
-      return(tarchetypes::tar_map(values = shards, names = nms, step_target))
+      return(tarchetypes::tar_map(
+        values = shards,
+        names = nms,
+        descriptions = tidyselect::all_of(character(0)),
+        step_target
+      ))
     }
     upload_target <- targets::tar_target_raw(
       paste0("upload_", step),
@@ -594,6 +599,7 @@ design_group_targets <- function(members, ref, sroot, upload, cue) {
     tarchetypes::tar_map(
       values = shards,
       names = nms,
+      descriptions = tidyselect::all_of(character(0)),
       step_target,
       upload_target
     )

--- a/R/design-targets.R
+++ b/R/design-targets.R
@@ -167,43 +167,95 @@ design_hc_assembly <- function(members, ref) {
   }
   all_hc <- dplyr::bind_rows(flat)
 
-  # Reduce the demand per hc cell (one representative row per `hc_id`; every other
-  # axis column is constant within an `hc_id`, so only the demand is aggregated).
-  grouped <- dplyr::group_by(all_hc, dplyr::across(dplyr::all_of("hc_id")))
-  splits <- dplyr::group_split(grouped)
-  cells <- lapply(splits, function(g) {
-    rep <- g[1L, , drop = FALSE]
-    rep$.dem_prop <- list(sort(unique(unlist(g$.dem_prop))))
-    rep$.dem_em <- list(unique(unlist(g$.dem_em)))
-    rep$.dem_ci <- any(unlist(g$.dem_ci))
-    rep$.dem_samples <- any(unlist(g$.dem_samples))
-    rep
-  })
-  cells <- dplyr::bind_rows(cells)
+  # Reduce the demand per hc cell. The expected shape is **most cells touched by
+  # one member** (a singleton `hc_id`): such a cell needs no reduction - its row
+  # *is* the cell, its demand already final - so only the multi-member cells go
+  # through the grouped set-union, optimising the common case. (`all_hc` is
+  # R-resident - it carries list-columns like `primer` that cannot originate in
+  # DuckDB - so the cheap count stays in dplyr; see this change's
+  # `exploration/FINDINGS.md`.)
+  demand_cols <- c(".dem_prop", ".dem_em", ".dem_ci", ".dem_samples")
+  sizes <- dplyr::summarise(
+    dplyr::group_by(all_hc, dplyr::across(dplyr::all_of("hc_id"))),
+    .n = dplyr::n(),
+    .groups = "drop"
+  )
+  multi_ids <- sizes$hc_id[sizes$.n > 1L]
+  is_multi <- all_hc$hc_id %in% multi_ids
+  single_cells <- all_hc[!is_multi, , drop = FALSE]
+  multi_rows <- all_hc[is_multi, , drop = FALSE]
+  if (nrow(multi_rows)) {
+    # One grouped summarise does every multi-member set-union; the constant
+    # axis/primer columns rejoin from the first row of each `hc_id`.
+    reduced <- dplyr::summarise(
+      dplyr::group_by(multi_rows, dplyr::across(dplyr::all_of("hc_id"))),
+      .dem_prop = list(sort(unique(unlist(.data[[".dem_prop"]])))),
+      .dem_em = list(unique(unlist(.data[[".dem_em"]]))),
+      .dem_ci = any(.data[[".dem_ci"]]),
+      .dem_samples = any(.data[[".dem_samples"]]),
+      .groups = "drop"
+    )
+    skel <- multi_rows[
+      !duplicated(multi_rows$hc_id),
+      setdiff(names(multi_rows), demand_cols),
+      drop = FALSE
+    ]
+    multi_cells <- dplyr::left_join(skel, reduced, by = "hc_id")
+  } else {
+    multi_cells <- single_cells[0L, , drop = FALSE]
+  }
+  cells <- dplyr::bind_rows(single_cells, multi_cells)
 
   # `ci` routing: fold each `ci = FALSE` cell's demand into a coincident
-  # `ci = TRUE` cell (same `fit_id`, `distset`) when one exists.
+  # `ci = TRUE` cell (same `fit_id`, `distset`) when one exists. Expressed as a
+  # join - each `ci = FALSE` cell maps to the `first()` matching `ci = TRUE` cell
+  # - rather than a per-cell scan over the `ci = TRUE` cells.
   ci_true <- cells[cells$.dem_ci, , drop = FALSE]
   ci_false <- cells[!cells$.dem_ci, , drop = FALSE]
   route <- character(0L) # served `ci = FALSE` hc_id -> serving `ci = TRUE` hc_id
   if (nrow(ci_true) && nrow(ci_false)) {
-    for (j in seq_len(nrow(ci_false))) {
-      cf <- ci_false[j, , drop = FALSE]
-      hit <- which(
-        ci_true$fit_id == cf$fit_id & ci_true$distset == cf$distset
+    serving_lookup <- dplyr::summarise(
+      dplyr::group_by(
+        ci_true,
+        dplyr::across(dplyr::all_of(c(
+          "fit_id",
+          "distset"
+        )))
+      ),
+      serving = dplyr::first(.data[["hc_id"]]),
+      .groups = "drop"
+    )
+    routed <- dplyr::left_join(
+      ci_false[c("hc_id", "fit_id", "distset", demand_cols)],
+      serving_lookup,
+      by = c("fit_id", "distset")
+    )
+    served <- routed[!is.na(routed$serving), , drop = FALSE]
+    route <- rlang::set_names(served$serving, served$hc_id)
+    if (nrow(served)) {
+      # Fold each served cell's demand into its serving `ci = TRUE` cell, grouped
+      # by the serving hc_id so a cell served by several `ci = FALSE` members is
+      # folded once.
+      fold <- dplyr::summarise(
+        dplyr::group_by(served, dplyr::across(dplyr::all_of("serving"))),
+        add_prop = list(unique(unlist(.data[[".dem_prop"]]))),
+        add_em = list(unique(unlist(.data[[".dem_em"]]))),
+        add_samples = any(.data[[".dem_samples"]]),
+        .groups = "drop"
       )
-      if (length(hit)) {
-        i <- hit[[1L]]
-        route[cf$hc_id] <- ci_true$hc_id[[i]]
+      pos <- match(fold$serving, ci_true$hc_id)
+      for (k in seq_len(nrow(fold))) {
+        i <- pos[[k]]
         ci_true$.dem_prop[[i]] <- sort(unique(c(
           ci_true$.dem_prop[[i]],
-          cf$.dem_prop[[1L]]
+          fold$add_prop[[k]]
         )))
         ci_true$.dem_em[[i]] <- unique(c(
           ci_true$.dem_em[[i]],
-          cf$.dem_em[[1L]]
+          fold$add_em[[k]]
         ))
-        ci_true$.dem_samples[i] <- ci_true$.dem_samples[i] || cf$.dem_samples
+        ci_true$.dem_samples[i] <- ci_true$.dem_samples[i] ||
+          fold$add_samples[[k]]
       }
     }
   }
@@ -228,10 +280,7 @@ design_hc_assembly <- function(members, ref) {
   computed$ci <- computed$.dem_ci
   computed$samples <- computed$.dem_samples
   computed <- computed[,
-    setdiff(
-      names(computed),
-      c(".dem_prop", ".dem_em", ".dem_ci", ".dem_samples")
-    ),
+    setdiff(names(computed), demand_cols),
     drop = FALSE
   ]
   path_axes <- scenario_partition_axes(ref, "hc")$path

--- a/R/design-targets.R
+++ b/R/design-targets.R
@@ -40,40 +40,32 @@ union_shards <- function(members, step) {
 # Build the synthetic reference scenario that drives the slice/partition machinery
 # for a seed group. `data`, `min_pmix_fns`, and `distsets` may differ in
 # *coverage* across members (the ragged grid) and are unioned (consistent values
-# by the `ssd_design()` contract). The slice-determining *settings* - `nrow_max`,
-# the fit `dists` union, and the hc readouts - must be uniform within the group in
-# this (irregular-grid) build: a shared cell then has byte-identical content under
-# pure cell-union. (Per-overlap readout aggregation, which relaxes the hc-readout
-# requirement, is layered on separately.)
+# by the `ssd_design()` contract). The fit `dists` union is reconciled by fitting
+# the **design-wide union** of the members' `dists` once per fit cell, each member
+# subsetting via its `distset` hc axis (sound by distset-subset-invariance:
+# per-dist fits are independent, so fitting extra dists does not change a member's
+# subset hc). The four non-axis hc readouts (`proportion`, `est_method`, `ci`,
+# `samples`) MAY differ too and are reconciled by the per-overlap aggregation
+# (`design_hc_assembly()`); only the layout-shaping `nrow_max` (and `partition_by`,
+# enforced by `ssd_design()`) remain uniform-required here.
 design_reference_scenario <- function(members, call = rlang::caller_env()) {
   ref <- members[[1L]]
   for (i in seq_along(members)[-1L]) {
     s <- members[[i]]
     require_uniform(ref, s, "nrow_max", ref$nrow_max, s$nrow_max, call)
-    require_uniform(ref, s, "dists", ref$fit$dists, s$fit$dists, call)
-    require_uniform(ref, s, "ci", ref$hc$ci, s$hc$ci, call)
-    require_uniform(
-      ref,
-      s,
-      "proportion",
-      ref$hc$proportion,
-      s$hc$proportion,
-      call
-    )
-    require_uniform(
-      ref,
-      s,
-      "est_method",
-      ref$hc$est_method,
-      s$hc$est_method,
-      call
-    )
-    require_uniform(ref, s, "samples", ref$hc$samples, s$hc$samples, call)
   }
   ref$data <- union_named(lapply(members, function(s) s$data))
   ref$datasets <- names(ref$data)
   ref$min_pmix_fns <- union_named(lapply(members, function(s) s$min_pmix_fns))
   ref$hc$distsets <- union_named(lapply(members, function(s) s$hc$distsets))
+  # Fit the design-wide union of the members' `dists` once per fit cell; each
+  # member subsets it to its own `distset` members at the hc step. (The fit `dists`
+  # do not enter the `fit_id`, so a wider union shares the fit cells; the hc
+  # `distset` axis isolates each member's subset.)
+  ref$fit$dists <- sort(unique(unlist(
+    lapply(members, function(s) s$fit$dists),
+    use.names = FALSE
+  )))
   ref
 }
 
@@ -82,9 +74,7 @@ require_uniform <- function(ref, s, what, a, b, call = rlang::caller_env()) {
     chk::abort_chk(
       "Members sharing a seed must agree on `",
       what,
-      "` (per-overlap aggregation of differing hc readouts across members is ",
-      "not yet supported in `ssd_design_targets()` - see the ",
-      "`hc-readout-aggregation` change); scenario seed ",
+      "`; scenario seed ",
       ref$seed,
       " has divergent `",
       what,
@@ -107,6 +97,158 @@ union_named <- function(lists) {
     }
   }
   out
+}
+
+# Assemble the hc shard table for a seed group with per-overlap readout
+# aggregation, returning the shards plus, per member, the serving `hc_id`s and the
+# `proportion`/`est_method` row filters its summary applies.
+#
+# When every member shares the four non-axis hc settings
+# (`proportion`/`est_method`/`ci`/`samples`) the plain cell-union (`union_shards()`)
+# is byte-identical to a standalone run and cache-compatible with it, so it is
+# taken unchanged (no per-task demand columns, no filtering). Otherwise the
+# members' hc tasks are unioned, **tagged with each member's readout demand**, and
+# grouped by hc **cell** (`hc_id` = fit identity + `nboot`/`ci_method`/`parametric`
+# /`distset`). For each cell the demand is reduced - `union` `proportion`/
+# `est_method`, `any` `ci`/`samples` - and attached to the shard's tasks so the
+# runner computes the maximal readout set; the per-member summary then filters its
+# slice.
+#
+# `ci` NA-collapse routing: a `ci = FALSE` task collapses `nboot`/`ci_method`/
+# `parametric` to `NA`, so its cell never coincides with a `ci = TRUE` task's. The
+# point `est` is analytical and bootstrap-config-invariant, so a `ci = FALSE`
+# cell's demand is folded into a coincident `ci = TRUE` cell at the same
+# `(fit_id, distset)` when one exists (the `ci = FALSE` member then reads its
+# served `est` from that `ci = TRUE` shard); only otherwise is a standalone
+# `ci = FALSE` cell minted. The computed cells are therefore every `ci = TRUE`
+# cell plus the `ci = FALSE` cells with no overlapping `ci = TRUE` cell.
+design_hc_assembly <- function(members, ref) {
+  nms <- names(members)
+  readout_key <- function(s) {
+    list(s$hc$proportion, s$hc$est_method, s$hc$ci, s$hc$samples)
+  }
+  uniform <- all(vapply(
+    members[-1L],
+    function(s) identical(readout_key(s), readout_key(members[[1L]])),
+    logical(1L)
+  ))
+  est_method_varies <- !all(vapply(
+    members[-1L],
+    function(s) identical(s$hc$est_method, members[[1L]]$hc$est_method),
+    logical(1L)
+  ))
+  no_filter <- rlang::set_names(vector("list", length(nms)), nms)
+
+  if (uniform) {
+    # The slice carries the (uniform) readouts; the runner reads them - no
+    # per-task demand columns, byte-identical to the cell-union path.
+    return(list(
+      shards = union_shards(members, "hc"),
+      serving = lapply(members, function(s) ssd_scenario_hc_tasks(s)$hc_id),
+      proportion = no_filter,
+      est_method = no_filter
+    ))
+  }
+
+  # Flat, demand-tagged hc tasks across all members (the `(seed, primer)`
+  # decoration mirrors `scenario_shards()`; the readout demand is the same for
+  # every row of a member, as those are scenario-level settings).
+  flat <- list()
+  for (nm in nms) {
+    s <- members[[nm]]
+    tbl <- tibble::as_tibble(ssd_scenario_hc_tasks(s))
+    tbl$seed <- s$seed
+    tbl$primer <- task_primers(tbl, "hc")
+    tbl$.dem_prop <- rep(list(s$hc$proportion), nrow(tbl))
+    tbl$.dem_em <- rep(list(s$hc$est_method), nrow(tbl))
+    tbl$.dem_ci <- s$hc$ci
+    tbl$.dem_samples <- s$hc$samples
+    flat[[nm]] <- tbl
+  }
+  all_hc <- dplyr::bind_rows(flat)
+
+  # Reduce the demand per hc cell (one representative row per `hc_id`; every other
+  # axis column is constant within an `hc_id`, so only the demand is aggregated).
+  grouped <- dplyr::group_by(all_hc, dplyr::across(dplyr::all_of("hc_id")))
+  splits <- dplyr::group_split(grouped)
+  cells <- lapply(splits, function(g) {
+    rep <- g[1L, , drop = FALSE]
+    rep$.dem_prop <- list(sort(unique(unlist(g$.dem_prop))))
+    rep$.dem_em <- list(unique(unlist(g$.dem_em)))
+    rep$.dem_ci <- any(unlist(g$.dem_ci))
+    rep$.dem_samples <- any(unlist(g$.dem_samples))
+    rep
+  })
+  cells <- dplyr::bind_rows(cells)
+
+  # `ci` routing: fold each `ci = FALSE` cell's demand into a coincident
+  # `ci = TRUE` cell (same `fit_id`, `distset`) when one exists.
+  ci_true <- cells[cells$.dem_ci, , drop = FALSE]
+  ci_false <- cells[!cells$.dem_ci, , drop = FALSE]
+  route <- character(0L) # served `ci = FALSE` hc_id -> serving `ci = TRUE` hc_id
+  if (nrow(ci_true) && nrow(ci_false)) {
+    for (j in seq_len(nrow(ci_false))) {
+      cf <- ci_false[j, , drop = FALSE]
+      hit <- which(
+        ci_true$fit_id == cf$fit_id & ci_true$distset == cf$distset
+      )
+      if (length(hit)) {
+        i <- hit[[1L]]
+        route[cf$hc_id] <- ci_true$hc_id[[i]]
+        ci_true$.dem_prop[[i]] <- sort(unique(c(
+          ci_true$.dem_prop[[i]],
+          cf$.dem_prop[[1L]]
+        )))
+        ci_true$.dem_em[[i]] <- unique(c(
+          ci_true$.dem_em[[i]],
+          cf$.dem_em[[1L]]
+        ))
+        ci_true$.dem_samples[i] <- ci_true$.dem_samples[i] || cf$.dem_samples
+      }
+    }
+  }
+  unserved_false <- ci_false[
+    !(ci_false$hc_id %in% names(route)),
+    ,
+    drop = FALSE
+  ]
+  computed <- dplyr::bind_rows(ci_true, unserved_false)
+
+  # Per member: the serving hc_id of each of its tasks (own cell, or the routed
+  # `ci = TRUE` cell for a served `ci = FALSE` task), and its readout filters.
+  serving <- lapply(members, function(s) {
+    ids <- ssd_scenario_hc_tasks(s)$hc_id
+    mapped <- route[ids]
+    ifelse(is.na(mapped), ids, unname(mapped))
+  })
+
+  # Expose the per-task demand under the runner's argument names and shard it.
+  computed$proportion <- computed$.dem_prop
+  computed$est_method <- computed$.dem_em
+  computed$ci <- computed$.dem_ci
+  computed$samples <- computed$.dem_samples
+  computed <- computed[,
+    setdiff(
+      names(computed),
+      c(".dem_prop", ".dem_em", ".dem_ci", ".dem_samples")
+    ),
+    drop = FALSE
+  ]
+  path_axes <- scenario_partition_axes(ref, "hc")$path
+  grp <- dplyr::group_by(computed, dplyr::across(dplyr::all_of(path_axes)))
+  shards <- dplyr::group_keys(grp)
+  shards$tasks <- dplyr::group_split(grp, .keep = TRUE)
+
+  list(
+    shards = tibble::as_tibble(shards),
+    serving = serving,
+    proportion = lapply(members, function(s) s$hc$proportion),
+    est_method = if (est_method_varies) {
+      lapply(members, function(s) s$hc$est_method)
+    } else {
+      no_filter
+    }
+  )
 }
 
 #' Combine Per-scenario Summaries into One Design Summary
@@ -149,22 +291,36 @@ ssd_summarise_design <- function(summaries, path) {
 #' Summarise One Design Member from the Shared hc Shards
 #'
 #' The per-scenario fan-in used by [ssd_design_targets()]: reads the (shared) hc
-#' shards under `dir_hc`, filters to the member's hc task identities (`hc_ids`),
-#' projects out the `dists`/`samples` list-columns at the DuckDB level, and writes
-#' the member's compact summary at `path`. Filtering by `hc_id` selects exactly the
-#' member's rows from the shards it shares with other members of the design. The
-#' read, filter, projection, and write all happen inside DuckDB (never collecting
-#' into R), mirroring [ssd_summarise()].
+#' shards under `dir_hc`, filters to the member's **serving** hc task identities
+#' (`hc_ids`) - its own cells, plus the coincident `ci = TRUE` cell serving each of
+#' its `ci = FALSE` cells under [ssd_design_targets()]'s `ci` routing - projects out
+#' the `dists`/`samples` list-columns at the DuckDB level, and writes the member's
+#' compact summary at `path`. When the design aggregates differing readouts into a
+#' shared cell, `proportion`/`est_method` narrow the maximal computed set back to
+#' the member's requested readout rows. The read, filter, projection, and write all
+#' happen inside DuckDB (never collecting into R), mirroring [ssd_summarise()].
 #'
 #' @param dir_hc The (shared) `hc` results root of the member's seed group.
-#' @param hc_ids The member's hc task identities (`hc_id`s) to keep.
+#' @param hc_ids The member's serving hc task identities (`hc_id`s) to keep.
 #' @param path The output Parquet path for the member's compact summary (the
 #'   `format = "file"` contract).
+#' @param proportion Optional `proportion` values to keep (the member's requested
+#'   proportions when the design aggregates a wider union into the shared cell);
+#'   `NULL` (the default) keeps every proportion.
+#' @param est_method Optional `est_method` values to keep (the member's requested
+#'   methods when the design aggregates a wider union); `NULL` (the default) keeps
+#'   every method.
 #' @return `path`.
 #' @seealso [ssd_design_targets()], [ssd_summarise_design()], [ssd_summarise()].
 #' @export
 #' @autoglobal
-ssd_summarise_member <- function(dir_hc, hc_ids, path) {
+ssd_summarise_member <- function(
+  dir_hc,
+  hc_ids,
+  path,
+  proportion = NULL,
+  est_method = NULL
+) {
   local_duckplyr_config()
   glob <- file.path(dir_hc, "**", "part.parquet")
   hc_shards <- duckplyr::read_parquet_duckdb(
@@ -172,6 +328,14 @@ ssd_summarise_member <- function(dir_hc, hc_ids, path) {
     options = list(hive_partitioning = FALSE)
   )
   hc <- dplyr::filter(hc_shards, hc_id %in% hc_ids)
+  keep_prop <- proportion
+  keep_em <- est_method
+  if (!is.null(keep_prop)) {
+    hc <- dplyr::filter(hc, proportion %in% keep_prop)
+  }
+  if (!is.null(keep_em)) {
+    hc <- dplyr::filter(hc, est_method %in% keep_em)
+  }
   hc <- dplyr::select(hc, -dplyr::any_of(c("dists", "samples")))
   ssd_write_parquet(hc, path)
   path
@@ -209,6 +373,31 @@ ssd_summarise_member <- function(dir_hc, hc_ids, path) {
 #' Members may use different `seed`s (e.g. repeating the exploration under several
 #' master seeds); they land under separate `seed=` trees and share nothing.
 #' Members sharing a `seed` share their coincident cells (common random numbers).
+#'
+#' @section Per-overlap hc readout aggregation:
+#' Members of a seed group MAY differ in the four **non-axis** hc readout settings
+#' (`proportion`, `est_method`, `ci`, `samples`) and in their fit `dists` union;
+#' only the layout-shaping `nrow_max` and `partition_by` stay uniform-required.
+#' Differing readouts are reconciled **per shared hc cell, over only the members
+#' whose task set contains that cell** - `proportion`/`est_method` are `union`-ed
+#' and `ci`/`samples` reduced with `any()` - so the cell computes the maximal
+#' readout set in one shard and each member's summary filters its slice. A cell one
+#' member reaches keeps that member's (smaller) demand, so the expensive bootstrap
+#' runs only where a `ci = TRUE` member has tasks. The draw-shaping hc axes
+#' (`nboot`/`ci_method`/`parametric`/`distset`) are **not** aggregated - they stay
+#' cell axes (in the per-task primer), so byte-identity holds: a member's per-task
+#' results equal its standalone-run results.
+#'
+#' Because a `ci = FALSE` task collapses `nboot`/`ci_method`/`parametric` to `NA`,
+#' its cell never coincides with a `ci = TRUE` task's. The point `est` is analytical
+#' and bootstrap-config-invariant, so a `ci = FALSE` cell is **served by a
+#' coincident `ci = TRUE` shard** at the same `(fit, distset)` when one exists (the
+#' computed hc shards are every `ci = TRUE` cell plus the `ci = FALSE` cells with no
+#' overlapping `ci = TRUE` shard); a `ci = TRUE` member's confidence interval still
+#' uses its own cell's `(nboot, ci_method, parametric)` primer. Differing fit
+#' `dists` unions are reconciled by fitting the **design-wide union** once per fit
+#' cell, each member subsetting via its `distset` axis (distset-subset-invariance),
+#' so members differing only in `distset` coverage share every `sample`/`fit` shard.
 #'
 #' @param design An `ssdsims_design` from [ssd_design()].
 #' @param ... Unused; must be empty (forces `root`/`upload`/`cue` to be named).
@@ -270,7 +459,9 @@ ssd_design_targets <- function(
       member_info[[nm]] <- list(
         hc_dir = group$hc_dir,
         hc_names = group$hc_names,
-        hc_ids = ssd_scenario_hc_tasks(members[[nm]])$hc_id,
+        hc_ids = group$serving[[nm]],
+        proportion = group$proportion[[nm]],
+        est_method = group$est_method[[nm]],
         summary_path = file.path(root, paste0("summary-", nm, ".parquet"))
       )
     }
@@ -283,7 +474,13 @@ ssd_design_targets <- function(
       paste0("summary_", nm),
       rlang::expr({
         !!edge_block(unname(info$hc_names))
-        ssd_summarise_member(!!info$hc_dir, !!info$hc_ids, !!info$summary_path)
+        ssd_summarise_member(
+          !!info$hc_dir,
+          !!info$hc_ids,
+          !!info$summary_path,
+          proportion = !!info$proportion,
+          est_method = !!info$est_method
+        )
       }),
       format = "file"
     )
@@ -385,7 +582,12 @@ design_group_targets <- function(members, ref, sroot, upload, cue) {
   )
   fit_names <- shard_cell_names(fit_targets, fit_shards, ref, "fit")
 
-  hc_shards <- union_shards(members, "hc")
+  # The hc step reconciles members that differ in the four non-axis readouts
+  # (`proportion`/`est_method`/`ci`/`samples`) by per-overlap aggregation, so its
+  # shard build (and the per-member serving ids / readout filters) come from
+  # `design_hc_assembly()` rather than the plain cell-union.
+  hc <- design_hc_assembly(members, ref)
+  hc_shards <- hc$shards
   hc_shards$seed <- ref$seed
   hc_shards$.parents <- child_parent_edges(hc_shards, ref, "fit", fit_names)
   hc_shards$.slice <- purrr::map(hc_shards$tasks, function(tasks) {
@@ -404,6 +606,9 @@ design_group_targets <- function(members, ref, sroot, upload, cue) {
   list(
     targets = list(sample_targets, fit_targets, hc_targets),
     hc_dir = hc_dir,
-    hc_names = hc_names
+    hc_names = hc_names,
+    serving = hc$serving,
+    proportion = hc$proportion,
+    est_method = hc$est_method
   )
 }

--- a/R/targets-runner.R
+++ b/R/targets-runner.R
@@ -936,6 +936,7 @@ ssd_scenario_targets <- function(
         names = tidyselect::all_of(
           c("seed", scenario_partition_axes(scenario, step)$path)
         ),
+        descriptions = tidyselect::all_of(character(0)),
         step_target
       ))
     }
@@ -954,6 +955,7 @@ ssd_scenario_targets <- function(
       names = tidyselect::all_of(
         c("seed", scenario_partition_axes(scenario, step)$path)
       ),
+      descriptions = tidyselect::all_of(character(0)),
       step_target,
       upload_target
     )

--- a/R/targets-runner.R
+++ b/R/targets-runner.R
@@ -379,6 +379,14 @@ ssd_run_fit_step <- function(tasks, scenario, sample_dir, out_dir) {
 #'   `fit_id`, and `distset` name, stacked, and written as one Parquet at the
 #'   shard's partition path. A set whose members all dropped from the union fit
 #'   emits no rows for that cell (the survivor model).
+#'
+#'   The four non-axis hc readout settings (`proportion`, `est_method`, `ci`,
+#'   `samples`) default to the scenario slice, so the single-scenario and
+#'   standalone paths are byte-identical. When the shard's `tasks` carry per-task
+#'   `proportion`/`est_method`/`ci`/`samples` columns (the design factory's
+#'   per-overlap aggregated demand, [ssd_design_targets()]), each task is
+#'   summarised with its own cell's demand instead - the maximal readout set the
+#'   per-member summary then filters.
 #' @export
 #' @examples
 #' \donttest{
@@ -442,23 +450,33 @@ ssd_run_hc_step <- function(tasks, scenario, fit_dir, out_dir) {
     fit_cache[[fit_id]] <- decode_obj(blob)
     fit_cache[[fit_id]]
   }
+  # The four non-axis readouts default to the scenario slice (single-scenario /
+  # standalone paths, byte-identical) but are read per task when the shard's
+  # `tasks` carry them (the design factory's per-overlap aggregated demand).
+  has_demand <- all(
+    c("proportion", "est_method", "ci", "samples") %in% names(tasks)
+  )
   rows <- vector("list", nrow(tasks))
   for (i in seq_len(nrow(tasks))) {
     t <- tasks[i, ]
     fits <- decode_fit(t$fit_id)
+    proportion <- if (has_demand) t$proportion[[1L]] else scenario$hc$proportion
+    est_method <- if (has_demand) t$est_method[[1L]] else scenario$hc$est_method
+    ci <- if (has_demand) t$ci else scenario$hc$ci
+    samples <- if (has_demand) t$samples else scenario$hc$samples
     t_start <- utc_now()
     hc <- hc_data_task_primer(
       fits = fits,
-      proportion = scenario$hc$proportion,
-      ci = scenario$hc$ci,
+      proportion = proportion,
+      ci = ci,
       nboot = t$nboot,
-      est_method = scenario$hc$est_method,
+      est_method = est_method,
       ci_method = t$ci_method,
       parametric = t$parametric,
       # Resolve this task's `distset` name to its members and subset the union
       # fit to that pool (the subset happens in the shared primer chokepoint).
       dists = scenario_distset(scenario, t$distset),
-      samples = scenario$hc$samples,
+      samples = samples,
       seed = t$seed,
       primer = t$primer[[1L]]
     )

--- a/R/task-lists.R
+++ b/R/task-lists.R
@@ -320,9 +320,29 @@ ssd_run_scenario_baseline <- function(scenario) {
 # (CLAUDE.md error-call-origin rule).
 task_primers <- function(tbl, step) {
   axes <- task_axes(step)
-  primers <- vector("list", nrow(tbl))
-  for (i in seq_len(nrow(tbl))) {
-    primers[[i]] <- task_primer(tbl[i, axes])
+  n <- nrow(tbl)
+  cols <- lapply(axes, function(a) tbl[[a]])
+  is_df <- vapply(cols, is.data.frame, logical(1L))
+  is_lst <- vapply(
+    cols,
+    function(v) is.list(v) && !is.data.frame(v),
+    logical(1L)
+  )
+  primers <- vector("list", n)
+  for (i in seq_len(n)) {
+    row <- vector("list", length(axes))
+    names(row) <- axes
+    for (j in seq_along(cols)) {
+      v <- cols[[j]]
+      row[[j]] <- if (is_df[[j]]) {
+        v[i, , drop = FALSE]
+      } else if (is_lst[[j]]) {
+        v[[i]]
+      } else {
+        v[[i]]
+      }
+    }
+    primers[[i]] <- task_primer(row)
   }
   primers
 }

--- a/man/ssd_design_targets.Rd
+++ b/man/ssd_design_targets.Rd
@@ -58,6 +58,33 @@ master seeds); they land under separate \verb{seed=} trees and share nothing.
 Members sharing a \code{seed} share their coincident cells (common random numbers).
 }
 
+\section{Per-overlap hc readout aggregation}{
+
+Members of a seed group MAY differ in the four \strong{non-axis} hc readout settings
+(\code{proportion}, \code{est_method}, \code{ci}, \code{samples}) and in their fit \code{dists} union;
+only the layout-shaping \code{nrow_max} and \code{partition_by} stay uniform-required.
+Differing readouts are reconciled \strong{per shared hc cell, over only the members
+whose task set contains that cell} - \code{proportion}/\code{est_method} are \code{union}-ed
+and \code{ci}/\code{samples} reduced with \code{any()} - so the cell computes the maximal
+readout set in one shard and each member's summary filters its slice. A cell one
+member reaches keeps that member's (smaller) demand, so the expensive bootstrap
+runs only where a \code{ci = TRUE} member has tasks. The draw-shaping hc axes
+(\code{nboot}/\code{ci_method}/\code{parametric}/\code{distset}) are \strong{not} aggregated - they stay
+cell axes (in the per-task primer), so byte-identity holds: a member's per-task
+results equal its standalone-run results.
+
+Because a \code{ci = FALSE} task collapses \code{nboot}/\code{ci_method}/\code{parametric} to \code{NA},
+its cell never coincides with a \code{ci = TRUE} task's. The point \code{est} is analytical
+and bootstrap-config-invariant, so a \code{ci = FALSE} cell is \strong{served by a
+coincident \code{ci = TRUE} shard} at the same \verb{(fit, distset)} when one exists (the
+computed hc shards are every \code{ci = TRUE} cell plus the \code{ci = FALSE} cells with no
+overlapping \code{ci = TRUE} shard); a \code{ci = TRUE} member's confidence interval still
+uses its own cell's \verb{(nboot, ci_method, parametric)} primer. Differing fit
+\code{dists} unions are reconciled by fitting the \strong{design-wide union} once per fit
+cell, each member subsetting via its \code{distset} axis (distset-subset-invariance),
+so members differing only in \code{distset} coverage share every \code{sample}/\code{fit} shard.
+}
+
 \examples{
 \dontrun{
 # _targets.R

--- a/man/ssd_run_step.Rd
+++ b/man/ssd_run_step.Rd
@@ -77,6 +77,14 @@ scenario options \code{NA} when \code{ci = FALSE}) is tagged with its \code{hc_i
 shard's partition path. A set whose members all dropped from the union fit
 emits no rows for that cell (the survivor model).
 
+The four non-axis hc readout settings (\code{proportion}, \code{est_method}, \code{ci},
+\code{samples}) default to the scenario slice, so the single-scenario and
+standalone paths are byte-identical. When the shard's \code{tasks} carry per-task
+\code{proportion}/\code{est_method}/\code{ci}/\code{samples} columns (the design factory's
+per-overlap aggregated demand, \code{\link[=ssd_design_targets]{ssd_design_targets()}}), each task is
+summarised with its own cell's demand instead - the maximal readout set the
+per-member summary then filters.
+
 }}
 \examples{
 data <- ssd_scenario_data(ssddata::ccme_boron)

--- a/man/ssd_summarise_member.Rd
+++ b/man/ssd_summarise_member.Rd
@@ -4,27 +4,43 @@
 \alias{ssd_summarise_member}
 \title{Summarise One Design Member from the Shared hc Shards}
 \usage{
-ssd_summarise_member(dir_hc, hc_ids, path)
+ssd_summarise_member(
+  dir_hc,
+  hc_ids,
+  path,
+  proportion = NULL,
+  est_method = NULL
+)
 }
 \arguments{
 \item{dir_hc}{The (shared) \code{hc} results root of the member's seed group.}
 
-\item{hc_ids}{The member's hc task identities (\code{hc_id}s) to keep.}
+\item{hc_ids}{The member's serving hc task identities (\code{hc_id}s) to keep.}
 
 \item{path}{The output Parquet path for the member's compact summary (the
 \code{format = "file"} contract).}
+
+\item{proportion}{Optional \code{proportion} values to keep (the member's requested
+proportions when the design aggregates a wider union into the shared cell);
+\code{NULL} (the default) keeps every proportion.}
+
+\item{est_method}{Optional \code{est_method} values to keep (the member's requested
+methods when the design aggregates a wider union); \code{NULL} (the default) keeps
+every method.}
 }
 \value{
 \code{path}.
 }
 \description{
 The per-scenario fan-in used by \code{\link[=ssd_design_targets]{ssd_design_targets()}}: reads the (shared) hc
-shards under \code{dir_hc}, filters to the member's hc task identities (\code{hc_ids}),
-projects out the \code{dists}/\code{samples} list-columns at the DuckDB level, and writes
-the member's compact summary at \code{path}. Filtering by \code{hc_id} selects exactly the
-member's rows from the shards it shares with other members of the design. The
-read, filter, projection, and write all happen inside DuckDB (never collecting
-into R), mirroring \code{\link[=ssd_summarise]{ssd_summarise()}}.
+shards under \code{dir_hc}, filters to the member's \strong{serving} hc task identities
+(\code{hc_ids}) - its own cells, plus the coincident \code{ci = TRUE} cell serving each of
+its \code{ci = FALSE} cells under \code{\link[=ssd_design_targets]{ssd_design_targets()}}'s \code{ci} routing - projects out
+the \code{dists}/\code{samples} list-columns at the DuckDB level, and writes the member's
+compact summary at \code{path}. When the design aggregates differing readouts into a
+shared cell, \code{proportion}/\code{est_method} narrow the maximal computed set back to
+the member's requested readout rows. The read, filter, projection, and write all
+happen inside DuckDB (never collecting into R), mirroring \code{\link[=ssd_summarise]{ssd_summarise()}}.
 }
 \seealso{
 \code{\link[=ssd_design_targets]{ssd_design_targets()}}, \code{\link[=ssd_summarise_design]{ssd_summarise_design()}}, \code{\link[=ssd_summarise]{ssd_summarise()}}.

--- a/openspec/changes/hc-readout-aggregation/exploration/FINDINGS.md
+++ b/openspec/changes/hc-readout-aggregation/exploration/FINDINGS.md
@@ -1,0 +1,70 @@
+# Exploration: vectorising the hc demand reduction
+
+Reframe the `group_split()` + per-cell `for` loop in `design_hc_assembly()`
+(`R/design-targets.R`) as a vectorised reduction, optimised for the
+majority-size-one case, exploring `duckplyr` / `.prudence = "stingy"`.
+
+POC: `poc-summarise-reduction.R` (equivalence vs the current implementation on
+five design shapes + benchmark).
+
+## What the reframe is
+
+1. **Group sizes** by `hc_id`, then a **singleton fast-path**: a cell touched by
+   one member (`n == 1`) needs no reduction — the row *is* the cell, its demand
+   already final. Only the multi-member cells are reduced.
+2. **One grouped `summarise(.by = hc_id)`** over the (rare) multi-member cells
+   does the set-unions (`list(sort(unique(unlist(...))))` for `proportion`/
+   `est_method`, `any()` for `ci`/`samples`); the constant axis/primer columns
+   rejoin from the first row per group. This replaces the explicit per-cell loop.
+3. **`ci` routing as a join**: each `ci = FALSE` cell finds its serving
+   `ci = TRUE` cell via a join on `(fit_id, distset)` + `first(hc_id)`, replacing
+   the current `O(n_false × n_true)` nested scan.
+
+## Findings
+
+**Equivalence.** Byte-for-byte identical computed cells, serving maps, and
+readout filters vs the current `design_hc_assembly()` on: readout-only
+(`proportion`), ci-mix (+routing), `est_method`+`proportion`, distset (uniform
+path), a large ci-mix, and a multi-`nboot` routing tie-break.
+
+**Speed.** Median wall time for the assembly (the part that re-runs on every
+`_targets.R` source, i.e. every `tar_make`/worker):
+
+| all_hc rows | current (split+loop) | new (dplyr count) | new (duckplyr count) |
+|-------------|----------------------|-------------------|----------------------|
+| 1,260       | 1.17s                | 0.54s             | 0.58s                |
+| 6,300       | 5.85s                | 2.39s             | 2.42s                |
+| 25,200      | 25.3s                | 9.8s              | 9.4s                 |
+
+~2.5× faster overall. For **ci-mix** designs specifically, the dominant win is
+the routing join (the current nested scan is `O(n_false × n_true)` — ~29M
+comparisons at 25k rows); every `hc_id` there is a singleton, so the reduction
+fast-path also skips the `summarise` entirely.
+
+**duckplyr / `.prudence = "stingy"` is a wash here — challenge to the premise.**
+The count engine (duckplyr-stingy vs plain dplyr) makes no measurable difference,
+and duckplyr is slightly *slower* at small scale (transfer/startup overhead). The
+reason is structural: `all_hc` carries list-columns (`primer`, `range_shape1/2`,
+and the per-member demand vectors), which **cannot originate in DuckDB** — the
+primer needs R-side hashing (`task_primer()`). So `all_hc` is always fully
+materialised in R *before* any count, leaving DuckDB nothing to protect: the
+"stingy" memory guarantee (don't pull DuckDB intermediates into R) is moot when
+the input already lives in R. Only the scalar `hc_id` column could cross over,
+and counting one in-memory character column is equally cheap in dplyr.
+
+`dd$` (a DuckDB-function pronoun that *could* express `array_agg(DISTINCT ...)`
+list-aggregation entirely in DuckDB) does **not** exist in the pinned
+`duckplyr` 1.2.1, so a "duckplyr-only" reduction of the vector demand is not
+reachable on this version regardless.
+
+## Recommendation
+
+Adopt the **singleton fast-path + single `summarise` reduction + join-based
+routing**, using **plain `dplyr` for the group-size count**. It is the clear,
+evidence-backed win (~2.5×, cleaner code, no behavioural change) without taking
+on the `as_duckdb_tibble()` round-trip that buys nothing in this architecture.
+
+If the `duckplyr`/stingy pattern is wanted for consistency with the rest of the
+codebase regardless of the wash, the count can use
+`as_duckdb_tibble(all_hc["hc_id"], prudence = "stingy")` (POC `count_engine =
+"duckplyr"`) — identical results, marginally slower at small scale.

--- a/openspec/changes/hc-readout-aggregation/exploration/poc-summarise-reduction.R
+++ b/openspec/changes/hc-readout-aggregation/exploration/poc-summarise-reduction.R
@@ -1,0 +1,408 @@
+# Proof of concept: reframe the per-cell hc demand reduction as a vectorised
+# `summarise(.by = hc_id)` with a singleton fast-path, plus duckplyr (`.prudence
+# = "stingy"`) for the group-size partition and the `ci` routing join.
+#
+# Goal: replace the `group_split()` + per-cell `for` loop in `design_hc_assembly()`
+# (R/design-targets.R) with
+#   1. a DuckDB group-size count (only the scalar `hc_id` column crosses over),
+#   2. a singleton fast-path (n == 1 cells need no reduction - the row IS the
+#      cell, its demand already final - and these are expected to dominate),
+#   3. ONE grouped `summarise()` over only the multi-member cells, and
+#   4. the `ci = FALSE` -> `ci = TRUE` routing expressed as a join.
+#
+# This script validates the reframed assembly against the CURRENT
+# `design_hc_assembly()` (the oracle) on several designs, then benchmarks both on
+# a large, singleton-heavy design.
+#
+# Run with:  Rscript --no-environ openspec/changes/hc-readout-aggregation/exploration/poc-summarise-reduction.R
+
+suppressMessages(devtools::load_all(quiet = TRUE))
+
+# ---- the reframed assembly (mirrors design_hc_assembly's contract) ----------
+
+assembly_new <- function(members, ref, count_engine = c("duckplyr", "dplyr")) {
+  count_engine <- match.arg(count_engine)
+  nms <- names(members)
+  readout_key <- function(s) {
+    list(s$hc$proportion, s$hc$est_method, s$hc$ci, s$hc$samples)
+  }
+  uniform <- all(vapply(
+    members[-1L],
+    function(s) identical(readout_key(s), readout_key(members[[1L]])),
+    logical(1L)
+  ))
+  est_method_varies <- !all(vapply(
+    members[-1L],
+    function(s) identical(s$hc$est_method, members[[1L]]$hc$est_method),
+    logical(1L)
+  ))
+  no_filter <- rlang::set_names(vector("list", length(nms)), nms)
+
+  if (uniform) {
+    return(list(
+      shards = union_shards(members, "hc"),
+      serving = lapply(members, function(s) ssd_scenario_hc_tasks(s)$hc_id),
+      proportion = no_filter,
+      est_method = no_filter
+    ))
+  }
+
+  flat <- list()
+  for (nm in nms) {
+    s <- members[[nm]]
+    tbl <- tibble::as_tibble(ssd_scenario_hc_tasks(s))
+    tbl$seed <- s$seed
+    tbl$primer <- task_primers(tbl, "hc")
+    tbl$.dem_prop <- rep(list(s$hc$proportion), nrow(tbl))
+    tbl$.dem_em <- rep(list(s$hc$est_method), nrow(tbl))
+    tbl$.dem_ci <- s$hc$ci
+    tbl$.dem_samples <- s$hc$samples
+    flat[[nm]] <- tbl
+  }
+  all_hc <- dplyr::bind_rows(flat)
+
+  # (1) group sizes. Only the scalar `hc_id` column crosses into DuckDB, so the
+  # list-columns (primer, range_shape*, the demand) never trip duckplyr.
+  if (count_engine == "duckplyr") {
+    sizes <- dplyr::collect(dplyr::summarise(
+      duckplyr::as_duckdb_tibble(all_hc["hc_id"], prudence = "stingy"),
+      .n = dplyr::n(),
+      .by = "hc_id"
+    ))
+  } else {
+    sizes <- dplyr::summarise(
+      dplyr::group_by(all_hc["hc_id"], hc_id),
+      .n = dplyr::n(),
+      .groups = "drop"
+    )
+  }
+  multi_ids <- sizes$hc_id[sizes$.n > 1L]
+
+  demand_cols <- c(".dem_prop", ".dem_em", ".dem_ci", ".dem_samples")
+  is_multi <- all_hc$hc_id %in% multi_ids
+
+  # (2) singleton fast-path: each such row is already its own cell with final
+  # demand - no reduction.
+  single_cells <- all_hc[!is_multi, , drop = FALSE]
+
+  # (3) ONE grouped summarise over the (rare) multi-member cells; rejoin the
+  # constant axis/primer columns from the first row of each group.
+  multi_rows <- all_hc[is_multi, , drop = FALSE]
+  if (nrow(multi_rows)) {
+    reduced <- dplyr::summarise(
+      dplyr::group_by(multi_rows, hc_id),
+      .dem_prop = list(sort(unique(unlist(.dem_prop)))),
+      .dem_em = list(unique(unlist(.dem_em))),
+      .dem_ci = any(.dem_ci),
+      .dem_samples = any(.dem_samples),
+      .groups = "drop"
+    )
+    skel <- multi_rows[
+      !duplicated(multi_rows$hc_id),
+      setdiff(names(multi_rows), demand_cols),
+      drop = FALSE
+    ]
+    multi_cells <- dplyr::left_join(skel, reduced, by = "hc_id")
+  } else {
+    multi_cells <- single_cells[0, , drop = FALSE]
+  }
+  cells <- dplyr::bind_rows(single_cells, multi_cells)
+
+  # (4) ci routing as a join: each ci = FALSE cell -> first coincident ci = TRUE
+  # cell at the same (fit_id, distset).
+  ci_true <- cells[cells$.dem_ci, , drop = FALSE]
+  ci_false <- cells[!cells$.dem_ci, , drop = FALSE]
+  route <- character(0L)
+  if (nrow(ci_true) && nrow(ci_false)) {
+    serving_lookup <- dplyr::summarise(
+      dplyr::group_by(ci_true, fit_id, distset),
+      serving = dplyr::first(hc_id),
+      .groups = "drop"
+    )
+    routed <- dplyr::left_join(
+      ci_false[c("hc_id", "fit_id", "distset")],
+      serving_lookup,
+      by = c("fit_id", "distset")
+    )
+    served <- routed[!is.na(routed$serving), , drop = FALSE]
+    route <- rlang::set_names(served$serving, served$hc_id)
+
+    # fold each served ci = FALSE cell's demand into its serving ci = TRUE cell.
+    served_dem <- dplyr::left_join(
+      served["hc_id"],
+      ci_false[c("hc_id", ".dem_prop", ".dem_em", ".dem_samples")],
+      by = "hc_id"
+    )
+    served_dem$serving <- served$serving
+    fold <- dplyr::summarise(
+      dplyr::group_by(served_dem, serving),
+      add_prop = list(unique(unlist(.dem_prop))),
+      add_em = list(unique(unlist(.dem_em))),
+      add_samp = any(.dem_samples),
+      .groups = "drop"
+    )
+    pos <- match(fold$serving, ci_true$hc_id)
+    for (k in seq_len(nrow(fold))) {
+      i <- pos[[k]]
+      ci_true$.dem_prop[[i]] <- sort(unique(c(
+        ci_true$.dem_prop[[i]],
+        fold$add_prop[[k]]
+      )))
+      ci_true$.dem_em[[i]] <- unique(c(ci_true$.dem_em[[i]], fold$add_em[[k]]))
+      ci_true$.dem_samples[i] <- ci_true$.dem_samples[i] || fold$add_samp[[k]]
+    }
+  }
+  unserved_false <- ci_false[!(ci_false$hc_id %in% names(route)), , drop = FALSE]
+  computed <- dplyr::bind_rows(ci_true, unserved_false)
+
+  serving <- lapply(members, function(s) {
+    ids <- ssd_scenario_hc_tasks(s)$hc_id
+    mapped <- route[ids]
+    ifelse(is.na(mapped), ids, unname(mapped))
+  })
+
+  computed$proportion <- computed$.dem_prop
+  computed$est_method <- computed$.dem_em
+  computed$ci <- computed$.dem_ci
+  computed$samples <- computed$.dem_samples
+  computed <- computed[
+    ,
+    setdiff(names(computed), demand_cols),
+    drop = FALSE
+  ]
+  path_axes <- scenario_partition_axes(ref, "hc")$path
+  grp <- dplyr::group_by(computed, dplyr::across(dplyr::all_of(path_axes)))
+  shards <- dplyr::group_keys(grp)
+  shards$tasks <- dplyr::group_split(grp, .keep = TRUE)
+
+  list(
+    shards = tibble::as_tibble(shards),
+    serving = serving,
+    proportion = lapply(members, function(s) s$hc$proportion),
+    est_method = if (est_method_varies) {
+      lapply(members, function(s) s$hc$est_method)
+    } else {
+      no_filter
+    }
+  )
+}
+
+# ---- normalise an assembly result to a comparable structure -----------------
+
+normalise <- function(res) {
+  # every computed task across all shards -> (hc_id, sorted proportion, sorted
+  # est_method, ci, samples), order-independent.
+  task_rows <- dplyr::bind_rows(res$shards$tasks)
+  has_demand <- all(
+    c("proportion", "est_method", "ci", "samples") %in% names(task_rows)
+  )
+  cells <- if (!has_demand) {
+    # uniform path: no demand columns; key on hc_id alone.
+    data.frame(hc_id = sort(task_rows$hc_id))
+  } else {
+    key <- vapply(
+      seq_len(nrow(task_rows)),
+      function(i) {
+        paste(
+          task_rows$hc_id[[i]],
+          paste(sort(task_rows$proportion[[i]]), collapse = ","),
+          paste(sort(task_rows$est_method[[i]]), collapse = ","),
+          task_rows$ci[[i]],
+          task_rows$samples[[i]],
+          sep = "|"
+        )
+      },
+      character(1L)
+    )
+    sort(key)
+  }
+  serving <- lapply(res$serving, function(x) sort(unname(x)))
+  list(
+    cells = cells,
+    serving = serving,
+    proportion = res$proportion,
+    est_method = res$est_method
+  )
+}
+
+check_equiv <- function(label, design) {
+  ref_members <- function(d) {
+    seeds <- vapply(d, function(s) s$seed, integer(1L))
+    d[seeds == seeds[[1L]]]
+  }
+  members <- ref_members(design)
+  ref <- design_reference_scenario(members)
+  cur <- normalise(design_hc_assembly(members, ref))
+  new_dp <- normalise(assembly_new(members, ref, "duckplyr"))
+  new_pl <- normalise(assembly_new(members, ref, "dplyr"))
+  ok <- identical(cur, new_dp) && identical(cur, new_pl)
+  cat(sprintf("[%s] equivalent: %s\n", label, ok))
+  if (!ok) {
+    cat("  --- current vs duckplyr-new diff ---\n")
+    cat("  cells identical:", identical(cur$cells, new_dp$cells), "\n")
+    cat("  serving identical:", identical(cur$serving, new_dp$serving), "\n")
+    cat(
+      "  proportion identical:",
+      identical(cur$proportion, new_dp$proportion),
+      "\n"
+    )
+    cat(
+      "  est_method identical:",
+      identical(cur$est_method, new_dp$est_method),
+      "\n"
+    )
+  }
+  ok
+}
+
+data <- ssd_scenario_data(a = data.frame(Conc = exp(seq(-1, 2, length.out = 30))))
+pb <- list(
+  sample = c("dataset", "sim"),
+  fit = c("dataset", "sim"),
+  hc = c("dataset", "sim")
+)
+
+# readout-only difference (proportion) -> multi-member hc cells
+d_readout <- ssd_design(
+  lo = ssd_define_scenario(
+    data,
+    nsim = 3L,
+    seed = 42L,
+    nrow = 6L,
+    dists = ssd_distset(lnorm = "lnorm"),
+    proportion = 0.05,
+    partition_by = pb
+  ),
+  hi = ssd_define_scenario(
+    data,
+    nsim = 3L,
+    seed = 42L,
+    nrow = 6L,
+    dists = ssd_distset(lnorm = "lnorm"),
+    proportion = 0.1,
+    partition_by = pb
+  )
+)
+
+# ci mix -> singleton hc cells + routing
+d_ci <- ssd_design(
+  slow = ssd_define_scenario(
+    data,
+    nsim = 4L,
+    seed = 42L,
+    nrow = 6L,
+    dists = ssd_distset(lnorm = "lnorm"),
+    ci = FALSE,
+    partition_by = pb
+  ),
+  fast = ssd_define_scenario(
+    data,
+    nsim = 2L,
+    seed = 42L,
+    nrow = 6L,
+    dists = ssd_distset(lnorm = "lnorm"),
+    ci = TRUE,
+    nboot = 10L,
+    partition_by = pb
+  )
+)
+
+# est_method varies + multi-dist + multiple proportions
+d_em <- ssd_design(
+  m = ssd_define_scenario(
+    data,
+    nsim = 2L,
+    seed = 42L,
+    nrow = 10L,
+    dists = ssd_distset(both = c("lnorm", "gamma")),
+    est_method = "multi",
+    proportion = c(0.05, 0.1),
+    partition_by = pb
+  ),
+  a = ssd_define_scenario(
+    data,
+    nsim = 2L,
+    seed = 42L,
+    nrow = 10L,
+    dists = ssd_distset(both = c("lnorm", "gamma")),
+    est_method = "arithmetic",
+    proportion = c(0.05, 0.2),
+    partition_by = pb
+  )
+)
+
+# distset coverage (uniform readouts -> uniform path)
+d_distset <- ssd_design(
+  one = ssd_define_scenario(
+    data,
+    nsim = 1L,
+    seed = 42L,
+    nrow = 10L,
+    dists = ssd_distset(one = "lnorm"),
+    partition_by = pb
+  ),
+  both = ssd_define_scenario(
+    data,
+    nsim = 1L,
+    seed = 42L,
+    nrow = 10L,
+    dists = ssd_distset(one = "lnorm", two = c("lnorm", "gamma")),
+    partition_by = pb
+  )
+)
+
+cat("\n=== equivalence vs current design_hc_assembly ===\n")
+results <- c(
+  check_equiv("readout-only", d_readout),
+  check_equiv("ci-mix", d_ci),
+  check_equiv("est_method+proportion", d_em),
+  check_equiv("distset (uniform path)", d_distset)
+)
+cat("\nall equivalent:", all(results), "\n")
+
+# ---- benchmark on a large, singleton-heavy design ---------------------------
+
+cat("\n=== benchmark (large singleton-heavy design) ===\n")
+# many sims, two members differing in ci so most hc cells are singletons; a
+# realistic settings-comparison scale.
+big_slow <- ssd_define_scenario(
+  data,
+  nsim = 600L,
+  seed = 42L,
+  nrow = c(5L, 8L),
+  dists = ssd_distset(lnorm = "lnorm"),
+  ci = FALSE,
+  partition_by = pb
+)
+big_fast <- ssd_define_scenario(
+  data,
+  nsim = 30L,
+  seed = 42L,
+  nrow = c(5L, 8L),
+  dists = ssd_distset(lnorm = "lnorm"),
+  ci = TRUE,
+  nboot = 100L,
+  partition_by = pb
+)
+big <- ssd_design(slow = big_slow, fast = big_fast)
+big_members <- big[c("slow", "fast")]
+big_ref <- design_reference_scenario(big_members)
+
+n_tasks <- nrow(ssd_scenario_hc_tasks(big_slow)) +
+  nrow(ssd_scenario_hc_tasks(big_fast))
+cat("total member hc tasks (rows of all_hc):", n_tasks, "\n")
+
+bench <- function(label, f, times = 5L) {
+  f() # warm
+  t <- replicate(times, system.time(f())[["elapsed"]])
+  cat(sprintf("  %-22s median %.3fs  (min %.3f)\n", label, median(t), min(t)))
+}
+bench("current (split+loop)", function() design_hc_assembly(big_members, big_ref))
+bench("new (duckplyr count)", function() {
+  assembly_new(big_members, big_ref, "duckplyr")
+})
+bench("new (dplyr count)", function() {
+  assembly_new(big_members, big_ref, "dplyr")
+})
+
+cat("\nequivalence on the big design:", check_equiv("big", big), "\n")

--- a/openspec/changes/hc-readout-aggregation/exploration/poc-summarise-reduction.R
+++ b/openspec/changes/hc-readout-aggregation/exploration/poc-summarise-reduction.R
@@ -152,7 +152,11 @@ assembly_new <- function(members, ref, count_engine = c("duckplyr", "dplyr")) {
       ci_true$.dem_samples[i] <- ci_true$.dem_samples[i] || fold$add_samp[[k]]
     }
   }
-  unserved_false <- ci_false[!(ci_false$hc_id %in% names(route)), , drop = FALSE]
+  unserved_false <- ci_false[
+    !(ci_false$hc_id %in% names(route)),
+    ,
+    drop = FALSE
+  ]
   computed <- dplyr::bind_rows(ci_true, unserved_false)
 
   serving <- lapply(members, function(s) {
@@ -165,8 +169,7 @@ assembly_new <- function(members, ref, count_engine = c("duckplyr", "dplyr")) {
   computed$est_method <- computed$.dem_em
   computed$ci <- computed$.dem_ci
   computed$samples <- computed$.dem_samples
-  computed <- computed[
-    ,
+  computed <- computed[,
     setdiff(names(computed), demand_cols),
     drop = FALSE
   ]
@@ -255,7 +258,9 @@ check_equiv <- function(label, design) {
   ok
 }
 
-data <- ssd_scenario_data(a = data.frame(Conc = exp(seq(-1, 2, length.out = 30))))
+data <- ssd_scenario_data(
+  a = data.frame(Conc = exp(seq(-1, 2, length.out = 30)))
+)
 pb <- list(
   sample = c("dataset", "sim"),
   fit = c("dataset", "sim"),
@@ -397,7 +402,9 @@ bench <- function(label, f, times = 5L) {
   t <- replicate(times, system.time(f())[["elapsed"]])
   cat(sprintf("  %-22s median %.3fs  (min %.3f)\n", label, median(t), min(t)))
 }
-bench("current (split+loop)", function() design_hc_assembly(big_members, big_ref))
+bench("current (split+loop)", function() {
+  design_hc_assembly(big_members, big_ref)
+})
 bench("new (duckplyr count)", function() {
   assembly_new(big_members, big_ref, "duckplyr")
 })

--- a/openspec/changes/hc-readout-aggregation/tasks.md
+++ b/openspec/changes/hc-readout-aggregation/tasks.md
@@ -2,24 +2,24 @@
 
 ## 1. Per-task readout overrides on the hc runner
 
-- [ ] 1.1 Extend `ssd_run_hc_step()` (`R/targets-runner.R`) to read optional
+- [x] 1.1 Extend `ssd_run_hc_step()` (`R/targets-runner.R`) to read optional
       per-task `est_method`/`proportion`/`ci`/`samples` demand from the shard's
       `tasks` columns, falling back to the scenario slice when absent
-- [ ] 1.2 Confirm the single-scenario factory and `ssd_run_scenario_shards()` path
+- [x] 1.2 Confirm the single-scenario factory and `ssd_run_scenario_shards()` path
       pass no per-task overrides, so their hc results stay byte-identical (existing
       tests pass untouched, no snapshot churn)
 
 ## 2. Per-overlap demand reduction in the design factory
 
-- [ ] 2.1 In `ssd_design_targets()`/`design_reference_scenario()`
+- [x] 2.1 In `ssd_design_targets()`/`design_reference_scenario()`
       (`R/design-targets.R`), drop `require_uniform()` for the shareable settings —
       `proportion`, `est_method`, `ci`, `samples`, and the fit `dists` union —
       keeping it only for `nrow_max` and `partition_by`
-- [ ] 2.2 Union the members' hc tasks tagged with each member's readout demand and
+- [x] 2.2 Union the members' hc tasks tagged with each member's readout demand and
       group by the hc cell (`fit` identity + `nboot`/`ci_method`/`parametric`/
       `distset`); reduce per cell: `union` `proportion`/`est_method`, `any`
       `ci`/`samples`; attach the reduced demand to the shard tasks
-- [ ] 2.3 Reconcile differing fit `dists` unions: fit the **design-wide union** of
+- [x] 2.3 Reconcile differing fit `dists` unions: fit the **design-wide union** of
       the members' `dists` once per fit cell and let each member subset via its
       `distset` axis (sound by distset-subset-invariance — fitting extra dists does
       not change a member's subset hc), so members differing in `distset` coverage
@@ -27,25 +27,25 @@
 
 ## 3. ci NA-collapse routing
 
-- [ ] 3.1 Compute the hc shard set as every `ci = TRUE` member's cells plus the
+- [x] 3.1 Compute the hc shard set as every `ci = TRUE` member's cells plus the
       `ci = FALSE` cells with no overlapping `ci = TRUE` shard at the same
       `(fit-id, distset)`
-- [ ] 3.2 Route each member's `ci = FALSE` hc tasks to the coincident `ci = TRUE`
+- [x] 3.2 Route each member's `ci = FALSE` hc tasks to the coincident `ci = TRUE`
       serving shard when present (for the per-member summary filter), else to the
       standalone `ci = FALSE` shard
 
 ## 4. Tests
 
-- [ ] 4.1 Flip the `scenario-combine` "members differ in hc readouts abort" test:
+- [x] 4.1 Flip the `scenario-combine` "members differ in hc readouts abort" test:
       a readout-only design now returns targets and runs; each member's summary
       carries exactly its requested `proportion`/`est_method`/`ci`/`samples` rows
-- [ ] 4.2 The motivating example: `ci = FALSE, nsim = 1000` vs `ci = TRUE,
+- [x] 4.2 The motivating example: `ci = FALSE, nsim = 1000` vs `ci = TRUE,
       nsim = 10` builds `ci = TRUE` hc shards only for the 10 overlapping sims and
       `ci = FALSE` for the rest; the `ci = FALSE` member's overlapping `est` equals
       its standalone `ci = FALSE` value
-- [ ] 4.3 Byte-identity: a `ci = TRUE` member's CI matches its standalone run; the
+- [x] 4.3 Byte-identity: a `ci = TRUE` member's CI matches its standalone run; the
       single-scenario hc path is unchanged
-- [ ] 4.4 distset-coverage sharing (moved from `scenario-combine` task 7.4): two
+- [x] 4.4 distset-coverage sharing (moved from `scenario-combine` task 7.4): two
       members differing only in `distset` coverage (hence in their fit `dists`
       union) share every `sample`/`fit` shard (one design-wide union fit) and
       differ only in their `distset` hc cells; each member's hc subset equals its
@@ -53,9 +53,9 @@
 
 ## 5. Docs
 
-- [ ] 5.1 Update `ssd_design_targets()` roxygen (per-overlap aggregation + the
+- [x] 5.1 Update `ssd_design_targets()` roxygen (per-overlap aggregation + the
       `ci`-routing); regenerate `man/`
-- [ ] 5.2 Add a setting-comparison section to `vignettes/sharded-pipeline.qmd`
+- [x] 5.2 Add a setting-comparison section to `vignettes/sharded-pipeline.qmd`
       (building on the irregular-grid section); `ROADMAP.md`
-- [ ] 5.3 Format with `air`, run `devtools::check()`, confirm no ssdtools edit and
+- [x] 5.3 Format with `air`, run `devtools::check()`, confirm no ssdtools edit and
       `ssd_scenario_targets()` contract unchanged

--- a/tests/testthat/_snaps/design-targets.md
+++ b/tests/testthat/_snaps/design-targets.md
@@ -1,0 +1,8 @@
+# scenario-combine: members sharing a seed must agree on nrow_max
+
+    Code
+      ssd_design_targets(ssd_design(a = a, b = b))
+    Condition
+      Error in `ssd_design_targets()`:
+      ! Members sharing a seed must agree on `nrow_max`; scenario seed 42 has divergent `nrow_max`.
+

--- a/tests/testthat/fixtures/design-ci-mixed-targets.R
+++ b/tests/testthat/fixtures/design-ci-mixed-targets.R
@@ -1,0 +1,37 @@
+# Test fixture: the motivating mix - a `ci = FALSE` member over more sims beside a
+# `ci = TRUE` member over fewer. The overlapping sims bootstrap once (under
+# `ci = TRUE`); the `ci = FALSE` member reads its (analytical, ci-invariant) `est`
+# from those shards, and the non-overlapping sims stay `ci = FALSE`.
+# Used by test-design-targets.R.
+library(targets)
+library(tarchetypes)
+library(ssdsims)
+
+d <- readRDS("data.rds")
+pb <- list(
+  sample = c("dataset", "sim"),
+  fit = c("dataset", "sim"),
+  hc = c("dataset", "sim")
+)
+
+slow <- ssd_define_scenario(
+  ssd_scenario_data(a = d),
+  nsim = 4L,
+  seed = 42L,
+  nrow = 6L,
+  dists = ssd_distset(lnorm = "lnorm"),
+  ci = FALSE,
+  partition_by = pb
+)
+fast <- ssd_define_scenario(
+  ssd_scenario_data(a = d),
+  nsim = 2L,
+  seed = 42L,
+  nrow = 6L,
+  dists = ssd_distset(lnorm = "lnorm"),
+  ci = TRUE,
+  nboot = 10L,
+  partition_by = pb
+)
+
+ssd_design_targets(ssd_design(slow = slow, fast = fast), root = "results")

--- a/tests/testthat/fixtures/design-distset-targets.R
+++ b/tests/testthat/fixtures/design-distset-targets.R
@@ -1,0 +1,34 @@
+# Test fixture: two members of a seed group that differ ONLY in their `distset`
+# coverage (hence in their fit `dists` union). They share every sample/fit shard
+# (one design-wide union fit of {lnorm, gamma}) and differ only in their `distset`
+# hc cells; each member's hc subset equals its standalone run.
+# Used by test-design-targets.R.
+library(targets)
+library(tarchetypes)
+library(ssdsims)
+
+d <- readRDS("data.rds")
+pb <- list(
+  sample = c("dataset", "sim"),
+  fit = c("dataset", "sim"),
+  hc = c("dataset", "sim")
+)
+
+one <- ssd_define_scenario(
+  ssd_scenario_data(a = d),
+  nsim = 1L,
+  seed = 42L,
+  nrow = 10L,
+  dists = ssd_distset(one = "lnorm"),
+  partition_by = pb
+)
+both <- ssd_define_scenario(
+  ssd_scenario_data(a = d),
+  nsim = 1L,
+  seed = 42L,
+  nrow = 10L,
+  dists = ssd_distset(one = "lnorm", two = c("lnorm", "gamma")),
+  partition_by = pb
+)
+
+ssd_design_targets(ssd_design(one = one, both = both), root = "results")

--- a/tests/testthat/fixtures/design-readout-proportion-targets.R
+++ b/tests/testthat/fixtures/design-readout-proportion-targets.R
@@ -1,0 +1,35 @@
+# Test fixture: two members of a seed group that differ ONLY in a readout
+# (`proportion`) - otherwise a coincident hc cell. The cell is one shared shard
+# carrying the union of the proportions; each member's summary filters its slice.
+# Used by test-design-targets.R.
+library(targets)
+library(tarchetypes)
+library(ssdsims)
+
+d <- readRDS("data.rds")
+pb <- list(
+  sample = c("dataset", "sim"),
+  fit = c("dataset", "sim"),
+  hc = c("dataset", "sim")
+)
+
+lo <- ssd_define_scenario(
+  ssd_scenario_data(a = d),
+  nsim = 1L,
+  seed = 42L,
+  nrow = 6L,
+  dists = ssd_distset(lnorm = "lnorm"),
+  proportion = 0.05,
+  partition_by = pb
+)
+hi <- ssd_define_scenario(
+  ssd_scenario_data(a = d),
+  nsim = 1L,
+  seed = 42L,
+  nrow = 6L,
+  dists = ssd_distset(lnorm = "lnorm"),
+  proportion = 0.1,
+  partition_by = pb
+)
+
+ssd_design_targets(ssd_design(lo = lo, hi = hi), root = "results")

--- a/tests/testthat/test-design-targets.R
+++ b/tests/testthat/test-design-targets.R
@@ -23,12 +23,23 @@ test_that("ssd_design_targets validates its inputs", {
   expect_error(ssd_design_targets(d, upload = "nope"), "upload")
 })
 
-test_that("members sharing a seed must agree on hc readouts (for now)", {
+test_that("scenario-combine: members differing in hc readouts no longer abort", {
   data <- ssd_scenario_data(d = numeric_dataset())
   a <- ssd_define_scenario(data, nsim = 1L, seed = 42L, ci = FALSE)
   b <- ssd_define_scenario(data, nsim = 1L, seed = 42L, ci = TRUE)
   design <- ssd_design(a = a, b = b)
-  expect_error(ssd_design_targets(design), "ci")
+  targets <- ssd_design_targets(design)
+  expect_type(targets, "list")
+  expect_gt(length(targets), 0L)
+})
+
+test_that("scenario-combine: members sharing a seed must agree on nrow_max", {
+  data <- ssd_scenario_data(d = numeric_dataset())
+  a <- ssd_define_scenario(data, nsim = 1L, seed = 42L, nrow_max = 10L)
+  b <- ssd_define_scenario(data, nsim = 1L, seed = 42L, nrow_max = 12L)
+  expect_snapshot(error = TRUE, {
+    ssd_design_targets(ssd_design(a = a, b = b))
+  })
 })
 
 # ---- upload shape (no pipeline) --------------------------------------------
@@ -258,4 +269,151 @@ test_that("members with distinct seeds land under separate seed= trees", {
 
   summary <- ssd_read_parquet("results/summary.parquet")
   expect_setequal(unique(summary$scenario), c("a", "b"))
+})
+
+# ---- per-overlap hc readout aggregation ------------------------------------
+
+# Unnest a baseline run's hc estimates into one (fit_id, proportion, est) table -
+# the byte-identity oracle for a member's standalone hc results.
+baseline_hc <- function(scenario) {
+  out <- ssd_run_scenario_baseline(scenario)$hc
+  purrr::list_rbind(purrr::map(seq_len(nrow(out)), function(i) {
+    h <- out$hc[[i]]
+    tibble::tibble(
+      fit_id = out$fit_id[[i]],
+      proportion = h$proportion,
+      est = h$est
+    )
+  }))
+}
+
+run_design_fixture <- function(fixture) {
+  dir <- withr::local_tempdir()
+  file.copy(test_path("fixtures", fixture), file.path(dir, "_targets.R"))
+  withr::local_dir(dir)
+  saveRDS(numeric_dataset(), "data.rds")
+  tar_make_local()
+  ssd_read_parquet("results/summary.parquet")
+}
+
+test_that("scenario-combine: readout-only members share the hc cell, filtered", {
+  skip_targets()
+  summary <- run_design_fixture("design-readout-proportion-targets.R")
+
+  lo <- summary[summary$scenario == "lo", ]
+  hi <- summary[summary$scenario == "hi", ]
+  # Each member's summary carries exactly its requested proportion.
+  expect_equal(unique(lo$proportion), 0.05)
+  expect_equal(unique(hi$proportion), 0.1)
+  # ... reading the SAME shared hc cell (proportion is not part of the hc_id).
+  expect_setequal(lo$hc_id, hi$hc_id)
+})
+
+test_that("scenario-combine: a ci mix bootstraps only the overlapping cells", {
+  skip_targets()
+  summary <- run_design_fixture("design-ci-mixed-targets.R")
+
+  slow <- summary[summary$scenario == "slow", ]
+  sim_of <- function(ids) sub(".*sim=([0-9]+).*", "\\1", ids)
+  # Only the overlapping sims (1, 2) carry a bootstrap (nboot == 10); the rest are
+  # computed ci = FALSE (nboot == 0).
+  bootstrapped <- summary$nboot == 10L
+  expect_setequal(sim_of(summary$hc_id[bootstrapped]), c("1", "2"))
+  expect_setequal(sim_of(summary$hc_id[!bootstrapped]), c("3", "4"))
+
+  # The ci = FALSE member's `est` equals its standalone ci = FALSE value, for the
+  # served (overlapping) sims and the un-served ones alike (keyed by the
+  # ci-independent fit_id + proportion).
+  oracle <- baseline_hc(ssd_define_scenario(
+    ssd_scenario_data(a = numeric_dataset()),
+    nsim = 4L,
+    seed = 42L,
+    nrow = 6L,
+    dists = ssd_distset(lnorm = "lnorm"),
+    ci = FALSE,
+    partition_by = design_pb
+  ))
+  m <- merge(
+    slow[, c("fit_id", "proportion", "est")],
+    oracle,
+    by = c("fit_id", "proportion"),
+    suffixes = c("_design", "_alone")
+  )
+  expect_equal(nrow(m), nrow(oracle))
+  expect_equal(m$est_design, m$est_alone)
+})
+
+test_that("scenario-combine: a ci = TRUE member's CI matches its standalone run", {
+  skip_targets()
+  summary <- run_design_fixture("design-ci-mixed-targets.R")
+  fast <- summary[summary$scenario == "fast", ]
+
+  oracle <- ssd_run_scenario_baseline(ssd_define_scenario(
+    ssd_scenario_data(a = numeric_dataset()),
+    nsim = 2L,
+    seed = 42L,
+    nrow = 6L,
+    dists = ssd_distset(lnorm = "lnorm"),
+    ci = TRUE,
+    nboot = 10L,
+    partition_by = design_pb
+  ))$hc
+  orows <- purrr::list_rbind(purrr::map(seq_len(nrow(oracle)), function(i) {
+    h <- oracle$hc[[i]]
+    tibble::tibble(hc_id = oracle$hc_id[[i]], lcl = h$lcl, ucl = h$ucl)
+  }))
+  m <- merge(
+    fast[, c("hc_id", "lcl", "ucl")],
+    orows,
+    by = "hc_id",
+    suffixes = c("_design", "_alone")
+  )
+  expect_gt(nrow(m), 0L)
+  expect_equal(m$lcl_design, m$lcl_alone)
+  expect_equal(m$ucl_design, m$ucl_alone)
+})
+
+test_that("scenario-combine: distset-coverage members share sample and fit", {
+  skip_targets()
+  dir <- withr::local_tempdir()
+  file.copy(
+    test_path("fixtures", "design-distset-targets.R"),
+    file.path(dir, "_targets.R")
+  )
+  withr::local_dir(dir)
+  saveRDS(numeric_dataset(), "data.rds")
+  tar_make_local()
+
+  progress <- targets::tar_progress()
+  built <- progress$name[progress$progress %in% c("completed", "built")]
+  # One member-shared cell (a, 1): a single sample and fit shard (the design-wide
+  # union fit), shared by both members.
+  expect_length(grep("^sample_step_", built), 1L)
+  expect_length(grep("^fit_step_", built), 1L)
+
+  summary <- ssd_read_parquet("results/summary.parquet")
+  one <- summary[summary$scenario == "one", ]
+  both <- summary[summary$scenario == "both", ]
+  # `one` covers only its single distset; `both` covers both.
+  expect_setequal(unique(one$distset), "one")
+  expect_setequal(unique(both$distset), c("one", "two"))
+
+  # Each member's hc subset equals its standalone run (distset-subset-invariance:
+  # the union fit subset to a member's distset matches fitting that set alone).
+  oracle <- baseline_hc(ssd_define_scenario(
+    ssd_scenario_data(a = numeric_dataset()),
+    nsim = 1L,
+    seed = 42L,
+    nrow = 10L,
+    dists = ssd_distset(one = "lnorm"),
+    partition_by = design_pb
+  ))
+  m <- merge(
+    one[, c("fit_id", "proportion", "est")],
+    oracle,
+    by = c("fit_id", "proportion"),
+    suffixes = c("_design", "_alone")
+  )
+  expect_equal(nrow(m), nrow(oracle))
+  expect_equal(m$est_design, m$est_alone)
 })

--- a/vignettes/sharded-pipeline.qmd
+++ b/vignettes/sharded-pipeline.qmd
@@ -285,6 +285,35 @@ fans in one combined `summary.parquet` with a `scenario` identity column. Growin
 a one-off run into a design is a one-line switch; see
 ["From a Single Scenario to a Design"](scenario-to-design.html).
 
+### Comparing settings in one design
+
+A design also serves the *secondary* use of comparing **settings** at the same
+cells. Members of a seed group may differ in the four non-axis hc readouts
+(`proportion`, `est_method`, `ci`, `samples`) and in their fit `dists` union ---
+only the layout-shaping `nrow_max` and `partition_by` must agree. Differing
+readouts are reconciled **per shared hc cell**: `proportion`/`est_method` are
+unioned and `ci`/`samples` reduced with `any()`, so the cell computes the maximal
+readout set in one shard and each member's summary filters its own slice.
+
+This is what makes a cheap-versus-expensive comparison economical. Put a
+broad `ci = FALSE` member beside a narrow `ci = TRUE` one --- say a point-estimate
+sweep over many sims and a confidence-interval check over a handful:
+
+```r
+broad  <- ssd_define_scenario(data, nsim = 1000L, seed = 42L, ci = FALSE)
+narrow <- ssd_define_scenario(data, nsim = 10L,  seed = 42L, ci = TRUE, nboot = 1000L)
+ssd_design_targets(ssd_design(broad = broad, narrow = narrow))
+```
+
+The expensive bootstrap runs **only** on the 10 overlapping sims (where `narrow`
+has tasks); the other 990 stay `ci = FALSE`. The `ci = FALSE` member reads its
+(analytical, ci-invariant) point `est` for the overlapping sims straight from the
+`ci = TRUE` shards rather than recomputing them. Members differing only in their
+`distset` coverage likewise share every `sample`/`fit` shard (one design-wide
+union fit, each member subsetting via its `distset` axis) and differ only in their
+`distset` hc cells. In every case a member's per-task results are byte-identical
+to its standalone run.
+
 ## See also
 
 - ["From a Single Scenario to a Design"](scenario-to-design.html) --- union


### PR DESCRIPTION
Implements the `hc-readout-aggregation` OpenSpec change: design members that
share a `seed` may now differ in the four **non-axis** hc readout settings
(`proportion`, `est_method`, `ci`, `samples`) and in their fit `dists` union.
Previously `ssd_design_targets()` aborted via `require_uniform()`; they are now
reconciled per shared hc cell instead. Only the layout-shaping `nrow_max` and
`partition_by` stay uniform-required.

## What changed

- **`ssd_run_hc_step()` per-task readout overrides** (`R/targets-runner.R`).
  The runner reads optional per-task `proportion`/`est_method`/`ci`/`samples`
  demand from the shard's `tasks`, defaulting to the scenario slice when absent.
  The single-scenario and standalone paths pass no overrides, so their hc
  results stay **byte-identical** (no new shard columns, no snapshot churn).

- **Per-overlap demand reduction** (`R/design-targets.R`, `design_hc_assembly()`).
  Members' hc tasks are unioned, tagged with each member's readout demand, and
  grouped by hc **cell** (`hc_id` = fit identity + `nboot`/`ci_method`/
  `parametric`/`distset`). Per cell the demand is reduced — `union`
  `proportion`/`est_method`, `any` `ci`/`samples` — and attached to the shard's
  tasks, so the cell computes the maximal readout set once and each member's
  summary filters its slice. The draw-shaping axes are **not** aggregated (they
  stay in the per-task primer), preserving byte-identity.

- **`ci` NA-collapse routing.** A `ci = FALSE` cell is served by a coincident
  `ci = TRUE` shard at the same `(fit, distset)` when one exists (it reads the
  analytical, ci-invariant `est` from there); only otherwise is a standalone
  `ci = FALSE` shard minted. The bootstrap therefore runs only where a
  `ci = TRUE` member has tasks.

- **Design-wide union fit** for differing `dists` unions: fit the union once per
  fit cell, each member subsetting via its `distset` axis
  (distset-subset-invariance), so members differing only in `distset` coverage
  share every `sample`/`fit` shard.

- **`ssd_summarise_member()`** gains optional `proportion`/`est_method` filters
  and keys on each member's *serving* hc ids (its own cells plus the routed
  `ci = TRUE` cells).

When members agree on the readouts (including a design of one), the existing
cell-union path is taken unchanged — byte-identical and cache-compatible with a
standalone run.

## Tests

- The previously-aborting "members differ in hc readouts" test flips from
  expect-error to expect-success; a new snapshot pins the remaining `nrow_max`
  uniformity abort.
- Readout-only members share one hc cell, each summary filtered to its
  requested rows.
- The motivating `ci = FALSE` vs `ci = TRUE` mix bootstraps only the
  overlapping sims; the `ci = FALSE` member's `est` equals its standalone value.
- A `ci = TRUE` member's CI matches its standalone run.
- distset-coverage members share `sample`/`fit` shards; each member's hc subset
  equals its standalone run.

`devtools::check()` is clean (0 errors / 0 warnings / 0 notes, modulo the
environmental `qpdf` warning). No ssdtools change; the `ssd_scenario_targets()`
contract is unchanged.

https://claude.ai/code/session_01DvzwjnvbgCXxzMc2H6HMLH

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvzwjnvbgCXxzMc2H6HMLH)_