### PR TITLE
docs: add Kirill Müller as author

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,9 @@ Authors@R: c(
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7683-4592")),
     person("Rebecca", "Fisher", , "R.Fisher@aims.gov.au", role = "aut",
-           comment = c(ORCID = "0000-0001-5148-6731"))
+           comment = c(ORCID = "0000-0001-5148-6731")),
+    person("Kirill", "Müller", , "kirill@cynkra.com", role = "aut",
+           comment = c(ORCID = "0000-0002-1416-3412"))
   )
 Description: Runs reproducible simulation studies for species sensitivity
     distribution (SSD) models built on the 'ssdtools' package. Expands a

--- a/man/ssdsims-package.Rd
+++ b/man/ssdsims-package.Rd
@@ -23,6 +23,7 @@ Authors:
 \itemize{
   \item Joe Thorley \email{joe@poissonconsulting.ca} (\href{https://orcid.org/0000-0002-7683-4592}{ORCID})
   \item Rebecca Fisher \email{R.Fisher@aims.gov.au} (\href{https://orcid.org/0000-0001-5148-6731}{ORCID})
+  \item Kirill Müller \email{kirill@cynkra.com} (\href{https://orcid.org/0000-0002-1416-3412}{ORCID})
 }
 
 }


### PR DESCRIPTION
## What

Adds **Kirill Müller** (ORCID [0000-0002-1416-3412](https://orcid.org/0000-0002-1416-3412), `kirill@cynkra.com`) as an author (`role = "aut"`) of the package.

- `DESCRIPTION`: new `person()` entry in `Authors@R`.
- `man/ssdsims-package.Rd`: corresponding line in the generated author block (edited directly to stay in sync; the roxygen toolchain — dev `roxygen2` + `roxyglobals` — is not available in this environment, but the block is deterministic from `Authors@R`, so a future `devtools::document()` reproduces it identically).

## Why a standalone PR

Split out from the `readme` documentation PR (#191) so this metadata change lands as its own squash commit and is captured in `NEWS.md` via `fledge`, rather than being absorbed into a `docs(openspec)` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJHtNLGYm8379WrTAUjrui)_