### PR TITLE
test: skip targets tests under covr to prevent hash perturbation

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -43,8 +43,21 @@ expect_snapshot_data <- function(x, name, digits = 6) {
 # Gate the tests that actually drive a `targets` pipeline: they spawn a worker
 # that `library(ssdsims)`, so the package must be installed (true under R CMD
 # check, not under a bare `devtools::test()`), and they are slow.
+#
+# Also skip under coverage. `covr` rewrites every function body to add its
+# per-line counters, which changes the deparsed bytes a `targets` command hashes
+# over. A step slice carries the package functions a shard runs with (e.g. the
+# `fit` slice's `min_pmix_fns`), so the instrumented bodies leak into the shard
+# target's dependency hash - breaking the "hash by name, not by body" identity
+# contract that `scenario_step_slice()` documents and that the standalone ->
+# design cache-reuse test asserts. The pipeline build also runs in a dedicated
+# `callr` session `covr` does not instrument, so these tests add no coverage.
 skip_targets <- function() {
   testthat::skip_on_cran()
+  testthat::skip_if(
+    identical(Sys.getenv("R_COVR"), "true"),
+    "On covr (instrumented bodies perturb `targets` dependency hashes)"
+  )
   testthat::skip_if_not_installed("targets")
   testthat::skip_if_not_installed("tarchetypes")
   testthat::skip_if_not_installed("duckplyr")


### PR DESCRIPTION
## Description

Skip `targets` pipeline tests when running under code coverage (`covr`). The `covr` package instruments function bodies to track per-line coverage, which changes the deparsed bytes that `targets` uses to compute dependency hashes. A step slice carries the package functions a shard runs with (e.g. the `fit` slice's `min_pmix_fns`), so the instrumented bodies leak into a shard target's dependency hash, breaking the "hash by name, not by body" identity contract documented in `scenario_step_slice()`.

Concretely, this failed the standalone → design cache-reuse assertion in `test-design-targets.R:250` (`fit_step`/`hc_step`/`summary` going stale) under `devtools::test_coverage()` — which sets `NOT_CRAN=true` and therefore runs the pipeline tests that the coverage CI job already skips via `skip_on_cran()`.

These tests also run the pipeline build in a dedicated `callr` session that `covr` does not instrument, so they add no coverage value.

## Changes

- Gate the `skip_targets()` helper on the `R_COVR` environment variable so the pipeline tests skip under coverage, mirroring how they already skip on CRAN.
- Added a comment explaining why the skip is necessary and how `covr` instrumentation perturbs `targets` dependency hashing.

## Test Plan

- Under covr with `NOT_CRAN=true` (the `devtools::test_coverage()` scenario): `FAIL 0 | SKIP 27 | PASS 829` (was `FAIL 1`); package coverage 84.87% → 87.99%.
- Normal run unaffected — `test-design-targets.R` still executes the targets tests (`SKIP 0 | PASS 49`); the skip only triggers when `R_COVR=true`.

https://claude.ai/code/session_0189qxDJcTcWQ6S5uhwtBJ4v

🤖 Generated with [Claude Code](https://claude.com/claude-code)