### PR TITLE
perf: cut per-task and per-target overhead in the targets DAG build

### DIFF
--- a/R/design-targets.R
+++ b/R/design-targets.R
@@ -579,7 +579,12 @@ design_group_targets <- function(members, ref, sroot, upload, cue) {
       cue = cue
     )
     if (is.null(upload)) {
-      return(tarchetypes::tar_map(values = shards, names = nms, step_target))
+      return(tarchetypes::tar_map(
+        values = shards,
+        names = nms,
+        descriptions = tidyselect::all_of(character(0)),
+        step_target
+      ))
     }
     upload_target <- targets::tar_target_raw(
       paste0("upload_", step),
@@ -594,6 +599,7 @@ design_group_targets <- function(members, ref, sroot, upload, cue) {
     tarchetypes::tar_map(
       values = shards,
       names = nms,
+      descriptions = tidyselect::all_of(character(0)),
       step_target,
       upload_target
     )

--- a/R/targets-runner.R
+++ b/R/targets-runner.R
@@ -936,6 +936,7 @@ ssd_scenario_targets <- function(
         names = tidyselect::all_of(
           c("seed", scenario_partition_axes(scenario, step)$path)
         ),
+        descriptions = tidyselect::all_of(character(0)),
         step_target
       ))
     }
@@ -954,6 +955,7 @@ ssd_scenario_targets <- function(
       names = tidyselect::all_of(
         c("seed", scenario_partition_axes(scenario, step)$path)
       ),
+      descriptions = tidyselect::all_of(character(0)),
       step_target,
       upload_target
     )

--- a/R/task-lists.R
+++ b/R/task-lists.R
@@ -320,9 +320,29 @@ ssd_run_scenario_baseline <- function(scenario) {
 # (CLAUDE.md error-call-origin rule).
 task_primers <- function(tbl, step) {
   axes <- task_axes(step)
-  primers <- vector("list", nrow(tbl))
-  for (i in seq_len(nrow(tbl))) {
-    primers[[i]] <- task_primer(tbl[i, axes])
+  n <- nrow(tbl)
+  cols <- lapply(axes, function(a) tbl[[a]])
+  is_df <- vapply(cols, is.data.frame, logical(1L))
+  is_lst <- vapply(
+    cols,
+    function(v) is.list(v) && !is.data.frame(v),
+    logical(1L)
+  )
+  primers <- vector("list", n)
+  for (i in seq_len(n)) {
+    row <- vector("list", length(axes))
+    names(row) <- axes
+    for (j in seq_along(cols)) {
+      v <- cols[[j]]
+      row[[j]] <- if (is_df[[j]]) {
+        v[i, , drop = FALSE]
+      } else if (is_lst[[j]]) {
+        v[[i]]
+      } else {
+        v[[i]]
+      }
+    }
+    primers[[i]] <- task_primer(row)
   }
   primers
 }


### PR DESCRIPTION
## What

Two further, **DAG-preserving** speedups to building the
`ssd_design_targets()` / `ssd_scenario_targets()` targets DAG, on top of the
vectorised design-hc reduction already on this branch (`ea58418`).

This PR is **stacked on #182** (base = `claude/awesome-lamport-8jko1p`) because
it builds directly on that branch's `design_hc_assembly()` work; it should be
reviewed/merged after #182 (or retargeted to `main` once #182 lands).

## Why

Profiling the `crew-ssdsims-rc` example (`ssdsims-org`), a `ssd_design()` of
three members that expands to **~20,000 targets** (~58k hc tasks), showed the
DAG build — the work `tar_make()` does before any target can be scheduled on
the cluster — was dominated by avoidable per-row and per-target work:

| State | DAG build (median, 3 reps) |
|---|---|
| `main` | **errors** — the example's non-uniform `samples` needs the design hc-readout aggregation, absent on `main` |
| original branch (`b12d483`, pre-vectorisation) | ~156 s |
| this branch before the PR (`ea58418`) | ~131 s |
| **with this PR** | **~105 s** |

So this PR is **~131 s → ~105 s (−20%)** on the current branch, and **~156 s →
~105 s (−33%)** measured from the pre-aggregation baseline. The residual
(~95 s) is `targets`/`tarchetypes` per-target dependency analysis
(`codetools::findGlobals`), intrinsic to the target count — not reducible
without changing the sharding/invalidation design.

## Changes

1. **`task_primers()` (`R/task-lists.R`)** — extract the `task_axes()` columns
   once and assemble each row's canonical hash input directly, instead of
   slicing the tibble one row at a time (`tbl[i, axes]`) and normalising it with
   `purrr::map()`. The hash input — and therefore every primer, RNG stream, and
   shard identity — is unchanged; only the per-row tibble/`purrr` overhead is
   removed. This is the hot loop when a step fans out to tens of thousands of
   tasks.

2. **`tar_map(descriptions = …)` (`R/design-targets.R`, `R/targets-runner.R`)** —
   pass a "select none" `descriptions` so `tarchetypes::tar_map()` no longer
   deparses the heavy `tasks` / `.slice` / `.parents` list-columns into each
   target's `description` string. Descriptions are cosmetic metadata and do not
   affect target identity or invalidation.

## Correctness

- **Byte-identical DAG**: hashing every target's `(name, format, command)` over
  the full `crew-ssdsims-rc` design gives the *same* overall signature with and
  without this PR (`67cec4c…`), across all ~20,000 targets — only the
  (excluded-from-hash) `description` differs.
- **Primers identical**: the new `task_primers()` is verified equal, element for
  element, to the previous per-row `task_primer(tbl[i, axes])` on the real
  `sample`/`fit`/`hc` tables.
- `test-task-primer`, `test-task-shards`, and `test-design-targets` all pass
  (`NOT_CRAN=true`), including the "design per-task hc results equal a standalone
  run" semantic checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dH969CLqwnUX6mBGQ2wRG

---
_Generated by [Claude Code](https://claude.ai/code/session_016dH969CLqwnUX6mBGQ2wRG)_