### PR TITLE
fix: silence tidyselect deprecation warnings from `ssd_design_targets()`

### DIFF
--- a/R/design-targets.R
+++ b/R/design-targets.R
@@ -576,10 +576,7 @@ design_group_targets <- function(members, ref, sroot, upload, cue) {
   hc_dir <- file.path(sroot, "hc")
 
   step_map <- function(step, shards, command) {
-    nms <- tidyselect::all_of(c(
-      "seed",
-      scenario_partition_axes(ref, step)$path
-    ))
+    nms <- c("seed", scenario_partition_axes(ref, step)$path)
     step_target <- targets::tar_target_raw(
       paste0(step, "_step"),
       command,
@@ -590,7 +587,7 @@ design_group_targets <- function(members, ref, sroot, upload, cue) {
     if (is.null(upload)) {
       return(tarchetypes::tar_map(
         values = shards,
-        names = nms,
+        names = tidyselect::all_of(nms),
         descriptions = tidyselect::all_of(character(0)),
         step_target
       ))
@@ -607,7 +604,7 @@ design_group_targets <- function(members, ref, sroot, upload, cue) {
     )
     tarchetypes::tar_map(
       values = shards,
-      names = nms,
+      names = tidyselect::all_of(nms),
       descriptions = tidyselect::all_of(character(0)),
       step_target,
       upload_target


### PR DESCRIPTION
## Description

The testthat suite emitted 24 tidyselect soft-deprecation warnings, all traced to `ssd_design_targets()`:

- *Using `all_of()` outside of a selecting function was deprecated in tidyselect 1.2.0.*
- *Using an external vector in selections was deprecated in tidyselect 1.1.0.*

(These are *soft* deprecations, so they only surface under testthat / `R CMD check`, where `lifecycle` escalates them because the calling package is under test.)

### Root cause

`design_group_targets()`'s `step_map()` evaluated `tidyselect::all_of()` **eagerly**, outside a selecting context, then passed the resulting bare character vector to `tar_map(names = )`:

```r
nms <- tidyselect::all_of(c("seed", ...))   # all_of() forced outside a selecting fn → warning 1
tar_map(values = shards, names = nms, ...)  # nms is now a bare char vector → warning 2
```

The warnings live entirely in `ssdsims`: `tarchetypes::eval_tidyselect()` is byte-identical between the CRAN (0.14.1) and dev (0.14.1.9000) versions, so the warnings appear on both — this cannot be fixed by upgrading `targets`/`tarchetypes`.

### Fix

Keep `nms` as a plain character vector and wrap it inline at both `tar_map()` call sites, so `tar_map()` captures the call with `enquo()` and `all_of()` runs inside `eval_select()`'s selecting context:

```r
nms <- c("seed", scenario_partition_axes(ref, step)$path)
names = tidyselect::all_of(nms),
```

This matches the pattern already used by the sibling factory `ssd_scenario_targets()` and the cost-analysis resolvers.

## Test Plan

Full suite, both toolchains:

| targets / tarchetypes | before | after |
|---|---|---|
| CRAN 1.12.0 / 0.14.1 | `FAIL 0 \| WARN 24 \| PASS 969` | `FAIL 0 \| WARN 0 \| PASS 969` |
| dev 1.12.0.9001 / 0.14.1.9000 | 18 warnings in `test-design-targets.R` | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SpPnfTgLEWCAX9muAQ1Tc