### PR TITLE
docs(openspec): propose stingy-duckplyr-pipeline for stingy DuckDB execution

### DIFF
--- a/openspec/changes/stingy-duckplyr-pipeline/.openspec.yaml
+++ b/openspec/changes/stingy-duckplyr-pipeline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-22

--- a/openspec/changes/stingy-duckplyr-pipeline/design.md
+++ b/openspec/changes/stingy-duckplyr-pipeline/design.md
@@ -1,0 +1,126 @@
+## Context
+
+The pipeline reads and writes Parquet through a thin duckplyr seam
+(`ssd_read_parquet()`/`ssd_write_parquet()`) and fans shards in through three
+never-collected DuckDB pipelines (`ssd_summarise()`,
+`ssd_summarise_member()`, `ssd_summarise_design()`). Today those frames carry
+duckplyr's default prudence — `lavish` for `as_duckdb_tibble()`, `thrifty`
+for `read_parquet_duckdb()` — which permits two silent hazards:
+
+1. **Accidental materialisation.** A stray `nrow()`/`$`/`[[` pulls a shard
+   union into R. On the one-CPU/1-GB cluster worker that is the OOM the
+   `duckplyr-config` change already fights with thread/memory caps.
+2. **Silent dplyr fallback.** An un-translatable verb makes duckplyr
+   materialise columns and run the op in R, leaving DuckDB without a sound —
+   the opposite of "compute everything in DuckDB".
+
+`prudence = "stingy"` forbids both: a stingy frame never auto-materialises and
+cannot fall back (a fallback needs materialised columns first), so an
+unsupported verb errors loudly. `collect()` still works on a stingy frame
+(duckplyr promotes it to `lavish` for that one call), so "collect only when R
+needs the rows" is exactly the stingy contract.
+
+A spike (preserved in `exploration/`) applied stingy to all three fan-in reads
+plus a prudence-preserving write seam, reinstalled, and ran the `NOT_CRAN`
+suites: `test-design-targets` 25/0, `test-run-scenario` 15/0,
+`test-cost-analysis` 13/0, with the same 6 pre-existing (unrelated) baseline
+failures and **zero** new ones. The fan-in verbs (`select(any_of)`,
+`filter(%in%)`, constant `mutate`, `union_all`, `compute_parquet`) all execute
+in DuckDB — no `dd$` rescue is needed there.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make stingy the prudence of every internal pipeline duckplyr frame, so
+  no implicit materialisation and no silent fallback are possible.
+- Keep R-boundary collection **explicit** (decode `fit` objects; the
+  cost-analysis timing reads) — stingy read, intentional `collect()`.
+- Push the cost-analysis per-task duration math into DuckDB with the `dd$`
+  escape hatch instead of `difftime()` in R.
+- Give the upload read-back generics a stingy default with a `lavish`
+  opt-out, preserving their lazy/composable contract.
+- Reshape every touched nested call into a native `|>` pipeline.
+
+**Non-Goals:**
+
+- Changing any result. Stingy alters *when/whether* materialisation happens,
+  never the rows; the `duckplyr-config` value-identity guarantee is unchanged.
+- Re-piping flat stepwise code that is not deeply nested (the fan-in bodies
+  are already stepwise reassignments and stay as-is).
+- Removing or weakening the `skip_on_cran()` gate on the slow targets
+  pipeline tests — it is correct and unrelated to this change.
+
+## Decisions
+
+### D1. Stingy on the three never-collected fan-in reads
+Thread `prudence = "stingy"` into the `read_parquet_duckdb()` call in
+`ssd_summarise()`, `ssd_summarise_member()`, and `ssd_summarise_design()`.
+These never `collect()`, so stingy is a pure contract upgrade — proven safe by
+the spike. *Alternative considered:* leave them `thrifty` and add a test that
+asserts no fallback. Rejected — `thrifty` still permits a future fallback to
+materialise silently; stingy makes the engine itself the enforcer.
+
+### D2. The write seam preserves prudence
+`ssd_write_parquet()` currently does
+`compute_parquet(as_duckdb_tibble(df), path)`. `as_duckdb_tibble()` defaults to
+`lavish`, so it **downgrades a stingy fan-in frame to lavish right before the
+write** — masking exactly the fallback stingy is meant to catch (the spike
+surfaced this). New behaviour: if `df` is already a `duckplyr_df`, pass it to
+`compute_parquet()` unchanged (keeping its prudence); otherwise wrap a plain R
+tibble as `stingy`. *Alternative:* always force stingy. Rejected — re-wrapping
+an existing frame is what loses its prudence; pass-through is both simpler and
+correct.
+
+### D3. Explicit collect at the R boundaries, stingy read
+`ssd_read_parquet()` and the cost-analysis reads genuinely need rows in R
+(decoding `fit` objects; computing/returning timings). Keep the explicit
+`collect()`; switch the read to `stingy` so nothing materialises implicitly
+between read and the deliberate collect. `collect()` on a stingy frame is the
+sanctioned escape, so this composes cleanly.
+
+### D4. In-engine duration math via `dd$epoch`
+The cost-analysis reads compute `seconds = as.numeric(difftime(.end, .start))`
+in R after `collect()`. Move it before the collect as
+`mutate(seconds = dd$epoch(.end) - dd$epoch(.start))`. `dd$epoch()` on a
+`TIMESTAMP` returns fractional seconds since the epoch, so the difference is
+sub-second-exact (a standalone probe returned `1.25` for a 1.25 s gap, matching
+`difftime(units = "secs")`). `dd$` resolves symbolically inside duckplyr's
+translation layer — no `dd` package is needed at runtime; the symbol is never
+evaluated as an R object, so `@autoglobal`/`globalVariables` handling for `dd`
+must be confirmed under `R CMD check` (see Risks). *Alternative:*
+`dd$date_diff('second', ...)` — rejected, it truncates to whole seconds.
+
+### D5. Upload generics: stingy default + lavish opt-out
+`ssd_open_uploaded()` and `ssd_summarise_uploaded()` gain
+`prudence = "stingy"`, threaded into their `read_parquet_duckdb()` calls. The
+returned table stays lazy and composable (`collect()`/`compute_parquet()`
+unchanged), but an accidental `nrow()` on a remote glob now errors instead of
+downloading. `prudence = "lavish"` restores the prior auto-materialising
+behaviour for callers who want it. *Alternative:* keep upload at `thrifty`
+(internal-only stingy). Rejected per the chosen scope — but the opt-out is the
+concession that keeps the published contract usable.
+
+### D6. Pipe style on touched sites only
+Reshape the deeply nested touched calls (e.g.
+`as_tibble(collect(distinct(select(rel, ...))))`) into native `|>` chains —
+the codebase is native `|>` throughout (no magrittr). Limited to lines D1–D5
+already modify, plus the optional `duckplyr_current_settings()` drive-by (same
+file/concern, same `as_tibble(collect(read_sql_duckdb(...)))` nest).
+
+## Risks / Trade-offs
+
+- **`dd$epoch` and `R CMD check` globals** → `dd` is an undefined symbol to
+  static analysis. Confirm the existing `@autoglobal`/`globalVariables`
+  machinery covers it (or add `dd` to the globals) so check stays clean;
+  the spike proved the runtime behaviour, not the check-time lint.
+- **Upload stingy default is a behaviour change** → mitigated by the
+  `prudence = "lavish"` opt-out and a documented note; `collect()`/`count()`
+  round-trip checks still work because explicit collection is unaffected.
+- **A future fan-in edit introduces an un-translatable verb** → that is the
+  *intended* outcome: stingy turns it into a loud test failure instead of a
+  silent OOM. The remedy is the `dd$` escape hatch (rewrite the verb
+  in-engine), not reverting to lavish.
+- **Byte-identity** → unchanged. Stingy does not touch `threads`,
+  `memory_limit`, or `preserve_insertion_order`; the `duckplyr-config`
+  value-/byte-identity guarantees stand.

--- a/openspec/changes/stingy-duckplyr-pipeline/exploration/spike-stingy-fanins.R
+++ b/openspec/changes/stingy-duckplyr-pipeline/exploration/spike-stingy-fanins.R
@@ -1,0 +1,47 @@
+# Spike: does any never-collected fan-in chain secretly fall back to dplyr?
+#
+# Method: apply `prudence = "stingy"` to all three fan-in reads
+# (ssd_summarise, ssd_summarise_member, ssd_summarise_design) and make the
+# write seam preserve a frame's prudence instead of re-wrapping it lavish,
+# then run the NOT_CRAN fan-in suites. A hidden fallback would need to
+# materialise columns, which a stingy frame forbids -> a loud error.
+#
+# Result (duckplyr 1.2.1.9901, duckdb 1.5.4):
+#   test-design-targets.R   pass=25 fail=0 skip=0   (member + design unions)
+#   test-run-scenario.R     pass=15 fail=0 skip=0   (ssd_summarise fan-in)
+#   test-cost-analysis.R    pass=13 fail=0 skip=0
+#   full suite: same 6 pre-existing (unrelated) failures, ZERO new ones.
+# Conclusion: select(any_of) / filter(%in%) / constant mutate / union_all /
+# compute_parquet all execute in DuckDB. No dd$ rescue needed in the fan-ins.
+#
+# The edits the spike applied (reverted afterwards; this is the record):
+#   - read_parquet_duckdb(..., prudence = "stingy") in ssd_summarise(),
+#     ssd_summarise_member(), ssd_summarise_design()
+#   - ssd_write_parquet(): pass an existing duckplyr_df through to
+#     compute_parquet() unchanged; wrap a plain tibble as prudence = "stingy".
+
+# --- standalone mechanic checks (no ssdsims needed) -------------------------
+suppressMessages(library(duckplyr))
+Sys.setenv(DUCKPLYR_FALLBACK_COLLECT = 0)
+
+# dd$epoch duration math is sub-second-exact (matches difftime(units="secs"))
+t0 <- as.POSIXct("2024-01-01 00:00:00", tz = "UTC")
+res <- duckdb_tibble(.start = t0, .end = t0 + 1.25) |>
+  dplyr::mutate(seconds = dd$epoch(.end) - dd$epoch(.start)) |>
+  dplyr::collect()
+stopifnot(isTRUE(all.equal(res$seconds, 1.25)))
+
+# stingy never auto-materialises; collect() is the explicit escape
+s <- duckdb_tibble(g = c("a", "a", "b"), x = 1:3, .prudence = "stingy")
+stopifnot(inherits(try(nrow(s), silent = TRUE), "try-error")) # errors (good)
+stopifnot(nrow(dplyr::collect(dplyr::filter(s, x %in% c(1L, 3L)))) == 2L)
+
+# --- full reproduction (run from the package root) --------------------------
+# Apply the edits above, then:
+#   R CMD INSTALL --no-docs --no-multiarch .
+#   NOT_CRAN=true Rscript -e '
+#     Sys.setenv(NOT_CRAN="true"); library(testthat); library(ssdsims)
+#     for (f in c("test-design-targets.R","test-run-scenario.R","test-cost-analysis.R")) {
+#       d <- as.data.frame(test_file(file.path("tests/testthat", f), reporter="silent"))
+#       cat(sprintf("%-26s pass=%d fail=%d skip=%d\n", f, sum(d$passed), sum(d$failed), sum(d$skipped)))
+#     }'

--- a/openspec/changes/stingy-duckplyr-pipeline/proposal.md
+++ b/openspec/changes/stingy-duckplyr-pipeline/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+The pipeline's duckplyr frames are created at duckplyr's permissive defaults
+(`as_duckdb_tibble()` → `lavish`, `read_parquet_duckdb()` → `thrifty`), so two
+failure modes are only ever a convention away: an accidental `nrow()`/`$` can
+slurp a shard union into a one-CPU/1-GB worker (the OOM the `duckplyr-config`
+change exists to prevent), and an un-translatable verb can **silently** fall
+back to dplyr — materialising into R and quietly leaving DuckDB. `prudence =
+"stingy"` turns both into loud, catchable errors instead of silent hazards, and
+makes "everything computes in DuckDB, collect only when R needs the rows" an
+enforced contract rather than a hope. A spike (this change's
+`exploration/`) confirmed the internal fan-ins already satisfy this — stingy
+passes clean with no new failures — so adopting it is a free hardening that
+also future-proofs every later edit.
+
+## What Changes
+
+- The internal, never-collected fan-in reads (`ssd_summarise()`,
+  `ssd_summarise_member()`, `ssd_summarise_design()`) read their Parquet with
+  `prudence = "stingy"`, so the union/filter/projection/write provably stay in
+  DuckDB and any future fallback fails loudly instead of materialising into R.
+- `ssd_write_parquet()` stops downgrading an already-`duckplyr` frame to
+  `lavish` at the write seam (the spike showed the re-wrap masks stingy right
+  before the write); it preserves an existing frame's prudence and wraps a
+  plain R tibble as `stingy`.
+- The genuine R boundaries keep their **explicit** `collect()` (decoding
+  `fit` objects, the cost-analysis timing reads) but switch the read to
+  `stingy` so nothing materialises implicitly along the way.
+- The cost-analysis timing reads compute per-task durations **in DuckDB** via
+  the `dd$` escape hatch (`dd$epoch(.end) - dd$epoch(.start)`) before the
+  explicit `collect()`, rather than `difftime()` in R after it.
+- **BREAKING (opt-out provided)**: the upload read-back generics
+  (`ssd_open_uploaded()`, `ssd_summarise_uploaded()`) gain a `prudence`
+  argument defaulting to `"stingy"`, so a returned table no longer
+  auto-materialises (an accidental `nrow()` on a remote glob errors instead of
+  downloading); `prudence = "lavish"` restores the old auto-materialising
+  behaviour, and `collect()`/`compute_parquet()` work unchanged.
+- Every touched call site is reshaped from deeply nested calls into native
+  `|>` pipelines (matching the codebase's pipe convention).
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `duckplyr-config`: add the requirement that pipeline duckplyr frames are
+  **stingy** — no implicit materialisation, no silent dplyr fallback,
+  collection is always explicit — and that the Parquet write seam preserves a
+  frame's prudence rather than forcing `lavish`.
+- `cloud-upload`: the read-back generics `ssd_open_uploaded()` and
+  `ssd_summarise_uploaded()` gain a `prudence` argument defaulting to
+  `"stingy"` (a returned table no longer auto-materialises) with a documented
+  `"lavish"` opt-out.
+
+## Impact
+
+- **Code**: `R/targets-runner.R` (`ssd_summarise()`, `ssd_write_parquet()`,
+  `ssd_read_parquet()`), `R/design-targets.R` (`ssd_summarise_member()`,
+  `ssd_summarise_design()`), `R/cost-analysis.R` (`read_step_timings()`,
+  `design_fast_hc()`), `R/upload.R` (the two read-back generics).
+- **Behaviour**: pipeline results are byte-/value-identical (stingy changes
+  *when/whether* materialisation happens, never the rows); the only
+  user-visible change is the upload generics' new stingy default, covered by
+  the `prudence = "lavish"` opt-out.
+- **Dependencies**: none new — `prudence` and the `dd$` escape hatch are
+  existing duckplyr features (`dd$` resolves symbolically; no `dd` package is
+  required at runtime).
+- **Tests**: the existing `NOT_CRAN` fan-in suites are the oracle; add
+  targeted assertions for the stingy reads, the write-seam prudence
+  preservation, the in-engine duration math, and the upload opt-out.

--- a/openspec/changes/stingy-duckplyr-pipeline/specs/cloud-upload/spec.md
+++ b/openspec/changes/stingy-duckplyr-pipeline/specs/cloud-upload/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Read-back generics default to stingy prudence with a lavish opt-out
+The upload read-back generics `ssd_open_uploaded()` and `ssd_summarise_uploaded()` SHALL accept a `prudence` argument that controls the returned duckplyr frame's automatic materialisation, defaulting to `"stingy"`.
+With the default, the returned table SHALL remain lazy and composable with
+`dplyr` verbs and SHALL be materialisable with an explicit `dplyr::collect()`
+or writable with `duckplyr::compute_parquet()`, but an implicit materialisation
+(for example `nrow()` or `$` access) against the remote glob SHALL raise a
+catchable error rather than triggering an unbounded download/scan. Passing
+`prudence = "lavish"` SHALL restore automatic materialisation (the prior
+behaviour) for callers who want the returned table to compute on first access.
+The `prudence` value SHALL be threaded into the underlying
+`read_parquet_duckdb()` read.
+
+#### Scenario: Stingy default avoids accidental remote materialisation
+- **WHEN** `ssd_open_uploaded(upload, step)` is called with the default
+  `prudence`
+- **THEN** the returned table SHALL be stingy — composable with `dplyr` verbs
+  and collectable explicitly, but an implicit `nrow()`/`$` access SHALL error
+  rather than scanning/downloading the remote Parquet
+
+#### Scenario: Lavish opt-out restores automatic materialisation
+- **WHEN** `ssd_open_uploaded(upload, step, prudence = "lavish")` (or
+  `ssd_summarise_uploaded(upload, ..., prudence = "lavish")`) is called
+- **THEN** the returned table SHALL materialise automatically on first access,
+  matching the behaviour before the stingy default
+
+#### Scenario: Explicit collection works under either prudence
+- **WHEN** the table returned by either generic is passed to
+  `dplyr::collect()` or `duckplyr::compute_parquet()`
+- **THEN** it SHALL materialise/serialise the rows regardless of the `prudence`
+  setting

--- a/openspec/changes/stingy-duckplyr-pipeline/specs/duckplyr-config/spec.md
+++ b/openspec/changes/stingy-duckplyr-pipeline/specs/duckplyr-config/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Pipeline duckplyr frames are stingy
+The package SHALL create the internal pipeline's duckplyr frames with
+`prudence = "stingy"`, so that within the pipeline no duckplyr frame
+materialises implicitly and none falls back to dplyr silently. The
+never-collected fan-in reads — `ssd_summarise()`, `ssd_summarise_member()`,
+and `ssd_summarise_design()` — SHALL read their Parquet with
+`prudence = "stingy"`, and the read/filter/projection/union SHALL execute in
+DuckDB through to the write without collecting into R. The reads that genuinely
+return rows to R (`ssd_read_parquet()` and the cost-analysis timing reads) SHALL
+also read with `prudence = "stingy"` and SHALL materialise **only** via an
+explicit `dplyr::collect()`. An operation in a stingy pipeline frame that
+duckplyr cannot translate SHALL surface as a loud, catchable R error rather than
+a silent dplyr fallback (which would materialise into R and risk an
+out-of-memory kill on a constrained worker). The configuration SHALL NOT change
+any result: for a fixed scenario the written Parquets SHALL remain
+value-identical (and, under the single-threaded default, byte-identical) to a
+run with permissive prudence.
+
+#### Scenario: Fan-in unions never materialise into R
+- **WHEN** `ssd_summarise()`, `ssd_summarise_member()`, or
+  `ssd_summarise_design()` fans shard Parquets into a summary
+- **THEN** the union, filter, projection, and write SHALL execute in DuckDB
+  with the read frame at `prudence = "stingy"`, and the union SHALL NOT be
+  collected into R
+
+#### Scenario: An untranslatable verb fails loud, not silently in dplyr
+- **WHEN** a pipeline stingy frame is asked to perform an operation duckplyr
+  cannot translate to DuckDB
+- **THEN** the operation SHALL raise a catchable R error rather than falling
+  back to a dplyr implementation that materialises the data into R
+
+#### Scenario: R-boundary reads collect explicitly
+- **WHEN** `ssd_read_parquet()` or a cost-analysis timing read needs rows in R
+- **THEN** the read SHALL be `prudence = "stingy"` and the rows SHALL reach R
+  only through an explicit `dplyr::collect()`
+
+#### Scenario: Stingy does not change results
+- **WHEN** the same scenario is summarised under stingy pipeline frames and
+  under permissive prudence
+- **THEN** the written summaries SHALL contain the same multiset of rows
+  (byte-identical under the single-threaded default)
+
+### Requirement: The Parquet write seam preserves frame prudence
+`ssd_write_parquet()` SHALL NOT downgrade an already-`duckplyr` frame's prudence
+when writing. When given a frame that is already a `duckplyr_df`, it SHALL pass
+that frame to the Parquet write unchanged (preserving its prudence — so a stingy
+fan-in frame stays stingy through the write and a fallback cannot be masked by a
+`lavish` re-wrap). When given a plain R data frame, it SHALL convert it with
+`prudence = "stingy"` so the write itself cannot fall back to dplyr.
+
+#### Scenario: A stingy fan-in frame stays stingy through the write
+- **WHEN** a fan-in passes a stingy `duckplyr_df` to `ssd_write_parquet()`
+- **THEN** the frame SHALL be written without being re-wrapped to `lavish`, so
+  any untranslatable verb in the chain still errors at the write rather than
+  materialising into R
+
+#### Scenario: A plain tibble is wrapped stingy for the write
+- **WHEN** a plain R data frame (e.g. a per-shard result table) is passed to
+  `ssd_write_parquet()`
+- **THEN** it SHALL be converted to a duckplyr frame with `prudence = "stingy"`
+  before the Parquet write

--- a/openspec/changes/stingy-duckplyr-pipeline/tasks.md
+++ b/openspec/changes/stingy-duckplyr-pipeline/tasks.md
@@ -1,0 +1,72 @@
+## 1. Write seam preserves prudence
+
+- [ ] 1.1 In `R/targets-runner.R`, change `ssd_write_parquet()` so an existing
+  `duckplyr_df` is passed to `duckplyr::compute_parquet()` unchanged
+  (preserving its prudence) and a plain data frame is wrapped with
+  `duckplyr::as_duckdb_tibble(df, prudence = "stingy")`; update the function's
+  comment to explain why the lavish re-wrap is removed.
+
+## 2. Stingy on the internal pipeline reads
+
+- [ ] 2.1 `ssd_summarise()` (`R/targets-runner.R`): add `prudence = "stingy"`
+  to its `read_parquet_duckdb()` call.
+- [ ] 2.2 `ssd_summarise_member()` (`R/design-targets.R`): add
+  `prudence = "stingy"` to its `read_parquet_duckdb()` call.
+- [ ] 2.3 `ssd_summarise_design()` (`R/design-targets.R`): add
+  `prudence = "stingy"` to its `read_parquet_duckdb()` call.
+- [ ] 2.4 `ssd_read_parquet()` (`R/targets-runner.R`): add
+  `prudence = "stingy"` to its `read_parquet_duckdb()` call, keeping the
+  explicit `collect()`, and reshape the nested
+  `as_tibble(collect(read_parquet_duckdb(...)))` into a native `|>` chain.
+
+## 3. In-engine duration math (cost-analysis)
+
+- [ ] 3.1 `read_step_timings()` (`R/cost-analysis.R`): read with
+  `prudence = "stingy"`; compute `seconds` in DuckDB via
+  `dplyr::mutate(seconds = dd$epoch(.end) - dd$epoch(.start))` before the
+  explicit `collect()`; reshape the nested
+  `as_tibble(collect(distinct(select(...))))` calls into `|>` chains.
+- [ ] 3.2 `design_fast_hc()` (`R/cost-analysis.R`): same — stingy read,
+  in-engine `dd$epoch` duration, `|>` reshape of the nested calls.
+- [ ] 3.3 Ensure `dd` resolves cleanly under `R CMD check` (confirm the
+  `@autoglobal`/`globalVariables` machinery covers `dd`, or register it), so
+  no "undefined global" NOTE appears.
+
+## 4. Upload read-back prudence (stingy default + lavish opt-out)
+
+- [ ] 4.1 `ssd_open_uploaded()` (generic + Azure method, `R/upload.R`): add a
+  `prudence = "stingy"` argument threaded into `read_parquet_duckdb()`.
+- [ ] 4.2 `ssd_summarise_uploaded()` (generic + Azure method, `R/upload.R`):
+  add a `prudence = "stingy"` argument threaded into `read_parquet_duckdb()`.
+- [ ] 4.3 Update the roxygen for both generics: document `prudence`, the
+  stingy default, the `"lavish"` opt-out, and that `collect()`/
+  `compute_parquet()` are unaffected.
+
+## 5. Optional pipe drive-by
+
+- [ ] 5.1 `duckplyr_current_settings()` (`R/duckplyr-config.R`): reshape the
+  nested `as_tibble(collect(read_sql_duckdb(...)))` into a `|>` chain (no
+  behaviour change — its read is already stingy internally).
+
+## 6. Tests
+
+- [ ] 6.1 Add a test asserting the fan-in reads are stingy and that a stingy
+  fan-in frame is written without being downgraded (e.g. a frame returned by a
+  fan-in carries `prudent_duckplyr_df`; the summary write succeeds).
+- [ ] 6.2 Add a test for `ssd_write_parquet()`: a plain tibble is wrapped
+  stingy and a passed-in `duckplyr_df` keeps its prudence.
+- [ ] 6.3 Add a test that the cost-analysis `seconds` computed via `dd$epoch`
+  equal the previous `difftime(units = "secs")` result (sub-second exact).
+- [ ] 6.4 Add a test for the upload generics: the default returns a stingy
+  table (implicit access errors; `collect()` works) and
+  `prudence = "lavish"` restores auto-materialisation.
+- [ ] 6.5 Run the `NOT_CRAN=true` fan-in suites
+  (`test-design-targets`, `test-run-scenario`, `test-cost-analysis`,
+  `test-upload`) and confirm no new failures beyond the known baseline.
+
+## 7. Finalise
+
+- [ ] 7.1 Format with `air` and run `devtools::document()` for the new
+  `prudence` arguments.
+- [ ] 7.2 Update `NEWS.md` if warranted, and confirm the squash-merge PR title
+  is a valid Conventional Commit.


### PR DESCRIPTION
## Why

The pipeline's duckplyr frames run at duckplyr's permissive defaults
(`as_duckdb_tibble()` → `lavish`, `read_parquet_duckdb()` → `thrifty`), so two
hazards are only a convention away: an accidental `nrow()`/`$` can slurp a shard
union into a one-CPU/1-GB worker (the OOM `duckplyr-config` exists to prevent),
and an un-translatable verb can **silently** fall back to dplyr — materialising
into R and quietly leaving DuckDB. `prudence = "stingy"` turns both into loud,
catchable errors and makes *"everything computes in DuckDB, collect only when R
needs the rows"* an enforced contract.

This PR is the **OpenSpec proposal only** (proposal + design + spec deltas +
tasks + spike evidence) — no implementation yet. Run `/opsx:apply` to implement.

## What it proposes

- **Stingy** on the three never-collected fan-in reads (`ssd_summarise()`,
  `ssd_summarise_member()`, `ssd_summarise_design()`).
- `ssd_write_parquet()` stops downgrading an already-`duckplyr` frame to
  `lavish` at the write seam (the spike showed the re-wrap masks stingy right
  before the write); it preserves an existing frame's prudence and wraps a
  plain tibble as `stingy`.
- R-boundary reads keep their **explicit** `collect()` but read `stingy`.
- Cost-analysis duration math moves **in-engine** via the `dd$` escape hatch
  (`dd$epoch(.end) - dd$epoch(.start)`) instead of `difftime()` in R.
- Upload read-back generics gain a `prudence` arg defaulting to `"stingy"`
  with a documented `"lavish"` opt-out (**BREAKING**, opt-out provided).
- Touched nested calls reshaped into native `|>` pipelines.

## Spike evidence (`exploration/`)

Applying stingy to all three fan-in reads + a prudence-preserving write seam,
then running the `NOT_CRAN` suites:

| suite | pass | fail | skip |
|---|---|---|---|
| `test-design-targets` | 25 | 0 | 0 |
| `test-run-scenario` | 15 | 0 | 0 |
| `test-cost-analysis` | 13 | 0 | 0 |

Same 6 pre-existing (unrelated) baseline failures, **zero** new ones → the
fan-in verbs already execute in DuckDB; no `dd$` rescue is needed there. The
`dd$epoch` mechanic was verified standalone (1.25 s gap → `1.25`, sub-second
exact).

## Capabilities touched

- `duckplyr-config` (modified): pipeline frames are stingy; no implicit
  fallback; write seam preserves prudence.
- `cloud-upload` (modified): read-back generics default stingy with a lavish
  opt-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KM5h8HZFGfPbzmN1CU3ZA

---
_Generated by [Claude Code](https://claude.ai/code/session_012KM5h8HZFGfPbzmN1CU3ZA)_