### PR TITLE
docs: rewrite README and overhaul the vignette set

### DIFF
--- a/R/cost-estimate.R
+++ b/R/cost-estimate.R
@@ -133,8 +133,7 @@ ssd_cost_calibration <- function() {
 #' because the `nboot` values are tiny (the slope and floor are estimable from
 #' small bootstraps). The one-time research that discovered the model's *form*
 #' (which axes are free, the `max(nboot, n0)` shape, the non-monotonic `nrow`
-#' factor) is preserved under the change's `exploration/` directory; it is not
-#' rerun here.
+#' factor) is illustrative and is not rerun here.
 #'
 #' @param nboot An integer vector of tiny bootstrap sizes to sweep (the slope and
 #'   floor are fit over these).

--- a/R/targets-runner.R
+++ b/R/targets-runner.R
@@ -556,10 +556,7 @@ ssd_run_hc_step <- function(tasks, scenario, fit_dir, out_dir) {
 #' contractual** - re-summarising the same shards yields the same rows
 #' (address them by `hc_id`/`fit_id`), but their order and the file's bytes
 #' may differ. Under the default single thread, writes were observed in input
-#' order and byte-identical across runs regardless. Evidence: the
-#' `duckplyr-config` change's `exploration/experiment-summary-union.R`,
-#' `exploration/experiment-rgbytes.R`, and
-#' `exploration/experiment-preserve-order-copy-option.R`.
+#' order and byte-identical across runs regardless.
 #'
 #' @param dir_sample The `sample` results root.
 #' @param dir_fit The `fit` results root.

--- a/README.Rmd
+++ b/README.Rmd
@@ -20,9 +20,36 @@ knitr::opts_chunk$set(
 [![R-CMD-check](https://github.com/poissonconsulting/ssdsims/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/poissonconsulting/ssdsims/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
-The goal of ssdsims is to facilitate simulation studies with species sensitivity distribution data.
+ssdsims runs reproducible simulation studies for species sensitivity
+distribution (SSD) models built on the
+[ssdtools](https://bcgov.github.io/ssdtools/) package. You describe a study
+**declaratively** as a *scenario*; ssdsims expands it into per-step task tables,
+draws the data, fits the distributions, and estimates the hazard
+concentrations. The same scenario runs three ways over one execution core ---
+an in-memory baseline, single-core Hive-partitioned Parquet *shards*, and a
+[targets](https://docs.ropensci.org/targets/)-based shard pipeline for running
+in parallel or on a cluster --- with byte-identical, reproducible per-task
+results throughout.
+
+New here? Start with `vignette("ssdsims")` for the overview and a recommended
+reading order.
 
 ## Installation
+
+Install the development version from [GitHub](https://github.com/) with:
+
+```{r, eval = FALSE}
+# install.packages("pak")
+pak::pak("poissonconsulting/ssdsims")
+
+# or
+# install.packages("remotes")
+remotes::install_github("poissonconsulting/ssdsims")
+```
+
+## Usage
+
+Assemble the data, declare a scenario, and run the in-memory baseline:
 
 ```{r}
 library(ssdsims)
@@ -40,3 +67,23 @@ scenario
 
 ssd_run_scenario_baseline(scenario)
 ```
+
+The scenario is purely declarative --- it draws no random numbers and depends on
+no `targets` --- so the same object drives every runner. See
+`vignette("defining-a-scenario")` for the scenario object and
+`vignette("sharded-pipeline")` for the shard and `targets` pipeline.
+
+## Capability map
+
+| Area | Article |
+|---|---|
+| Define a scenario and expand it into `sample`/`fit`/`hc` task tables | `vignette("defining-a-scenario")` |
+| Run as Hive-partitioned Parquet shards and a `targets` pipeline | `vignette("sharded-pipeline")` |
+| Combine several scenarios into one ragged design | `vignette("scenario-to-design")` |
+| Run on a SLURM (or other) cluster | `vignette("cluster-pipeline")` |
+| Ship shards to cloud object storage | `vignette("cloud-upload")` |
+| Estimate compute cost before a run | `vignette("cost-estimation")` |
+| Analyse observed compute cost after a run | `vignette("cost-analysis")` |
+
+Reproducible per-task RNG (the dqrng `pcg64` backend with per-task primers)
+underpins all of the above; see `?task_primer`.

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
-[![R-CMD-check](https://github.com/poissonconsulting/ssdsims/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/poissonconsulting/ssdsims/actions/workflows/R-CMD-check.yaml)
+[![R-CMD-check](https://github.com/poissonconsulting/ssdsims/actions/workflows/R-CMD-check.yml/badge.svg)](https://github.com/poissonconsulting/ssdsims/actions/workflows/R-CMD-check.yml)
 <!-- badges: end -->
 
 ssdsims runs reproducible simulation studies for species sensitivity

--- a/README.Rmd
+++ b/README.Rmd
@@ -31,8 +31,9 @@ an in-memory baseline, single-core Hive-partitioned Parquet *shards*, and a
 in parallel or on a cluster --- with byte-identical, reproducible per-task
 results throughout.
 
-New here? Start with `vignette("ssdsims")` for the overview and a recommended
-reading order.
+New here? Start with
+[`vignette("ssdsims")`](https://poissonconsulting.github.io/ssdsims/articles/ssdsims.html)
+for the overview and a recommended reading order.
 
 ## Installation
 
@@ -70,20 +71,23 @@ ssd_run_scenario_baseline(scenario)
 
 The scenario is purely declarative --- it draws no random numbers and depends on
 no `targets` --- so the same object drives every runner. See
-`vignette("defining-a-scenario")` for the scenario object and
-`vignette("sharded-pipeline")` for the shard and `targets` pipeline.
+[`vignette("defining-a-scenario")`](https://poissonconsulting.github.io/ssdsims/articles/defining-a-scenario.html)
+for the scenario object and
+[`vignette("sharded-pipeline")`](https://poissonconsulting.github.io/ssdsims/articles/sharded-pipeline.html)
+for the shard and `targets` pipeline.
 
 ## Capability map
 
 | Area | Article |
 |---|---|
-| Define a scenario and expand it into `sample`/`fit`/`hc` task tables | `vignette("defining-a-scenario")` |
-| Run as Hive-partitioned Parquet shards and a `targets` pipeline | `vignette("sharded-pipeline")` |
-| Combine several scenarios into one ragged design | `vignette("scenario-to-design")` |
-| Run on a SLURM (or other) cluster | `vignette("cluster-pipeline")` |
-| Ship shards to cloud object storage | `vignette("cloud-upload")` |
-| Estimate compute cost before a run | `vignette("cost-estimation")` |
-| Analyse observed compute cost after a run | `vignette("cost-analysis")` |
+| Define a scenario and expand it into `sample`/`fit`/`hc` task tables | [`vignette("defining-a-scenario")`](https://poissonconsulting.github.io/ssdsims/articles/defining-a-scenario.html) |
+| Run as Hive-partitioned Parquet shards and a `targets` pipeline | [`vignette("sharded-pipeline")`](https://poissonconsulting.github.io/ssdsims/articles/sharded-pipeline.html) |
+| Combine several scenarios into one ragged design | [`vignette("scenario-to-design")`](https://poissonconsulting.github.io/ssdsims/articles/scenario-to-design.html) |
+| Run on a SLURM (or other) cluster | [`vignette("cluster-pipeline")`](https://poissonconsulting.github.io/ssdsims/articles/cluster-pipeline.html) |
+| Ship shards to cloud object storage | [`vignette("cloud-upload")`](https://poissonconsulting.github.io/ssdsims/articles/cloud-upload.html) |
+| Estimate compute cost before a run | [`vignette("cost-estimation")`](https://poissonconsulting.github.io/ssdsims/articles/cost-estimation.html) |
+| Analyse observed compute cost after a run | [`vignette("cost-analysis")`](https://poissonconsulting.github.io/ssdsims/articles/cost-analysis.html) |
 
 Reproducible per-task RNG (the dqrng `pcg64` backend with per-task primers)
-underpins all of the above; see `?task_primer`.
+underpins all of the above; see
+[`task_primer()`](https://poissonconsulting.github.io/ssdsims/reference/task_primer.html).

--- a/README.md
+++ b/README.md
@@ -10,10 +10,37 @@ experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](h
 [![R-CMD-check](https://github.com/poissonconsulting/ssdsims/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/poissonconsulting/ssdsims/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
-The goal of ssdsims is to facilitate simulation studies with species
-sensitivity distribution data.
+ssdsims runs reproducible simulation studies for species sensitivity
+distribution (SSD) models built on the
+[ssdtools](https://bcgov.github.io/ssdtools/) package. You describe a
+study **declaratively** as a *scenario*; ssdsims expands it into
+per-step task tables, draws the data, fits the distributions, and
+estimates the hazard concentrations. The same scenario runs three ways
+over one execution core — an in-memory baseline, single-core
+Hive-partitioned Parquet *shards*, and a
+[targets](https://docs.ropensci.org/targets/)-based shard pipeline for
+running in parallel or on a cluster — with byte-identical, reproducible
+per-task results throughout.
+
+New here? Start with `vignette("ssdsims")` for the overview and a
+recommended reading order.
 
 ## Installation
+
+Install the development version from [GitHub](https://github.com/) with:
+
+``` r
+# install.packages("pak")
+pak::pak("poissonconsulting/ssdsims")
+
+# or
+# install.packages("remotes")
+remotes::install_github("poissonconsulting/ssdsims")
+```
+
+## Usage
+
+Assemble the data, declare a scenario, and run the in-memory baseline:
 
 ``` r
 library(ssdsims)
@@ -106,3 +133,23 @@ ssd_run_scenario_baseline(scenario)
 #> #   ci_method <chr>, parametric <lgl>, distset <chr>, hc_id <chr>,
 #> #   fit_id <chr>, hc <list>, .start <dttm>, .end <dttm>, .host <chr>
 ```
+
+The scenario is purely declarative — it draws no random numbers and
+depends on no `targets` — so the same object drives every runner. See
+`vignette("defining-a-scenario")` for the scenario object and
+`vignette("sharded-pipeline")` for the shard and `targets` pipeline.
+
+## Capability map
+
+| Area | Article |
+|----|----|
+| Define a scenario and expand it into `sample`/`fit`/`hc` task tables | `vignette("defining-a-scenario")` |
+| Run as Hive-partitioned Parquet shards and a `targets` pipeline | `vignette("sharded-pipeline")` |
+| Combine several scenarios into one ragged design | `vignette("scenario-to-design")` |
+| Run on a SLURM (or other) cluster | `vignette("cluster-pipeline")` |
+| Ship shards to cloud object storage | `vignette("cloud-upload")` |
+| Estimate compute cost before a run | `vignette("cost-estimation")` |
+| Analyse observed compute cost after a run | `vignette("cost-analysis")` |
+
+Reproducible per-task RNG (the dqrng `pcg64` backend with per-task
+primers) underpins all of the above; see `?task_primer`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Lifecycle:
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
-[![R-CMD-check](https://github.com/poissonconsulting/ssdsims/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/poissonconsulting/ssdsims/actions/workflows/R-CMD-check.yaml)
+[![R-CMD-check](https://github.com/poissonconsulting/ssdsims/actions/workflows/R-CMD-check.yml/badge.svg)](https://github.com/poissonconsulting/ssdsims/actions/workflows/R-CMD-check.yml)
 <!-- badges: end -->
 
 ssdsims runs reproducible simulation studies for species sensitivity

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Hive-partitioned Parquet *shards*, and a
 running in parallel or on a cluster — with byte-identical, reproducible
 per-task results throughout.
 
-New here? Start with `vignette("ssdsims")` for the overview and a
-recommended reading order.
+New here? Start with
+[`vignette("ssdsims")`](https://poissonconsulting.github.io/ssdsims/articles/ssdsims.html)
+for the overview and a recommended reading order.
 
 ## Installation
 
@@ -136,20 +137,23 @@ ssd_run_scenario_baseline(scenario)
 
 The scenario is purely declarative — it draws no random numbers and
 depends on no `targets` — so the same object drives every runner. See
-`vignette("defining-a-scenario")` for the scenario object and
-`vignette("sharded-pipeline")` for the shard and `targets` pipeline.
+[`vignette("defining-a-scenario")`](https://poissonconsulting.github.io/ssdsims/articles/defining-a-scenario.html)
+for the scenario object and
+[`vignette("sharded-pipeline")`](https://poissonconsulting.github.io/ssdsims/articles/sharded-pipeline.html)
+for the shard and `targets` pipeline.
 
 ## Capability map
 
 | Area | Article |
 |----|----|
-| Define a scenario and expand it into `sample`/`fit`/`hc` task tables | `vignette("defining-a-scenario")` |
-| Run as Hive-partitioned Parquet shards and a `targets` pipeline | `vignette("sharded-pipeline")` |
-| Combine several scenarios into one ragged design | `vignette("scenario-to-design")` |
-| Run on a SLURM (or other) cluster | `vignette("cluster-pipeline")` |
-| Ship shards to cloud object storage | `vignette("cloud-upload")` |
-| Estimate compute cost before a run | `vignette("cost-estimation")` |
-| Analyse observed compute cost after a run | `vignette("cost-analysis")` |
+| Define a scenario and expand it into `sample`/`fit`/`hc` task tables | [`vignette("defining-a-scenario")`](https://poissonconsulting.github.io/ssdsims/articles/defining-a-scenario.html) |
+| Run as Hive-partitioned Parquet shards and a `targets` pipeline | [`vignette("sharded-pipeline")`](https://poissonconsulting.github.io/ssdsims/articles/sharded-pipeline.html) |
+| Combine several scenarios into one ragged design | [`vignette("scenario-to-design")`](https://poissonconsulting.github.io/ssdsims/articles/scenario-to-design.html) |
+| Run on a SLURM (or other) cluster | [`vignette("cluster-pipeline")`](https://poissonconsulting.github.io/ssdsims/articles/cluster-pipeline.html) |
+| Ship shards to cloud object storage | [`vignette("cloud-upload")`](https://poissonconsulting.github.io/ssdsims/articles/cloud-upload.html) |
+| Estimate compute cost before a run | [`vignette("cost-estimation")`](https://poissonconsulting.github.io/ssdsims/articles/cost-estimation.html) |
+| Analyse observed compute cost after a run | [`vignette("cost-analysis")`](https://poissonconsulting.github.io/ssdsims/articles/cost-analysis.html) |
 
 Reproducible per-task RNG (the dqrng `pcg64` backend with per-task
-primers) underpins all of the above; see `?task_primer`.
+primers) underpins all of the above; see
+[`task_primer()`](https://poissonconsulting.github.io/ssdsims/reference/task_primer.html).

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -111,10 +111,11 @@ articles:
 - title: Articles
   navbar: ~
   contents:
+  - ssdsims
   - defining-a-scenario
-  - cost-estimation
-  - cost-analysis
   - sharded-pipeline
   - scenario-to-design
   - cluster-pipeline
   - cloud-upload
+  - cost-estimation
+  - cost-analysis

--- a/man/ssd_calibrate_cost.Rd
+++ b/man/ssd_calibrate_cost.Rd
@@ -44,8 +44,7 @@ a reference dataset (\code{ssddata::ccme_boron} by default) and times with base
 because the \code{nboot} values are tiny (the slope and floor are estimable from
 small bootstraps). The one-time research that discovered the model's \emph{form}
 (which axes are free, the \code{max(nboot, n0)} shape, the non-monotonic \code{nrow}
-factor) is preserved under the change's \verb{exploration/} directory; it is not
-rerun here.
+factor) is illustrative and is not rerun here.
 }
 \examples{
 \dontrun{

--- a/man/ssd_summarise.Rd
+++ b/man/ssd_summarise.Rd
@@ -78,10 +78,7 @@ cannot substitute. The trade: the full summary's \strong{row order is not
 contractual} - re-summarising the same shards yields the same rows
 (address them by \code{hc_id}/\code{fit_id}), but their order and the file's bytes
 may differ. Under the default single thread, writes were observed in input
-order and byte-identical across runs regardless. Evidence: the
-\code{duckplyr-config} change's \code{exploration/experiment-summary-union.R},
-\code{exploration/experiment-rgbytes.R}, and
-\code{exploration/experiment-preserve-order-copy-option.R}.
+order and byte-identical across runs regardless.
 }
 
 \examples{

--- a/openspec/changes/readme/design.md
+++ b/openspec/changes/readme/design.md
@@ -67,11 +67,16 @@ already-exported functions and existing deps in examples.
   README's quick-start is the 30-second on-ramp and links to `vignette("ssdsims")`;
   the overview carries the map and reading order and links back out to each
   track. Neither is the sole source; the overview is the hub.
-- **`vignette()`-style links package-wide.** Convert every vignette→vignette
-  link to `vignette("name")` and every function mention to its reference page.
-  This satisfies the roadmap and (unlike hardcoded `.html`/absolute URLs)
-  resolves in local builds and installed-package help. Done across all seven
-  vignettes, the overview, and the README.
+- **`vignette()`-style links, auto-linked in vignettes, explicit in the README.**
+  pkgdown's downlit auto-links bare inline `vignette("name")` and `fn()` code to
+  the article / reference page, so the vignettes use that bare form (no
+  `[...](...)` wrapper, which would fight the auto-linker) with careful phrasing
+  — each reference is a clean standalone call expression, and `?fn` is avoided
+  because it does not auto-link. The README is different: it also renders on
+  GitHub, where no auto-linking happens, so its navigation uses explicit Markdown
+  links to the pkgdown article/reference URLs with the `vignette("...")` / `fn()`
+  call as the link text (per the Copilot review). Both keep the roadmap's
+  `vignette(...)`-style call form as the visible text.
 - **Re-knit/re-render as the build step.** `devtools::build_readme()` for
   `README.md`; `pkgdown`/`quarto` for the site. Output is generated, not
   hand-edited.

--- a/openspec/changes/readme/specs/package-vignettes/spec.md
+++ b/openspec/changes/readme/specs/package-vignettes/spec.md
@@ -21,19 +21,25 @@ the `_pkgdown.yml` `articles:` list.
   NOT use the legacy step functions
 
 ### Requirement: vignette()-style cross-links
-Cross-references between vignettes SHALL use `vignette("name")`-style links, and
-references to package functions SHALL link to the function reference (not to an
-article page). This applies to all vignettes and the README.
+Cross-references SHALL use the `vignette("name")` call form for articles and the
+`fn()` call form for functions. In the vignettes, these SHALL be written as bare
+inline code (no surrounding `[...](...)` link) so pkgdown's downlit auto-links
+them to the article / reference page; each reference SHALL be phrased as a clean
+standalone call expression (e.g. `vignette("sharded-pipeline")`, `ssd_summarise()`)
+so auto-linking applies. The README, which also renders on GitHub where
+auto-linking does not occur, SHALL instead use explicit Markdown links to the
+pkgdown article/reference URLs while keeping the `vignette("...")` / `fn()` text.
 
-#### Scenario: Vignette-to-vignette links use vignette()
-- **WHEN** one vignette refers a reader to another
-- **THEN** the link SHALL be a `vignette("name")`-style link rather than a
-  hardcoded `.html` or absolute site URL
+#### Scenario: Vignette cross-references are auto-linked
+- **WHEN** one vignette refers a reader to another article or to a function
+- **THEN** the reference SHALL be a bare inline `vignette("name")` or `fn()` code
+  expression (not a hardcoded `.html`/absolute-URL link), relying on pkgdown
+  auto-linking, and SHALL NOT use `?fn` (which does not auto-link)
 
-#### Scenario: Function mentions link to the reference
-- **WHEN** a vignette presents a package function as a link
-- **THEN** the link SHALL resolve to that function's reference page, not to an
-  article
+#### Scenario: README links are explicit
+- **WHEN** the README references an article or function
+- **THEN** it SHALL use an explicit Markdown link to the pkgdown URL (so it is
+  clickable on GitHub), with the `vignette("...")` / `fn()` call as the link text
 
 ### Requirement: Navigable, non-orphan vignette set
 Every vignette SHALL carry a "See also" / navigation section linking the

--- a/openspec/changes/readme/tasks.md
+++ b/openspec/changes/readme/tasks.md
@@ -6,38 +6,38 @@
 > rewrite — the example still sits under a mislabelled `## Installation` heading
 > with no real install, overview, capability map, or `vignette("ssdsims")` link.
 
-- [ ] 1.1 Keep the YAML header, the `<!-- README.md is generated from README.Rmd -->` provenance comment, the `knitr::opts_chunk$set(...)` setup chunk, the `# ssdsims` title, and the badges block.
-- [ ] 1.2 Rewrite the overview to describe the declarative scenario, expansion into per-step `sample`/`fit`/`hc` task tables, and the `targets`-based, Hive-partitioned shard pipeline (consistent with `DESCRIPTION`).
-- [ ] 1.3 Add a real `## Installation` section (`pak::pak("poissonconsulting/ssdsims")` plus a `remotes::install_github(...)` alternative), removing the example mislabelled as "Installation".
-- [ ] 1.4 Add a `## Usage` quick-start built only on the declarative path (`ssd_scenario_data()` → `ssd_define_scenario()` → `ssd_run_scenario_baseline()`), evaluated so output is captured. Do NOT use `ssd_sim_data()` / `ssd_fit_dists_sims()` / `ssd_hc_sims()` / `ssd_run_scenario()`.
-- [ ] 1.5 Add a capability map (scenarios & task expansion; targets pipeline; designs; cloud upload; cost estimation/analysis; reproducible RNG) and a prominent link to `vignette("ssdsims")`.
-- [ ] 1.6 Use Commonwealth (UK/AU) English; keep the diff minimal.
+- [x] 1.1 Keep the YAML header, the `<!-- README.md is generated from README.Rmd -->` provenance comment, the `knitr::opts_chunk$set(...)` setup chunk, the `# ssdsims` title, and the badges block.
+- [x] 1.2 Rewrite the overview to describe the declarative scenario, expansion into per-step `sample`/`fit`/`hc` task tables, and the `targets`-based, Hive-partitioned shard pipeline (consistent with `DESCRIPTION`).
+- [x] 1.3 Add a real `## Installation` section (`pak::pak("poissonconsulting/ssdsims")` plus a `remotes::install_github(...)` alternative), removing the example mislabelled as "Installation".
+- [x] 1.4 Add a `## Usage` quick-start built only on the declarative path (`ssd_scenario_data()` → `ssd_define_scenario()` → `ssd_run_scenario_baseline()`), evaluated so output is captured. Do NOT use `ssd_sim_data()` / `ssd_fit_dists_sims()` / `ssd_hc_sims()` / `ssd_run_scenario()`.
+- [x] 1.5 Add a capability map (scenarios & task expansion; targets pipeline; designs; cloud upload; cost estimation/analysis; reproducible RNG) and a prominent link to `vignette("ssdsims")`.
+- [x] 1.6 Use Commonwealth (UK/AU) English; keep the diff minimal.
 
 ## 2. Create the get-started overview vignette
 
-- [ ] 2.1 Add `vignettes/ssdsims.qmd` (`vignette("ssdsims")`): problem statement, a labelled map of the two tracks (build-and-run pipeline vs. predict-and-measure cost), an explicit recommended reading order, and a short declarative on-ramp.
-- [ ] 2.2 Lift the strongest framing from the review: `defining-a-scenario`'s "why declarative" + collection-input model, and `sharded-pipeline`'s "two drivers, one core, byte-identical" mental model — trimmed to a single dataset/minimal scenario, pointing onward rather than duplicating.
-- [ ] 2.3 Add `ssdsims` as the FIRST entry in the `_pkgdown.yml` `articles:` list.
+- [x] 2.1 Add `vignettes/ssdsims.qmd` (`vignette("ssdsims")`): problem statement, a labelled map of the two tracks (build-and-run pipeline vs. predict-and-measure cost), an explicit recommended reading order, and a short declarative on-ramp.
+- [x] 2.2 Lift the strongest framing from the review: `defining-a-scenario`'s "why declarative" + collection-input model, and `sharded-pipeline`'s "two drivers, one core, byte-identical" mental model — trimmed to a single dataset/minimal scenario, pointing onward rather than duplicating.
+- [x] 2.3 Add `ssdsims` as the FIRST entry in the `_pkgdown.yml` `articles:` list.
 
 ## 3. Convert cross-links to vignette()-style (package-wide)
 
-- [ ] 3.1 Convert every vignette-to-vignette link in all seven existing vignettes (and the new overview and README) from `.html`/absolute URLs to `vignette("name")`-style links.
-- [ ] 3.2 Point function-name links at the function reference, not at article pages (fixes the `cost-analysis` links to `ssd_estimate_cost()` / `ssd_calibrate_cost()`).
+- [x] 3.1 Convert every vignette-to-vignette link in all seven existing vignettes (and the new overview and README) from `.html`/absolute URLs to `vignette("name")`-style links.
+- [x] 3.2 Point function-name links at the function reference, not at article pages (fixes the `cost-analysis` links to `ssd_estimate_cost()` / `ssd_calibrate_cost()`).
 
 ## 4. Apply the per-vignette review fixes
 
-- [ ] 4.1 `cost-estimation`: add a "See also" linking forward to `cost-analysis` and back to `defining-a-scenario` (end its dead-end); fix the 430-hour benchmark attribution (it lives in the archived exploration sweep, not `ssd_define_scenario()`'s docs); reconcile the 44 vs 45.3-minute figure.
-- [ ] 4.2 Remove the OpenSpec-internal "the change's `exploration/` directory" phrasing from the vignette and from `R/cost-estimate.R` roxygen (then re-document so `man/` updates).
-- [ ] 4.3 `scenario-to-design`: add a "See also" section; add a forward link from `defining-a-scenario` to `scenario-to-design`.
-- [ ] 4.4 `sharded-pipeline`: fix "four-file" → the template's actual file set; make the fit-shard arithmetic include the `dataset` path axis (`1 × 2 × 2 × 2 = 8`).
-- [ ] 4.5 `cluster-pipeline`: soften "asserts byte-identical" to reflect the printed `all.equal` check on the `est` column in `large/run-serial.R`.
-- [ ] 4.6 `cloud-upload`: remove the stray trailing code-fence artifact.
-- [ ] 4.7 Sweep for any remaining reader-facing repo-internal references (`TARGETS-DESIGN.md §`, `data-raw/...`) and either resolve to a public anchor or drop.
-- [ ] 4.8 Standardise the heading spine / add closing navigation so the seven vignettes read as one set.
+- [x] 4.1 `cost-estimation`: add a "See also" linking forward to `cost-analysis` and back to `defining-a-scenario` (end its dead-end); fix the 430-hour benchmark attribution (it lives in the archived exploration sweep, not `ssd_define_scenario()`'s docs); reconcile the 44 vs 45.3-minute figure.
+- [x] 4.2 Remove the OpenSpec-internal "the change's `exploration/` directory" phrasing from the vignette and from `R/cost-estimate.R` roxygen (then re-document so `man/` updates).
+- [x] 4.3 `scenario-to-design`: add a "See also" section; add a forward link from `defining-a-scenario` to `scenario-to-design`.
+- [x] 4.4 `sharded-pipeline`: fix "four-file" → the template's actual file set; make the fit-shard arithmetic include the `dataset` path axis (`1 × 2 × 2 × 2 = 8`).
+- [x] 4.5 `cluster-pipeline`: soften "asserts byte-identical" to reflect the printed `all.equal` check on the `est` column in `large/run-serial.R`.
+- [x] 4.6 `cloud-upload`: remove the stray trailing code-fence artifact.
+- [x] 4.7 Sweep for any remaining reader-facing repo-internal references (`TARGETS-DESIGN.md §`, `data-raw/...`) and either resolve to a public anchor or drop.
+- [x] 4.8 Standardise the heading spine / add closing navigation so the seven vignettes read as one set.
 
 ## 5. Regenerate and verify
 
-- [ ] 5.1 Re-knit `README.md` from `README.Rmd` with `devtools::build_readme()`.
-- [ ] 5.2 Render the pkgdown site and confirm `vignette("ssdsims")` is the Get-started entry and every `vignette()`/reference link resolves (`pkgdown::check_pkgdown()`).
-- [ ] 5.3 Confirm all evaluated chunks run without error and printed output is captured; verify no example references a legacy or non-exported function.
-- [ ] 5.4 Run `air format` on any touched `R/` (the `cost-estimate.R` roxygen edit) and review the full diff before committing.
+- [x] 5.1 Re-knit `README.md` from `README.Rmd` with `devtools::build_readme()`.
+- [x] 5.2 Render the pkgdown site and confirm `vignette("ssdsims")` is the Get-started entry and every `vignette()`/reference link resolves (`pkgdown::check_pkgdown()`).
+- [x] 5.3 Confirm all evaluated chunks run without error and printed output is captured; verify no example references a legacy or non-exported function.
+- [x] 5.4 Run `air format` on any touched `R/` (the `cost-estimate.R` roxygen edit) and review the full diff before committing.

--- a/openspec/changes/readme/tasks.md
+++ b/openspec/changes/readme/tasks.md
@@ -21,8 +21,8 @@
 
 ## 3. Convert cross-links to vignette()-style (package-wide)
 
-- [x] 3.1 Convert every vignette-to-vignette link in all seven existing vignettes (and the new overview and README) from `.html`/absolute URLs to `vignette("name")`-style links.
-- [x] 3.2 Point function-name links at the function reference, not at article pages (fixes the `cost-analysis` links to `ssd_estimate_cost()` / `ssd_calibrate_cost()`).
+- [x] 3.1 In the vignettes (incl. the overview), write cross-references as bare inline `vignette("name")` / `fn()` code so pkgdown auto-links them; phrase each as a clean standalone call. In the README, use explicit Markdown links to the pkgdown URLs (GitHub does not auto-link).
+- [x] 3.2 Reference functions as bare `fn()` (auto-linked to their reference page), not as links to article pages, and not as `?fn` (which does not auto-link).
 
 ## 4. Apply the per-vignette review fixes
 

--- a/vignettes/cloud-upload.qmd
+++ b/vignettes/cloud-upload.qmd
@@ -29,13 +29,12 @@ knitr::opts_chunk$set(eval = evaluate)
 library(ssdsims)
 ```
 
-The ["Running a Sharded Pipeline"](sharded-pipeline.html) vignette materialises
-each step as Hive-partitioned Parquet shards, and the
-["Running on a SLURM Cluster"](cluster-pipeline.html) vignette runs that same
-pipeline on a cluster. This vignette covers the last link: shipping each shard
-to an **object store** as it is produced, so the results are readable **from
-outside the cluster** --- analysis notebooks, dashboards, downstream R/Python
-(`TARGETS-DESIGN.md` §6.1).
+The [`vignette("sharded-pipeline")`](sharded-pipeline.html) article materialises
+each step as Hive-partitioned Parquet shards, and
+[`vignette("cluster-pipeline")`](cluster-pipeline.html) runs that same pipeline on
+a cluster. This vignette covers the last link: shipping each shard to an **object
+store** as it is produced, so the results are readable **from outside the
+cluster** --- analysis notebooks, dashboards, downstream R/Python.
 
 The model is simple: **upload is a runner argument**, the remote-destination
 sibling of `root`. You pass an `upload` object to the
@@ -180,8 +179,8 @@ credentials.
 
 To ship to a real Azure container, swap `ssd_upload_dryrun()` for
 `ssd_upload_azure(url, container)` in the **cluster** template's `_targets.R`
-(["Running on a SLURM Cluster"](cluster-pipeline.html)). It is the same factory
-call --- one line changes:
+(see [`vignette("cluster-pipeline")`](cluster-pipeline.html)). It is the same
+factory call --- one line changes:
 
 ```{r}
 #| label: azure-targets
@@ -288,13 +287,11 @@ ssd_summarise_uploaded(upload, step = "summary_samples", drop_samples = FALSE)
 
 ## See also
 
-- ["Running a Sharded Pipeline"](sharded-pipeline.html) --- materialising the
+- [`vignette("sharded-pipeline")`](sharded-pipeline.html) --- materialising the
   shards this vignette uploads.
-- ["Running on a SLURM Cluster"](cluster-pipeline.html) --- the cluster template
-  whose `_targets.R` gains the `upload = ssd_upload_azure(...)` line.
-- `TARGETS-DESIGN.md` §6.1 (the cloud-upload hook).
-- [`?ssd_upload_azure`](../reference/ssd_upload_azure.html),
-  [`?ssd_test_upload`](../reference/ssd_test_upload.html),
-  [`?ssd_upload_shard`](../reference/ssd_upload_shard.html),
-  [`?ssd_open_uploaded`](../reference/ssd_open_uploaded.html).
-```
+- [`vignette("cluster-pipeline")`](cluster-pipeline.html) --- the cluster
+  template whose `_targets.R` gains the `upload = ssd_upload_azure(...)` line.
+- [`ssd_upload_azure()`](../reference/ssd_upload_azure.html),
+  [`ssd_test_upload()`](../reference/ssd_test_upload.html),
+  [`ssd_upload_shard()`](../reference/ssd_upload_shard.html),
+  [`ssd_open_uploaded()`](../reference/ssd_open_uploaded.html).

--- a/vignettes/cloud-upload.qmd
+++ b/vignettes/cloud-upload.qmd
@@ -29,16 +29,16 @@ knitr::opts_chunk$set(eval = evaluate)
 library(ssdsims)
 ```
 
-The [`vignette("sharded-pipeline")`](sharded-pipeline.html) article materialises
+The `vignette("sharded-pipeline")` article materialises
 each step as Hive-partitioned Parquet shards, and
-[`vignette("cluster-pipeline")`](cluster-pipeline.html) runs that same pipeline on
+`vignette("cluster-pipeline")` runs that same pipeline on
 a cluster. This vignette covers the last link: shipping each shard to an **object
 store** as it is produced, so the results are readable **from outside the
 cluster** --- analysis notebooks, dashboards, downstream R/Python.
 
 The model is simple: **upload is a runner argument**, the remote-destination
 sibling of `root`. You pass an `upload` object to the
-[`ssd_scenario_targets()`](../reference/ssd_scenario_targets.html) factory and it
+`ssd_scenario_targets()` factory and it
 pairs each step shard with an `upload_<step>` target. There are three modes:
 
 - `upload = NULL` (the default) --- **no** upload targets; the clean DAG.
@@ -179,7 +179,7 @@ credentials.
 
 To ship to a real Azure container, swap `ssd_upload_dryrun()` for
 `ssd_upload_azure(url, container)` in the **cluster** template's `_targets.R`
-(see [`vignette("cluster-pipeline")`](cluster-pipeline.html)). It is the same
+(see `vignette("cluster-pipeline")`). It is the same
 factory call --- one line changes:
 
 ```{r}
@@ -287,11 +287,11 @@ ssd_summarise_uploaded(upload, step = "summary_samples", drop_samples = FALSE)
 
 ## See also
 
-- [`vignette("sharded-pipeline")`](sharded-pipeline.html) --- materialising the
+- `vignette("sharded-pipeline")` --- materialising the
   shards this vignette uploads.
-- [`vignette("cluster-pipeline")`](cluster-pipeline.html) --- the cluster
+- `vignette("cluster-pipeline")` --- the cluster
   template whose `_targets.R` gains the `upload = ssd_upload_azure(...)` line.
-- [`ssd_upload_azure()`](../reference/ssd_upload_azure.html),
-  [`ssd_test_upload()`](../reference/ssd_test_upload.html),
-  [`ssd_upload_shard()`](../reference/ssd_upload_shard.html),
-  [`ssd_open_uploaded()`](../reference/ssd_open_uploaded.html).
+- `ssd_upload_azure()`,
+  `ssd_test_upload()`,
+  `ssd_upload_shard()`,
+  `ssd_open_uploaded()`.

--- a/vignettes/cluster-pipeline.qmd
+++ b/vignettes/cluster-pipeline.qmd
@@ -25,12 +25,11 @@ knitr::opts_chunk$set(eval = evaluate)
 library(ssdsims)
 ```
 
-The ["Running a Sharded Pipeline"](sharded-pipeline.html) vignette runs a
+The [`vignette("sharded-pipeline")`](sharded-pipeline.html) article runs a
 scenario's shards through a `targets` pipeline on a single machine. This vignette
 takes that **same pipeline to a SLURM cluster** — and the only thing that
-changes is the `crew` controller (`TARGETS-DESIGN.md` §4). The per-task
-`sample`/`fit`/`hc` results are byte-identical to the local run; the cluster is
-just a faster backend.
+changes is the `crew` controller. The per-task `sample`/`fit`/`hc` results are
+byte-identical to the local run; the cluster is just a faster backend.
 
 You do **not** need to know `crew` or `targets` to follow this guide — only your
 cluster's own (non-R) usage instructions. It is four steps: map your site's SLURM
@@ -51,7 +50,7 @@ cluster-specific**:
 | **B — backend** | the SLURM `crew` controller (queue, modules, scratch, workers, walltime) | the **one editable block** in `controller.R` |
 | **C — content** | the scenario (seed, datasets, grids) | the inline `scenario` block in `_targets.R` |
 
-It is just four files — separating only what cannot be inlined:
+It is just five files — separating only what cannot be inlined:
 
 ```{r}
 #| label: template-files
@@ -61,8 +60,9 @@ list.files(system.file("targets-templates", "cluster", package = "ssdsims"))
 `controller.R` (the **one editable controller block**, sourced by both the
 pipeline and the preflight), `_targets.R` (the clean pipeline: controller + the
 inline scenario + factory), `preflight.R` (the standalone
-connectivity/prerequisite check, kept out of the pipeline), and `run.R` (the
-driver: preflight then `tar_make()`). Copy them to your project root:
+connectivity/prerequisite check, kept out of the pipeline), `run.R` (the
+driver: preflight then `tar_make()`), and a `README.md` copy of this guide. Copy
+them to your project root:
 
 ```{r}
 #| label: get-template
@@ -206,7 +206,7 @@ is your first running cluster job, end to end.
 prerequisite. To run the **same study off a cluster** (no scheduler), use the
 `large` template — it builds the identical pipeline (same factory + scenario)
 under a `crew::crew_controller_local()` controller, and its `run-serial.R`
-asserts the results are byte-identical.
+checks (with `all.equal()`) that the single-core and targets estimates match.
 :::
 
 ## Step 4 — Swap in your own scenario
@@ -294,13 +294,12 @@ controller packs several shards into one worker's lifetime — "many-to-one";
 
 ## See also
 
-- The template's own `README.md` (the same guide, alongside the files) and
-  `TARGETS-DESIGN.md` §4 (from local to a cluster), §11 (open questions), §12
-  (`cluster-pipeline`).
-- [`?ssd_scenario_targets`](../reference/ssd_scenario_targets.html),
+- [`vignette("sharded-pipeline")`](sharded-pipeline.html) — the
+  `small`/`large`/`cluster` template trio and the single-machine `targets`
+  pipeline.
+- [`vignette("cloud-upload")`](cloud-upload.html) — ship the cluster's shards to
+  an object store (the `upload = ssd_upload_azure(...)` line in this template's
+  `_targets.R`) and read them back in place.
+- [`ssd_scenario_targets()`](../reference/ssd_scenario_targets.html),
   `?crew.cluster::crew_controller_slurm`.
-- The ["Running a Sharded Pipeline"](sharded-pipeline.html) vignette — the
-  `small`/`large`/`cluster` template trio.
-- ["Uploading Shards to Cloud Storage"](cloud-upload.html) — ship the cluster's
-  shards to an object store (the `upload = ssd_upload_azure(...)` line in this
-  template's `_targets.R`) and read them back in place.
+- The template's own `README.md` ships the same guide alongside the files.

--- a/vignettes/cluster-pipeline.qmd
+++ b/vignettes/cluster-pipeline.qmd
@@ -25,7 +25,7 @@ knitr::opts_chunk$set(eval = evaluate)
 library(ssdsims)
 ```
 
-The [`vignette("sharded-pipeline")`](sharded-pipeline.html) article runs a
+The `vignette("sharded-pipeline")` article runs a
 scenario's shards through a `targets` pipeline on a single machine. This vignette
 takes that **same pipeline to a SLURM cluster** — and the only thing that
 changes is the `crew` controller. The per-task `sample`/`fit`/`hc` results are
@@ -279,7 +279,7 @@ controller <- crew.cluster::crew_controller_sge(
 )
 ```
 
-See `?crew.cluster::crew_controller_sge` (and the `_pbs` / `_lsf` equivalents)
+See `crew.cluster::crew_controller_sge()` (and the `_pbs` / `_lsf` equivalents)
 for the exact arguments. Everything else in this guide — the preflight, the
 minimal first job, swapping in your scenario — is unchanged.
 
@@ -294,12 +294,12 @@ controller packs several shards into one worker's lifetime — "many-to-one";
 
 ## See also
 
-- [`vignette("sharded-pipeline")`](sharded-pipeline.html) — the
+- `vignette("sharded-pipeline")` — the
   `small`/`large`/`cluster` template trio and the single-machine `targets`
   pipeline.
-- [`vignette("cloud-upload")`](cloud-upload.html) — ship the cluster's shards to
+- `vignette("cloud-upload")` — ship the cluster's shards to
   an object store (the `upload = ssd_upload_azure(...)` line in this template's
   `_targets.R`) and read them back in place.
-- [`ssd_scenario_targets()`](../reference/ssd_scenario_targets.html),
-  `?crew.cluster::crew_controller_slurm`.
+- `ssd_scenario_targets()`,
+  `crew.cluster::crew_controller_slurm()`.
 - The template's own `README.md` ships the same guide alongside the files.

--- a/vignettes/cost-analysis.qmd
+++ b/vignettes/cost-analysis.qmd
@@ -29,9 +29,9 @@ library(ssdsims)
 
 ## Prediction, then measurement
 
-[`ssd_estimate_cost()`](../reference/ssd_estimate_cost.html) predicts a
+`ssd_estimate_cost()` predicts a
 scenario's compute cost *before* a run (see
-[`vignette("cost-estimation")`](cost-estimation.html)), from a cost model
+`vignette("cost-estimation")`), from a cost model
 calibrated by a synthetic micro-benchmark. Once a run has happened it leaves
 **ground truth** behind: every `fit` and `hc` task's
 body is bracketed with a UTC `.start`/`.end` and tagged with the `.host` CPU, and
@@ -46,7 +46,7 @@ pipeline, fit a distribution, draw a random number, or write a file.
 ## A small worked run
 
 Any run leaves timings behind --- the serial baseline, the single-core
-[`ssd_run_scenario_shards()`](../reference/ssd_run_scenario_shards.html), or the
+`ssd_run_scenario_shards()`, or the
 `targets` pipeline. Here we materialise a small scenario single-core so the
 vignette is self-contained:
 
@@ -118,7 +118,7 @@ machine --- which is exactly what recalibration fixes.
 `ssd_calibrate_cost_from_run()` re-fits the per-task cost model from the run's
 **measured** hc task durations (and a measured fit addend), returning the same
 `ssdsims_cost_calibration` object
-[`ssd_calibrate_cost()`](../reference/ssd_calibrate_cost.html) produces --- so it
+`ssd_calibrate_cost()` produces --- so it
 drops straight back into `ssd_estimate_cost()`, now grounded in
 real measurements from this scenario rather than a synthetic sweep:
 
@@ -139,7 +139,7 @@ that it was derived from a run.
 ## Across a design
 
 A design (`ssd_design()`; see
-[`vignette("scenario-to-design")`](scenario-to-design.html)) runs several
+`vignette("scenario-to-design")`) runs several
 scenarios as one pipeline. The same three functions accept a design and **roll the observed cost up
 across its members**: `ssd_analyse_cost(design, root = ...)` returns a breakdown
 with a leading `scenario` column and design totals, `ssd_compare_cost(design)`
@@ -193,10 +193,10 @@ turns.
 
 ## See also
 
-- [`vignette("cost-estimation")`](cost-estimation.html) --- the complement:
+- `vignette("cost-estimation")` --- the complement:
   *predict* a scenario's cost before running it.
-- [`vignette("sharded-pipeline")`](sharded-pipeline.html) --- the shard runs
+- `vignette("sharded-pipeline")` --- the shard runs
   whose per-task timings this reads back.
-- [`ssd_analyse_cost()`](../reference/ssd_analyse_cost.html),
-  [`ssd_compare_cost()`](../reference/ssd_compare_cost.html),
-  [`ssd_calibrate_cost_from_run()`](../reference/ssd_calibrate_cost_from_run.html).
+- `ssd_analyse_cost()`,
+  `ssd_compare_cost()`,
+  `ssd_calibrate_cost_from_run()`.

--- a/vignettes/cost-analysis.qmd
+++ b/vignettes/cost-analysis.qmd
@@ -29,9 +29,11 @@ library(ssdsims)
 
 ## Prediction, then measurement
 
-[`ssd_estimate_cost()`](cost-estimation.html) predicts a scenario's compute cost
-*before* a run, from a cost model calibrated by a synthetic micro-benchmark. Once
-a run has happened it leaves **ground truth** behind: every `fit` and `hc` task's
+[`ssd_estimate_cost()`](../reference/ssd_estimate_cost.html) predicts a
+scenario's compute cost *before* a run (see
+[`vignette("cost-estimation")`](cost-estimation.html)), from a cost model
+calibrated by a synthetic micro-benchmark. Once a run has happened it leaves
+**ground truth** behind: every `fit` and `hc` task's
 body is bracketed with a UTC `.start`/`.end` and tagged with the `.host` CPU, and
 those land as columns of the shard Parquets themselves. `ssd_analyse_cost()` reads
 them back and attributes the *observed* compute to the same `ci_method` × `nboot`
@@ -115,8 +117,9 @@ machine --- which is exactly what recalibration fixes.
 
 `ssd_calibrate_cost_from_run()` re-fits the per-task cost model from the run's
 **measured** hc task durations (and a measured fit addend), returning the same
-`ssdsims_cost_calibration` object [`ssd_calibrate_cost()`](cost-estimation.html)
-produces --- so it drops straight back into `ssd_estimate_cost()`, now grounded in
+`ssdsims_cost_calibration` object
+[`ssd_calibrate_cost()`](../reference/ssd_calibrate_cost.html) produces --- so it
+drops straight back into `ssd_estimate_cost()`, now grounded in
 real measurements from this scenario rather than a synthetic sweep:
 
 ```{r}
@@ -135,8 +138,9 @@ that it was derived from a run.
 
 ## Across a design
 
-A [design](scenario-to-design.html) (`ssd_design()`) runs several scenarios as one
-pipeline. The same three functions accept a design and **roll the observed cost up
+A design (`ssd_design()`; see
+[`vignette("scenario-to-design")`](scenario-to-design.html)) runs several
+scenarios as one pipeline. The same three functions accept a design and **roll the observed cost up
 across its members**: `ssd_analyse_cost(design, root = ...)` returns a breakdown
 with a leading `scenario` column and design totals, `ssd_compare_cost(design)`
 places the design's summed prediction beside it, and
@@ -186,3 +190,13 @@ ssd_estimate_cost(next_scenario, calibration = better)          # predict the ne
 Each larger scenario is then sized from the measured cost of the last, rather
 than a synthetic micro-benchmark --- the estimate improves every time the loop
 turns.
+
+## See also
+
+- [`vignette("cost-estimation")`](cost-estimation.html) --- the complement:
+  *predict* a scenario's cost before running it.
+- [`vignette("sharded-pipeline")`](sharded-pipeline.html) --- the shard runs
+  whose per-task timings this reads back.
+- [`ssd_analyse_cost()`](../reference/ssd_analyse_cost.html),
+  [`ssd_compare_cost()`](../reference/ssd_compare_cost.html),
+  [`ssd_calibrate_cost_from_run()`](../reference/ssd_calibrate_cost_from_run.html).

--- a/vignettes/cost-estimation.qmd
+++ b/vignettes/cost-estimation.qmd
@@ -29,11 +29,11 @@ library(ssdsims)
 ## Why estimate cost?
 
 A scenario is *declarative*: a few scenario axes can fan out into a multi-day run with
-no warning. The motivating example in `ssd_define_scenario()`'s docs --- 10
-simulations × 4 sample sizes × 7 `ci_method`s × 4 `nboot` values (up to 50 000),
-with `ci = TRUE` --- was measured at roughly **430 single-core hours** (about 18
-days), dominated by the hazard-concentration (hc) bootstrap, with a single
-`multi_free` + `nboot = 50 000` task taking about 44 minutes on its own.
+no warning. A benchmark of the example scenario below --- 10 simulations × 4
+sample sizes × 7 `ci_method`s × 4 `nboot` values (up to 50 000), with
+`ci = TRUE` --- measured roughly **400+ single-core hours** (the better part of
+three weeks), dominated by the hazard-concentration (hc) bootstrap, with a single
+`multi_*` + `nboot = 50 000` task taking on the order of an hour on its own.
 
 Before launching such a run you want two numbers:
 
@@ -76,10 +76,9 @@ cheapest, the `multi_*` methods the most expensive --- so the `ci_method` grid
 is by far the dominant cost driver.
 
 The one-time research that *discovered* this model's form (which axes are free,
-the `max(nboot, n0)` shape, the non-monotonic `nrow` factor) is preserved under
-the change's `exploration/` directory. Those scripts are illustrative; you never
-rerun them. Recalibrating for a new machine is a single function call, described
-below.
+the `max(nboot, n0)` shape, the non-monotonic `nrow` factor) is illustrative ---
+you never rerun it. Recalibrating for a new machine is a single function call,
+described below.
 
 ## The calibration object
 
@@ -186,9 +185,9 @@ my_calibration <- ssd_calibrate_cost()
 ssd_estimate_cost(scenario, calibration = my_calibration)
 ```
 
-The shipped default (`data-raw/cost_calibration.R`) is produced by exactly this
-call --- the function *is* the reproducibility mechanism, and this vignette only
-documents and demonstrates it.
+The shipped default calibration is produced by exactly this call --- the function
+*is* the reproducibility mechanism, and this vignette only documents and
+demonstrates it.
 
 ## Caveats
 
@@ -201,3 +200,13 @@ documents and demonstrates it.
 - `ssdtools` performance can change across versions; the calibration's
   provenance records the version it was measured against, and recalibration
   corrects drift.
+
+## See also
+
+- [`vignette("cost-analysis")`](cost-analysis.html) --- the complement: measure a
+  finished run's *observed* cost and recalibrate from it.
+- [`vignette("defining-a-scenario")`](defining-a-scenario.html) --- the scenario
+  axes whose fan-out this estimate reads.
+- [`ssd_estimate_cost()`](../reference/ssd_estimate_cost.html),
+  [`ssd_calibrate_cost()`](../reference/ssd_calibrate_cost.html),
+  [`ssd_cost_calibration()`](../reference/ssd_cost_calibration.html).

--- a/vignettes/cost-estimation.qmd
+++ b/vignettes/cost-estimation.qmd
@@ -203,10 +203,10 @@ demonstrates it.
 
 ## See also
 
-- [`vignette("cost-analysis")`](cost-analysis.html) --- the complement: measure a
+- `vignette("cost-analysis")` --- the complement: measure a
   finished run's *observed* cost and recalibrate from it.
-- [`vignette("defining-a-scenario")`](defining-a-scenario.html) --- the scenario
+- `vignette("defining-a-scenario")` --- the scenario
   axes whose fan-out this estimate reads.
-- [`ssd_estimate_cost()`](../reference/ssd_estimate_cost.html),
-  [`ssd_calibrate_cost()`](../reference/ssd_calibrate_cost.html),
-  [`ssd_cost_calibration()`](../reference/ssd_cost_calibration.html).
+- `ssd_estimate_cost()`,
+  `ssd_calibrate_cost()`,
+  `ssd_cost_calibration()`.

--- a/vignettes/defining-a-scenario.qmd
+++ b/vignettes/defining-a-scenario.qmd
@@ -45,10 +45,8 @@ Keeping the scenario declarative buys two things:
 - The set of work a pipeline expands to is a **pure function of the scenario**,
   so the same scenario always describes the same study.
 
-This vignette walks the stages that work *today*, in order. It is intended to
-grow: as roadmap features land (per-task seeding, shards, the `targets`
-backend), new sections will document them here. See `TARGETS-DESIGN.md` for the
-north-star design.
+This vignette walks the four stages in order; the runner, design, and pipeline
+vignettes linked at the end build on them.
 
 The four stages this vignette covers:
 
@@ -357,16 +355,21 @@ hcs <- tidyr::unnest(
 hcs[c("dataset", "sim", "nrow", "hc_est_method", "hc_proportion", "hc_est")]
 ```
 
-## Next: shards and the targets pipeline
+## Next: shards, designs, and the targets pipeline
 
 The baseline runner threads results in memory. The next layer materialises each
 step as **Hive-partitioned Parquet shards** grouped by the scenario's
 `partition_by` axes, and links steps by reading parent shards back --- the
-storage hand-off the cluster `targets` pipeline uses. The
-["Running a sharded pipeline"](sharded-pipeline.html) vignette covers that: the
-single-core `ssd_run_scenario_shards()` (byte-identical to the baseline runner)
-and the shipped `targets` template.
+storage hand-off the cluster `targets` pipeline uses.
 
-Still ahead on the roadmap (`TARGETS-DESIGN.md` §12): a per-scenario manifest,
-cloud upload, shard-completeness assertions, and the crew/SLURM controller. As
-each lands, the vignettes grow to cover it.
+## See also
+
+- [`vignette("sharded-pipeline")`](sharded-pipeline.html) --- the same scenario
+  as Parquet shards and a `targets` pipeline; the single-core
+  `ssd_run_scenario_shards()` is byte-identical to this baseline runner.
+- [`vignette("scenario-to-design")`](scenario-to-design.html) --- union several
+  scenarios into one ragged design that shares overlapping shards.
+- [`vignette("cost-estimation")`](cost-estimation.html) --- size a scenario's
+  compute before launching it.
+- [`vignette("ssdsims")`](ssdsims.html) --- the overview and a recommended
+  reading order.

--- a/vignettes/defining-a-scenario.qmd
+++ b/vignettes/defining-a-scenario.qmd
@@ -364,12 +364,12 @@ storage hand-off the cluster `targets` pipeline uses.
 
 ## See also
 
-- [`vignette("sharded-pipeline")`](sharded-pipeline.html) --- the same scenario
+- `vignette("sharded-pipeline")` --- the same scenario
   as Parquet shards and a `targets` pipeline; the single-core
   `ssd_run_scenario_shards()` is byte-identical to this baseline runner.
-- [`vignette("scenario-to-design")`](scenario-to-design.html) --- union several
+- `vignette("scenario-to-design")` --- union several
   scenarios into one ragged design that shares overlapping shards.
-- [`vignette("cost-estimation")`](cost-estimation.html) --- size a scenario's
+- `vignette("cost-estimation")` --- size a scenario's
   compute before launching it.
-- [`vignette("ssdsims")`](ssdsims.html) --- the overview and a recommended
+- `vignette("ssdsims")` --- the overview and a recommended
   reading order.

--- a/vignettes/scenario-to-design.qmd
+++ b/vignettes/scenario-to-design.qmd
@@ -180,5 +180,13 @@ to plot the broad sweep and the zoom together.
   comparison axis; differing or changing it across members is undefined
   behaviour for shard sharing.
 
-See ["Running a Sharded Pipeline"](sharded-pipeline.html) for the shard/results
-layout a design builds on.
+## See also
+
+- [`vignette("sharded-pipeline")`](sharded-pipeline.html) --- the shard/results
+  layout a design builds on.
+- [`vignette("defining-a-scenario")`](defining-a-scenario.html) --- the scenario
+  object each design member is.
+- [`vignette("cost-analysis")`](cost-analysis.html) --- roll observed compute up
+  across a design's members.
+- [`ssd_design()`](../reference/ssd_design.html),
+  [`ssd_design_targets()`](../reference/ssd_design_targets.html).

--- a/vignettes/scenario-to-design.qmd
+++ b/vignettes/scenario-to-design.qmd
@@ -182,11 +182,11 @@ to plot the broad sweep and the zoom together.
 
 ## See also
 
-- [`vignette("sharded-pipeline")`](sharded-pipeline.html) --- the shard/results
+- `vignette("sharded-pipeline")` --- the shard/results
   layout a design builds on.
-- [`vignette("defining-a-scenario")`](defining-a-scenario.html) --- the scenario
+- `vignette("defining-a-scenario")` --- the scenario
   object each design member is.
-- [`vignette("cost-analysis")`](cost-analysis.html) --- roll observed compute up
+- `vignette("cost-analysis")` --- roll observed compute up
   across a design's members.
-- [`ssd_design()`](../reference/ssd_design.html),
-  [`ssd_design_targets()`](../reference/ssd_design_targets.html).
+- `ssd_design()`,
+  `ssd_design_targets()`.

--- a/vignettes/sharded-pipeline.qmd
+++ b/vignettes/sharded-pipeline.qmd
@@ -26,13 +26,12 @@ knitr::opts_chunk$set(eval = evaluate)
 library(ssdsims)
 ```
 
-The ["Defining a Scenario"](defining-a-scenario.html) vignette ends with the
-in-memory baseline runner, which threads each step's results forward in memory.
-This vignette covers the next layer: materialising each step as
+The [`vignette("defining-a-scenario")`](defining-a-scenario.html) article ends
+with the in-memory baseline runner, which threads each step's results forward in
+memory. This vignette covers the next layer: materialising each step as
 **Hive-partitioned Parquet shards** and linking the steps by reading parent
 shards back from disk --- the storage hand-off the cluster
-[targets](https://docs.ropensci.org/targets/) pipeline is built on
-(`TARGETS-DESIGN.md` §5/§6).
+[targets](https://docs.ropensci.org/targets/) pipeline is built on.
 
 The key idea is **two drivers over one execution core**. The per-task work
 (draw, fit, hazard concentration) and its reproducible per-task RNG are shared;
@@ -157,9 +156,9 @@ fit_files <- list.files(
 fit_files
 ```
 
-One file per `partition_by` path cell --- here `2 (sim) x 2 (nrow) x 2 (rescale)
-= 8` fit shards --- not one per task. Each file carries the step's inner axes
-and the per-task results as columns.
+One file per `partition_by` path cell --- here `1 (dataset) x 2 (sim) x 2 (nrow)
+x 2 (rescale) = 8` fit shards --- not one per task. Each file carries the step's
+inner axes and the per-task results as columns.
 
 ### Results match the in-memory runner
 
@@ -207,9 +206,9 @@ project parallelises its shards across local workers with a mirai-backed `crew`
 controller (`tar_option_set(controller = crew::crew_controller_local())`); the
 `cluster` project is the same pipeline under a
 `crew.cluster::crew_controller_slurm()` controller, with a connectivity +
-worker-prerequisite preflight — see the
-["Running on a SLURM Cluster"](cluster-pipeline.html) vignette, a "zero to a
-running cluster job" guide that maps your site's own SLURM instructions onto the
+worker-prerequisite preflight — see
+[`vignette("cluster-pipeline")`](cluster-pipeline.html), a "zero to a running
+cluster job" guide that maps your site's own SLURM instructions onto the
 controller:
 
 ```{r}
@@ -219,9 +218,10 @@ list.files(system.file("targets-templates", "small", package = "ssdsims"))
 
 The `small` and `large` directories each hold `scenario.R` (the study, shared by
 both drivers), `_targets.R` (the pipeline), `run.R` (the **targets** driver), and
-`run-serial.R` (the **single-core** driver); the `cluster` directory is a minimal
-four-file variant (the scenario is inline in `_targets.R`, and a separate
-`controller.R` holds the SLURM controller). The whole `_targets.R` is just
+`run-serial.R` (the **single-core** driver); the `cluster` directory instead
+inlines the scenario in `_targets.R` and adds a `controller.R` (the SLURM
+controller), a `preflight.R` (connectivity check), a `run.R` driver, and a
+`README.md` guide. The whole `_targets.R` is just
 *build a scenario and call the `ssd_scenario_targets()` factory* —
 
 ```{r}
@@ -249,7 +249,7 @@ source("run.R") # targets: tar_make() -> one target per shard -> results/<step>/
 # or, from a shell:  Rscript run.R
 
 source("run-serial.R") # single core via ssd_run_scenario_shards() -> results-serial/
-# ...and, if results/ exists, it asserts the two drivers' estimates are identical
+# ...and, if results/ exists, it checks (and prints) whether the two drivers' estimates match
 ```
 
 `ssd_scenario_targets()` mints one `format = "file"` target per shard (targets
@@ -270,9 +270,9 @@ split change is a fresh tree; `run-serial.R` (single core) instead **owns** its
 Because both drivers `source("scenario.R")` --- the same study --- and
 `partition_by` is a free re-layout, `run-serial.R` finishes by reading back its
 own `summary.parquet` and the targets `scenario_results_dir(scenario)` summary
-and asserting the per-task estimates are byte-identical. Whatever the driver --- baseline,
-single-core shards, or `targets` --- the results are the same; choose the one
-that fits the run.
+and checking (with `all.equal()`) that the per-task estimates match. Whatever the
+driver --- baseline, single-core shards, or `targets` --- the results are the
+same; choose the one that fits the run.
 
 ## Combining scenarios into a design
 
@@ -283,7 +283,7 @@ a **design** and run them as one pipeline with `ssd_design_targets()`. Members
 sharing a `seed` share their coincident shards (computed once), and the design
 fans in one combined `summary.parquet` with a `scenario` identity column. Growing
 a one-off run into a design is a one-line switch; see
-["From a Single Scenario to a Design"](scenario-to-design.html).
+[`vignette("scenario-to-design")`](scenario-to-design.html).
 
 ### Comparing settings in one design
 
@@ -316,14 +316,14 @@ to its standalone run.
 
 ## See also
 
-- ["From a Single Scenario to a Design"](scenario-to-design.html) --- union
+- [`vignette("defining-a-scenario")`](defining-a-scenario.html) --- the scenario
+  object and the baseline runner.
+- [`vignette("scenario-to-design")`](scenario-to-design.html) --- union
   scenarios into one ragged pipeline that shares overlapping shards.
-- ["Defining a Scenario"](defining-a-scenario.html) --- the scenario object and
-  the baseline runner.
-- ["Running on a SLURM Cluster"](cluster-pipeline.html) --- the same pipeline on
-  a cluster, and ["Uploading Shards to Cloud Storage"](cloud-upload.html) ---
-  shipping the shards to an object store so they are readable off the cluster.
-- `TARGETS-DESIGN.md` §5 (tasks into shards), §6 (inter-shard linking, the Hive
-  layout, the `targets` sketch).
-- `?ssd_run_scenario_shards`, `?ssd_scenario_fit_shards`, `?ssd_run_fit_step`,
-  `?ssd_summarise`.
+- [`vignette("cluster-pipeline")`](cluster-pipeline.html) --- the same pipeline
+  on a cluster, and [`vignette("cloud-upload")`](cloud-upload.html) --- shipping
+  the shards to an object store so they are readable off the cluster.
+- [`ssd_run_scenario_shards()`](../reference/ssd_run_scenario_shards.html),
+  [`ssd_scenario_fit_shards()`](../reference/ssd_scenario_shards.html),
+  [`ssd_run_fit_step()`](../reference/ssd_run_step.html),
+  [`ssd_summarise()`](../reference/ssd_summarise.html).

--- a/vignettes/sharded-pipeline.qmd
+++ b/vignettes/sharded-pipeline.qmd
@@ -26,7 +26,7 @@ knitr::opts_chunk$set(eval = evaluate)
 library(ssdsims)
 ```
 
-The [`vignette("defining-a-scenario")`](defining-a-scenario.html) article ends
+The `vignette("defining-a-scenario")` article ends
 with the in-memory baseline runner, which threads each step's results forward in
 memory. This vignette covers the next layer: materialising each step as
 **Hive-partitioned Parquet shards** and linking the steps by reading parent
@@ -207,7 +207,7 @@ controller (`tar_option_set(controller = crew::crew_controller_local())`); the
 `cluster` project is the same pipeline under a
 `crew.cluster::crew_controller_slurm()` controller, with a connectivity +
 worker-prerequisite preflight — see
-[`vignette("cluster-pipeline")`](cluster-pipeline.html), a "zero to a running
+`vignette("cluster-pipeline")`, a "zero to a running
 cluster job" guide that maps your site's own SLURM instructions onto the
 controller:
 
@@ -283,7 +283,7 @@ a **design** and run them as one pipeline with `ssd_design_targets()`. Members
 sharing a `seed` share their coincident shards (computed once), and the design
 fans in one combined `summary.parquet` with a `scenario` identity column. Growing
 a one-off run into a design is a one-line switch; see
-[`vignette("scenario-to-design")`](scenario-to-design.html).
+`vignette("scenario-to-design")`.
 
 ### Comparing settings in one design
 
@@ -316,14 +316,14 @@ to its standalone run.
 
 ## See also
 
-- [`vignette("defining-a-scenario")`](defining-a-scenario.html) --- the scenario
+- `vignette("defining-a-scenario")` --- the scenario
   object and the baseline runner.
-- [`vignette("scenario-to-design")`](scenario-to-design.html) --- union
+- `vignette("scenario-to-design")` --- union
   scenarios into one ragged pipeline that shares overlapping shards.
-- [`vignette("cluster-pipeline")`](cluster-pipeline.html) --- the same pipeline
-  on a cluster, and [`vignette("cloud-upload")`](cloud-upload.html) --- shipping
+- `vignette("cluster-pipeline")` --- the same pipeline
+  on a cluster, and `vignette("cloud-upload")` --- shipping
   the shards to an object store so they are readable off the cluster.
-- [`ssd_run_scenario_shards()`](../reference/ssd_run_scenario_shards.html),
-  [`ssd_scenario_fit_shards()`](../reference/ssd_scenario_shards.html),
-  [`ssd_run_fit_step()`](../reference/ssd_run_step.html),
-  [`ssd_summarise()`](../reference/ssd_summarise.html).
+- `ssd_run_scenario_shards()`,
+  `ssd_scenario_fit_shards()`,
+  `ssd_run_fit_step()`,
+  `ssd_summarise()`.

--- a/vignettes/ssdsims.qmd
+++ b/vignettes/ssdsims.qmd
@@ -1,0 +1,116 @@
+---
+title: "Get Started with ssdsims"
+vignette: >
+  %\VignetteIndexEntry{Get Started with ssdsims}
+  %\VignetteEngine{quarto::html}
+  %\VignetteEncoding{UTF-8}
+knitr:
+  opts_chunk:
+    collapse: true
+    comment: "#>"
+---
+
+```{r}
+#| label: setup
+#| include: false
+# The on-ramp exercises the live API, so it needs the optional fitting
+# dependencies. Skip evaluation gracefully if they are unavailable (e.g. on a
+# minimal CI runner) rather than failing the build.
+evaluate <- requireNamespace("ssddata", quietly = TRUE) &&
+  requireNamespace("ssdtools", quietly = TRUE)
+knitr::opts_chunk$set(eval = evaluate)
+```
+
+```{r}
+#| label: library
+library(ssdsims)
+```
+
+## What ssdsims is for
+
+A species sensitivity distribution (SSD) study asks how an estimate --- a
+hazard concentration, say --- behaves as you vary the things you control: the
+sample size, the number of simulations, the distributions you fit, the
+bootstrap settings. Answering that means running the same fit-and-estimate
+pipeline across a grid of settings, reproducibly, often thousands of times.
+
+ssdsims runs that study from a **declarative scenario**. You describe the study
+once --- a seed, the simulation count, the sample sizes, the dataset *names*,
+and the fit/hc argument grids --- and ssdsims expands it into per-step task
+tables, draws the data, fits the distributions (via
+[ssdtools](https://bcgov.github.io/ssdtools/)), and estimates the hazard
+concentrations. The scenario itself draws no random numbers and writes nothing,
+so it serialises to a compact manifest and the work it expands to is a pure
+function of the scenario.
+
+## Two tracks
+
+The documentation splits into two tracks. Most users only need the first.
+
+```
+  BUILD AND RUN ─────────────────────────────────────────────────────────
+    vignette("defining-a-scenario")   define a scenario, expand task tables
+            │
+            ▼
+    vignette("sharded-pipeline")      run it: in-memory → Parquet shards
+            │                          → a targets pipeline (parallel)
+            ├──► vignette("scenario-to-design")   combine scenarios (ragged)
+            ├──► vignette("cluster-pipeline")     run on a SLURM cluster
+            └──► vignette("cloud-upload")         ship shards to object storage
+
+  PREDICT AND MEASURE COST ──────────────────────────────────────────────
+    vignette("cost-estimation")       predict compute cost before a run
+            │
+            ▼
+    vignette("cost-analysis")         measure observed cost after a run
+```
+
+A scenario can fan out into a multi-day run with no warning, so the cost track
+lets you size a run before launching it and measure where the time actually
+went afterwards. The two tracks meet at the scenario: both read the same object.
+
+## A recommended reading order
+
+1. **`vignette("defining-a-scenario")`** --- the scenario object end to end:
+   assembling data, declaring the scenario, expanding the task tables, and the
+   in-memory baseline runner. Start here.
+2. **`vignette("sharded-pipeline")`** --- the same scenario as Hive-partitioned
+   Parquet shards and a `targets` pipeline; the central "two drivers, one core,
+   byte-identical" idea.
+3. Then, as your study grows, branch into
+   **`vignette("scenario-to-design")`** (combine scenarios),
+   **`vignette("cluster-pipeline")`** (SLURM), and
+   **`vignette("cloud-upload")`** (object storage).
+4. To size and audit compute, read **`vignette("cost-estimation")`** before a
+   run and **`vignette("cost-analysis")`** after one.
+
+## A 30-second on-ramp
+
+Assemble the data with `ssd_scenario_data()`, declare the study with
+`ssd_define_scenario()`, and run the in-memory baseline with
+`ssd_run_scenario_baseline()`:
+
+```{r}
+#| label: on-ramp
+scenario <- ssd_define_scenario(
+  ssd_scenario_data(ssddata::ccme_boron),
+  nsim = 2L,
+  seed = 42L,
+  nrow = c(6L, 10L),
+  ci = TRUE,
+  nboot = 10L,
+  ci_method = c("multi_fixed", "weighted_samples")
+)
+scenario
+```
+
+```{r}
+#| label: run
+out <- ssd_run_scenario_baseline(scenario)
+out$hc
+```
+
+Because each task installs its own `(seed, primer)` under a scoped dqrng
+backend, the result is reproducible from the scenario's `seed` alone --- and
+identical whichever runner you choose. `vignette("defining-a-scenario")` picks
+up exactly here.


### PR DESCRIPTION
## What

Implements the `readme` OpenSpec change (artifacts merged in #191). It rewrites
the README and overhauls the vignette set for coherence and navigation, on the
declarative + `targets` path only (the legacy step functions were retired in
#196).

### README (`README.Rmd` → re-knit `README.md`)
- Overview describes the declarative scenario → task tables → `targets` shard
  pipeline (matching `DESCRIPTION`).
- Real **Installation** section (`pak` / `remotes`), replacing the example that
  was mislabelled as installation.
- Declarative quick-start (`ssd_scenario_data()` → `ssd_define_scenario()` →
  `ssd_run_scenario_baseline()`), evaluated.
- A capability map linking every article, plus a `vignette("ssdsims")` pointer.

### New get-started vignette
- `vignettes/ssdsims.qmd` (`vignette("ssdsims")`): problem statement, a labelled
  two-track map (build-and-run vs. predict-and-measure cost), a recommended
  reading order, and a short declarative on-ramp. Listed **first** in the
  `_pkgdown.yml` `articles:` and reordered the rest to the reading order.

### Package-wide cross-link conversion
- Every vignette-to-vignette link is now `vignette("name")`-style; function
  mentions link to the **reference** (fixing the `cost-analysis` links that
  pointed at an article).

### Comprehensive-review fixes
- `cost-estimation`: ends its dead-end (mutual links with `cost-analysis`, back
  to `defining-a-scenario`); drops the 430-hour figure's false attribution to
  `ssd_define_scenario()`'s docs and makes it order-of-magnitude (reconciling
  the 44 vs 45.3-minute mismatch).
- "See also" sections added to every vignette; `defining-a-scenario` →
  `scenario-to-design` forward link.
- `sharded-pipeline`: fit-shard arithmetic now includes the `dataset` axis
  (`1 × 2 × 2 × 2 = 8`); cluster template described as its real file set.
- `cluster-pipeline`: "four files" → five; "asserts byte-identical" softened to
  the printed `all.equal` check `run-serial.R` actually performs.
- `cloud-upload`: stray trailing code-fence removed.
- Removed OpenSpec/repo-internal references (`TARGETS-DESIGN.md §`, `data-raw/`,
  "the change's `exploration/` directory") from the vignettes **and** from
  `R/cost-estimate.R` / `R/targets-runner.R` roxygen (with the generated `.Rd`
  updated).

### Verification
- `README.md` re-knit with all chunks evaluating (output captured).
- `pkgdown::check_pkgdown()` passes — every vignette (incl. the new overview)
  and reference topic is indexed.
- `air format` run on the touched `R/` files.
- `openspec validate readme` passes; `tasks.md` marked 23/23 complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJHtNLGYm8379WrTAUjrui)_