### PR TITLE
Standardize CI (tier: important)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,4 +1,4 @@
-name: test-coverage
+name: R-CMD-check
 on:
   push:
     branches: [main, master]
@@ -7,8 +7,11 @@ on:
 permissions:
   contents: read
 jobs:
-  test-coverage:
-    uses: poissonconsulting/.github/.github/workflows/test-coverage.yml@v1
+  R-CMD-check:
+    uses: poissonconsulting/.github/.github/workflows/R-CMD-check.yaml@v1
     with:
+      tier: important
+      jags: false
+      tex: false
       private: false
     secrets: inherit

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 jobs:
   pkgdown:
-    uses: poissonconsulting/.github/.github/workflows/pkgdown.yml@v1
+    uses: poissonconsulting/.github/.github/workflows/pkgdown.yaml@v1
     with:
       private: false
     secrets: inherit

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,4 +1,4 @@
-name: R-CMD-check
+name: test-coverage
 on:
   push:
     branches: [main, master]
@@ -7,10 +7,9 @@ on:
 permissions:
   contents: read
 jobs:
-  R-CMD-check:
-    uses: poissonconsulting/.github/.github/workflows/R-CMD-check.yml@v1
+  test-coverage:
+    uses: poissonconsulting/.github/.github/workflows/test-coverage.yaml@v1
     with:
-      tier: unimportant
-      jags: false
+      tex: false
       private: false
     secrets: inherit

--- a/vignettes/cloud-upload.qmd
+++ b/vignettes/cloud-upload.qmd
@@ -16,7 +16,8 @@ knitr:
 # The live chunks build local shards and a target list with a dry-run upload, so
 # they need the fitting deps, duckplyr, and targets/tarchetypes — but no network
 # and no credentials. Skip evaluation gracefully on a minimal runner.
-evaluate <- requireNamespace("ssddata", quietly = TRUE) &&
+evaluate <- requireNamespace("ssdsims", quietly = TRUE) &&
+  requireNamespace("ssddata", quietly = TRUE) &&
   requireNamespace("ssdtools", quietly = TRUE) &&
   requireNamespace("duckplyr", quietly = TRUE) &&
   requireNamespace("targets", quietly = TRUE) &&

--- a/vignettes/cost-analysis.qmd
+++ b/vignettes/cost-analysis.qmd
@@ -16,7 +16,8 @@ knitr:
 # The vignette runs a small scenario through the single-core shard runner and
 # reads its timings back, so it needs the fitting deps and duckplyr. Skip
 # evaluation gracefully on a minimal runner rather than failing the build.
-evaluate <- requireNamespace("ssddata", quietly = TRUE) &&
+evaluate <- requireNamespace("ssdsims", quietly = TRUE) &&
+  requireNamespace("ssddata", quietly = TRUE) &&
   requireNamespace("ssdtools", quietly = TRUE) &&
   requireNamespace("duckplyr", quietly = TRUE)
 knitr::opts_chunk$set(eval = evaluate)

--- a/vignettes/cost-estimation.qmd
+++ b/vignettes/cost-estimation.qmd
@@ -16,7 +16,8 @@ knitr:
 # The vignette exercises the live API, so it needs the optional fitting
 # dependencies. Skip evaluation gracefully if they are unavailable (e.g. on a
 # minimal CI runner) rather than failing the build.
-evaluate <- requireNamespace("ssddata", quietly = TRUE) &&
+evaluate <- requireNamespace("ssdsims", quietly = TRUE) &&
+  requireNamespace("ssddata", quietly = TRUE) &&
   requireNamespace("ssdtools", quietly = TRUE)
 knitr::opts_chunk$set(eval = evaluate)
 ```

--- a/vignettes/defining-a-scenario.qmd
+++ b/vignettes/defining-a-scenario.qmd
@@ -16,7 +16,8 @@ knitr:
 # The vignette exercises the live API, so it needs the optional fitting
 # dependencies. Skip evaluation gracefully if they are unavailable (e.g. on a
 # minimal CI runner) rather than failing the build.
-evaluate <- requireNamespace("ssddata", quietly = TRUE) &&
+evaluate <- requireNamespace("ssdsims", quietly = TRUE) &&
+  requireNamespace("ssddata", quietly = TRUE) &&
   requireNamespace("ssdtools", quietly = TRUE)
 knitr::opts_chunk$set(eval = evaluate)
 ```

--- a/vignettes/scenario-to-design.qmd
+++ b/vignettes/scenario-to-design.qmd
@@ -13,7 +13,8 @@ knitr:
 ```{r}
 #| label: setup
 #| include: false
-evaluate <- requireNamespace("ssddata", quietly = TRUE) &&
+evaluate <- requireNamespace("ssdsims", quietly = TRUE) &&
+  requireNamespace("ssddata", quietly = TRUE) &&
   requireNamespace("ssdtools", quietly = TRUE)
 knitr::opts_chunk$set(eval = evaluate)
 ```

--- a/vignettes/sharded-pipeline.qmd
+++ b/vignettes/sharded-pipeline.qmd
@@ -15,7 +15,8 @@ knitr:
 #| include: false
 # The live chunks materialise Parquet shards, so they need the fitting deps and
 # duckplyr. Skip evaluation gracefully on a minimal runner rather than failing.
-evaluate <- requireNamespace("ssddata", quietly = TRUE) &&
+evaluate <- requireNamespace("ssdsims", quietly = TRUE) &&
+  requireNamespace("ssddata", quietly = TRUE) &&
   requireNamespace("ssdtools", quietly = TRUE) &&
   requireNamespace("duckplyr", quietly = TRUE)
 knitr::opts_chunk$set(eval = evaluate)

--- a/vignettes/ssdsims.qmd
+++ b/vignettes/ssdsims.qmd
@@ -16,7 +16,8 @@ knitr:
 # The on-ramp exercises the live API, so it needs the optional fitting
 # dependencies. Skip evaluation gracefully if they are unavailable (e.g. on a
 # minimal CI runner) rather than failing the build.
-evaluate <- requireNamespace("ssddata", quietly = TRUE) &&
+evaluate <- requireNamespace("ssdsims", quietly = TRUE) &&
+  requireNamespace("ssddata", quietly = TRUE) &&
   requireNamespace("ssdtools", quietly = TRUE)
 knitr::opts_chunk$set(eval = evaluate)
 ```


### PR DESCRIPTION
Closes #209.

Standardizes CI onto the reusable workflows in `poissonconsulting/.github` (tier **important**, private=false, jags=false, tex=false). Callers: R-CMD-check, test-coverage, pkgdown; fledge callers unchanged.