### PR TITLE
test: pin `task_primer()` values to `rlang >= 1.3.0`

### DIFF
--- a/R/task-primer.R
+++ b/R/task-primer.R
@@ -96,12 +96,12 @@ normalize_task_row <- function(row) {
 #' Function-valued parameters (e.g. `min_pmix`) MUST be referenced **by name**,
 #' not by function value, so a recompile or JIT does not move a task's primer.
 #'
-#' The primer is derived from [rlang::hash()], whose digest is **not stable
-#' across `rlang` versions** (a fast within-session identity hash, not a
-#' portable checksum). Primers -- and therefore simulation seeds -- can change
-#' when `rlang` is updated. Reproducibility is guaranteed by pinning the
-#' execution environment (including the `rlang` version) for a given simulation
-#' run, not by the digest being portable across versions.
+#' The primer is derived from [rlang::hash()], a fast within-session identity
+#' hash rather than a portable checksum, so its digest is not *guaranteed*
+#' stable across `rlang` versions. Such changes are rare and not anticipated,
+#' but have happened, and would shift primers -- and therefore simulation
+#' seeds. Reproducibility is therefore anchored by pinning the execution
+#' environment (including the `rlang` version) for a given simulation run.
 #'
 #' @param params A plain named list of task parameters, or a single-row data
 #'   frame (one task-table row).

--- a/R/task-primer.R
+++ b/R/task-primer.R
@@ -96,6 +96,13 @@ normalize_task_row <- function(row) {
 #' Function-valued parameters (e.g. `min_pmix`) MUST be referenced **by name**,
 #' not by function value, so a recompile or JIT does not move a task's primer.
 #'
+#' The primer is derived from [rlang::hash()], whose digest is **not stable
+#' across `rlang` versions** (a fast within-session identity hash, not a
+#' portable checksum). Primers -- and therefore simulation seeds -- can change
+#' when `rlang` is updated. Reproducibility is guaranteed by pinning the
+#' execution environment (including the `rlang` version) for a given simulation
+#' run, not by the digest being portable across versions.
+#'
 #' @param params A plain named list of task parameters, or a single-row data
 #'   frame (one task-table row).
 #' @return An integer vector of length 2 -- the per-task primer -- to pass as

--- a/man/task_primer.Rd
+++ b/man/task_primer.Rd
@@ -66,12 +66,12 @@ identity, so it is never a primer field (nor a task-row column).
 Function-valued parameters (e.g. \code{min_pmix}) MUST be referenced \strong{by name},
 not by function value, so a recompile or JIT does not move a task's primer.
 
-The primer is derived from \code{\link[rlang:hash]{rlang::hash()}}, whose digest is \strong{not stable
-across \code{rlang} versions} (a fast within-session identity hash, not a
-portable checksum). Primers -- and therefore simulation seeds -- can change
-when \code{rlang} is updated. Reproducibility is guaranteed by pinning the
-execution environment (including the \code{rlang} version) for a given simulation
-run, not by the digest being portable across versions.
+The primer is derived from \code{\link[rlang:hash]{rlang::hash()}}, a fast within-session identity
+hash rather than a portable checksum, so its digest is not \emph{guaranteed}
+stable across \code{rlang} versions. Such changes are rare and not anticipated,
+but have happened, and would shift primers -- and therefore simulation
+seeds. Reproducibility is therefore anchored by pinning the execution
+environment (including the \code{rlang} version) for a given simulation run.
 }
 \examples{
 task_primer(list(dataset = "boron", sim = 1L, replace = FALSE))

--- a/man/task_primer.Rd
+++ b/man/task_primer.Rd
@@ -65,6 +65,13 @@ identity, so it is never a primer field (nor a task-row column).
 
 Function-valued parameters (e.g. \code{min_pmix}) MUST be referenced \strong{by name},
 not by function value, so a recompile or JIT does not move a task's primer.
+
+The primer is derived from \code{\link[rlang:hash]{rlang::hash()}}, whose digest is \strong{not stable
+across \code{rlang} versions} (a fast within-session identity hash, not a
+portable checksum). Primers -- and therefore simulation seeds -- can change
+when \code{rlang} is updated. Reproducibility is guaranteed by pinning the
+execution environment (including the \code{rlang} version) for a given simulation
+run, not by the digest being portable across versions.
 }
 \examples{
 task_primer(list(dataset = "boron", sim = 1L, replace = FALSE))

--- a/tests/testthat/test-task-primer.R
+++ b/tests/testthat/test-task-primer.R
@@ -28,13 +28,21 @@ test_that("parallel-safe-seeding: hex8_to_int32 encoding", {
 
 test_that("parallel-safe-seeding: task_primer matches experiment smoke values", {
   # The validated reference (scripts/experiment-dqrng-hash.R, section 1).
+  #
+  # `task_primer()` derives the primer from `rlang::hash()`, whose digest is
+  # not stable across `rlang` versions (see issue #212). These values are
+  # therefore pinned to `rlang >= 1.3.0`; reproducibility across `rlang`
+  # versions is instead guaranteed by controlling the execution environment
+  # for simulations. Re-record with the `rlang >= 1.3.0` output if this test
+  # fails after an `rlang` update.
+  skip_if_not_installed("rlang", "1.3.0")
   expect_identical(
     task_primer(list(sim = 1L, nrow = 5L, rescale = FALSE)),
-    c(1588052819L, 2019509379L)
+    c(-135494555L, 2078443361L)
   )
   expect_identical(
     task_primer(list(sim = 1L, nrow = 5L, rescale = TRUE)),
-    c(-477519926L, -980032388L)
+    c(222240734L, 1330859749L)
   )
 })
 
@@ -82,10 +90,13 @@ test_that("parallel-safe-seeding: sample primer is nrow-free, fit/hc primer is n
 })
 
 test_that("parallel-safe-seeding: task_primer matches a recorded primer", {
-  # Stability guard: catches an unexpected rlang::hash() change.
+  # Stability guard: catches an unexpected rlang::hash() change *within* an
+  # rlang major/minor line. The digest is not stable across rlang versions
+  # (issue #212), so this is pinned to `rlang >= 1.3.0`.
+  skip_if_not_installed("rlang", "1.3.0")
   expect_identical(
     task_primer(list(dataset = "boron", sim = 1L, replace = FALSE)),
-    c(-310630442L, -782239665L)
+    c(-563099096L, -147061236L)
   )
 })
 

--- a/tests/testthat/test-task-primer.R
+++ b/tests/testthat/test-task-primer.R
@@ -30,11 +30,11 @@ test_that("parallel-safe-seeding: task_primer matches experiment smoke values", 
   # The validated reference (scripts/experiment-dqrng-hash.R, section 1).
   #
   # `task_primer()` derives the primer from `rlang::hash()`, whose digest is
-  # not stable across `rlang` versions (see issue #212). These values are
-  # therefore pinned to `rlang >= 1.3.0`; reproducibility across `rlang`
-  # versions is instead guaranteed by controlling the execution environment
-  # for simulations. Re-record with the `rlang >= 1.3.0` output if this test
-  # fails after an `rlang` update.
+  # not guaranteed stable across `rlang` versions (it changed once; see issue
+  # #212). Such changes are rare and not anticipated, so these values are
+  # simply pinned to `rlang >= 1.3.0`; reproducibility for simulations is
+  # anchored by controlling the execution environment. Re-record with the
+  # current output if this test fails after a future `rlang` update.
   skip_if_not_installed("rlang", "1.3.0")
   expect_identical(
     task_primer(list(sim = 1L, nrow = 5L, rescale = FALSE)),
@@ -90,9 +90,9 @@ test_that("parallel-safe-seeding: sample primer is nrow-free, fit/hc primer is n
 })
 
 test_that("parallel-safe-seeding: task_primer matches a recorded primer", {
-  # Stability guard: catches an unexpected rlang::hash() change *within* an
-  # rlang major/minor line. The digest is not stable across rlang versions
-  # (issue #212), so this is pinned to `rlang >= 1.3.0`.
+  # Stability guard: catches an unexpected rlang::hash() change. The digest is
+  # not guaranteed stable across rlang versions (it changed once; issue #212),
+  # so this is pinned to `rlang >= 1.3.0`.
   skip_if_not_installed("rlang", "1.3.0")
   expect_identical(
     task_primer(list(dataset = "boron", sim = 1L, replace = FALSE)),


### PR DESCRIPTION
Fixes #212.

## Problem

`task_primer()` derives parallel-safe RNG primers from `rlang::hash()`, a fast within-session identity hash rather than a portable checksum, so its digest is not *guaranteed* stable across `rlang` versions. It changed once when `rlang` was updated, and the hardcoded expected values in `test-task-primer.R` drifted, so CI began failing on all platforms with no change to the seeding code. Such changes are rare and not anticipated, but can recur.

## Approach

Per the maintainer's decision on the issue (condition the tests on `rlang >= 1.3.0` and update the recorded values, rather than swapping out `rlang::hash()`):

- Re-record the two value-pinned tests against `rlang` 1.3.0 output:
  - **smoke values** — `c(-135494555L, 2078443361L)` and `c(222240734L, 1330859749L)`
  - **recorded primer** — `c(-563099096L, -147061236L)`
- Guard both tests with `skip_if_not_installed("rlang", "1.3.0")` so they only assert on a supported `rlang`, and older `rlang` versions skip rather than fail.
- Document on `task_primer()` (roxygen + regenerated `man/task_primer.Rd`) that the primer is coupled to the `rlang` version, so reproducibility for a simulation run is anchored by pinning the execution environment.

The structural/behavioural tests (determinism, param-sensitivity, name-order sensitivity, row/list equivalence, dqrng seeding) are unaffected and remain unconditional.

## Verification

`devtools::test_file("tests/testthat/test-task-primer.R")` → `FAIL 0 | WARN 0 | SKIP 1 | PASS 24` under `rlang` 1.3.0 (the single skip is the pre-existing "On CRAN" snapshot test). Docs regenerated with `devtools::document()`; code formatted with `air format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ET4QZaXqcwe8yKy2ByLnuX