### PR TITLE
Remove committed Claude Code permissions from .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,32 +1,3 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "permissions": {
-    "defaultMode": "acceptEdits",
-    "allow": [
-      "Bash(air:*)",
-      "Bash(cat:*)",
-      "Bash(find:*)",
-      "Bash(gh issue list:*)",
-      "Bash(gh issue view:*)",
-      "Bash(gh pr diff:*)",
-      "Bash(gh pr view:*)",
-      "Bash(git checkout:*)",
-      "Bash(git grep:*)",
-      "Bash(grep:*)",
-      "Bash(ls:*)",
-      "Bash(quarto:*)",
-      "Bash(R:*)",
-      "Bash(rm:*)",
-      "Bash(Rscript:*)",
-      "Bash(sed:*)",
-      "Skill",
-      "WebFetch(domain:cran.r-project.org)",
-      "WebFetch(domain:github.com)",
-      "WebFetch(domain:raw.githubusercontent.com)"
-    ],
-    "deny": [
-      "Read(.Renviron)",
-      "Read(.env)"
-    ]
-  }
+  "$schema": "https://json.schemastore.org/claude-code-settings.json"
 }


### PR DESCRIPTION
Empties the committed `permissions` block in `.claude/settings.json` so the repo relies on each developer's personal `~/.claude/settings.json` instead of a shared committed allow/deny list.

This also removes the `Read(.Renviron)` / `Read(.env)` deny rules and `defaultMode: acceptEdits` — flagged for owner review.

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)